### PR TITLE
[controller] admit by logical slot

### DIFF
--- a/src/controller/admission.rs
+++ b/src/controller/admission.rs
@@ -1,6 +1,9 @@
 //! # Per-task admission policy
 //!
-//! Controller treats tasks as **slots** identified by `name`.
+//! The controller admits **one task per slot**.
+//! The slot is the spec's slot key ([`TaskSpec::slot`](crate::TaskSpec::slot)), which falls back to the task
+//! name when not set explicitly - so the admission unit is the *slot*, not the task name (several differently-named runs may share one slot).
+//!
 //! At any given time **one** task may run in a slot.
 //! When a new request for the same slot arrives, the admission policy decides what to do.
 //!
@@ -12,7 +15,7 @@
 //!
 //! ## Invariants
 //!
-//! - Tasks within the same slot never run in parallel (use dynamic names if you need parallel execution).
+//! - Tasks within the same slot never run in parallel (use distinct slots if you need parallel execution).
 //! - Queued requests are executed strictly in submission order.
 
 /// Policy controlling how new submissions are handled when a slot is busy.

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -88,6 +88,13 @@ pub(crate) struct Controller {
 
     slots: DashMap<Arc<str>, Arc<Mutex<SlotState>>>,
 
+    /// Reverse index: running task name → slot key.
+    ///
+    /// `TaskRemoved` carries only the task name, but slots are keyed by the logical slot (which may differ from the name).
+    ///  This index lets `on_task_finished` find the owning slot.
+    ///  An entry exists exactly while a task occupies a slot (inserted on start, removed on `TaskRemoved`).
+    running: DashMap<Arc<str>, Arc<str>>,
+
     tx: mpsc::Sender<ControllerSpec>,
     rx: RwLock<Option<mpsc::Receiver<ControllerSpec>>>,
 }
@@ -102,6 +109,7 @@ impl Controller {
             supervisor: Arc::downgrade(supervisor),
             bus,
             slots: DashMap::new(),
+            running: DashMap::new(),
             tx,
             rx: RwLock::new(Some(rx)),
         })
@@ -192,30 +200,42 @@ impl Controller {
                 continue;
             }
 
-            if !sup.registry_contains(&slot_name).await {
-                slot.status = SlotStatus::Idle;
+            let alive = match slot.running.as_deref() {
+                Some(name) => sup.registry_contains(name).await,
+                None => false,
+            };
+            if alive {
+                continue;
+            }
 
-                if let Some(next_spec) = slot.queue.pop_front() {
-                    if let Err(e) = sup.add_task(next_spec) {
-                        self.bus.publish(
-                            Event::new(EventKind::ControllerRejected)
-                                .with_task(Arc::clone(&slot_name))
-                                .with_reason(format!("recovery_start_failed: {e}")),
-                        );
-                        continue;
-                    }
-                    slot.status = SlotStatus::Running {
-                        started_at: Instant::now(),
-                    };
+            if let Some(name) = slot.running.take() {
+                self.running.remove(&*name);
+            }
+            slot.status = SlotStatus::Idle;
+
+            if let Some(next_spec) = slot.queue.pop_front() {
+                let next_name: Arc<str> = Arc::from(next_spec.name());
+                if let Err(e) = sup.add_task(next_spec) {
                     self.bus.publish(
-                        Event::new(EventKind::ControllerSubmitted)
+                        Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(&slot_name))
-                            .with_reason(format!("recovered_from_lag depth={}", slot.queue.len())),
+                            .with_reason(format!("recovery_start_failed: {e}")),
                     );
-                } else {
-                    drop(slot);
-                    self.slots.remove(&*slot_name);
+                    continue;
                 }
+                slot.status = SlotStatus::Running {
+                    started_at: Instant::now(),
+                };
+                slot.running = Some(Arc::clone(&next_name));
+                self.running.insert(next_name, Arc::clone(&slot_name));
+                self.bus.publish(
+                    Event::new(EventKind::ControllerSubmitted)
+                        .with_task(Arc::clone(&slot_name))
+                        .with_reason(format!("recovered_from_lag depth={}", slot.queue.len())),
+                );
+            } else {
+                drop(slot);
+                self.slots.remove(&*slot_name);
             }
         }
     }
@@ -246,6 +266,7 @@ impl Controller {
 
         match (&slot.status, admission) {
             (SlotStatus::Idle, _) => {
+                let task_name: Arc<str> = Arc::from(task_spec.name());
                 if let Err(e) = sup.add_task(task_spec) {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
@@ -257,6 +278,8 @@ impl Controller {
                 slot.status = SlotStatus::Running {
                     started_at: Instant::now(),
                 };
+                slot.running = Some(Arc::clone(&task_name));
+                self.running.insert(task_name, Arc::clone(&slot_name));
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
@@ -273,7 +296,9 @@ impl Controller {
                         .with_task(Arc::clone(&slot_name))
                         .with_reason("running→terminating (replace)"),
                 );
-                if let Err(e) = sup.remove_task(&slot_name) {
+                if let Some(running) = slot.running.clone()
+                    && let Err(e) = sup.remove_task(&running)
+                {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(&slot_name))
@@ -342,31 +367,36 @@ impl Controller {
 
     /// Handles `TaskRemoved` for a task; frees the slot and optionally starts the queued next.
     async fn on_task_finished(&self, event: &Event) {
-        let Some(task_name) = event.task.as_deref() else {
+        let Some(removed) = event.task.as_deref() else {
             return;
         };
         let Some(sup) = self.supervisor.upgrade() else {
             return;
         };
-        let Some(slot_arc) = self.slots.get(task_name).map(|e| e.clone()) else {
+
+        let Some((_, slot_name)) = self.running.remove(removed) else {
+            return;
+        };
+        let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
             return;
         };
         let mut slot = slot_arc.lock().await;
 
-        if matches!(slot.status, SlotStatus::Idle) {
-            return;
-        }
         slot.status = SlotStatus::Idle;
+        slot.running = None;
 
         while let Some(next_spec) = slot.queue.pop_front() {
+            let next_name: Arc<str> = Arc::from(next_spec.name());
             match sup.add_task(next_spec) {
                 Ok(()) => {
                     slot.status = SlotStatus::Running {
                         started_at: Instant::now(),
                     };
+                    slot.running = Some(Arc::clone(&next_name));
+                    self.running.insert(next_name, Arc::clone(&slot_name));
                     self.bus.publish(
                         Event::new(EventKind::ControllerSubmitted)
-                            .with_task(task_name)
+                            .with_task(Arc::clone(&slot_name))
                             .with_reason(format!("started_from_queue depth={}", slot.queue.len())),
                     );
                     break;
@@ -374,7 +404,7 @@ impl Controller {
                 Err(e) => {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
-                            .with_task(task_name)
+                            .with_task(Arc::clone(&slot_name))
                             .with_reason(format!("queue_start_failed: {e}")),
                     );
                 }
@@ -382,7 +412,7 @@ impl Controller {
         }
         if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
             drop(slot);
-            self.slots.remove(task_name);
+            self.slots.remove(&*slot_name);
         }
     }
 
@@ -553,6 +583,7 @@ mod tests {
             supervisor: Weak::new(),
             bus,
             slots: DashMap::new(),
+            running: DashMap::new(),
             tx,
             rx: RwLock::new(Some(rx)),
         }

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -2,7 +2,7 @@
 //!
 //! [`SlotState`] tracks the current status and pending queue for a single named slot.
 
-use std::{collections::VecDeque, time::Instant};
+use std::{collections::VecDeque, sync::Arc, time::Instant};
 
 use crate::TaskSpec;
 
@@ -15,6 +15,9 @@ use crate::TaskSpec;
 pub(super) struct SlotState {
     /// Current status (idle, running, or terminating).
     pub status: SlotStatus,
+
+    /// Name of the task currently occupying the slot (running or terminating).
+    pub running: Option<Arc<str>>,
 
     /// Queue of pending tasks (FIFO order).
     pub queue: VecDeque<TaskSpec>,
@@ -44,6 +47,7 @@ impl SlotState {
     pub fn new() -> Self {
         Self {
             status: SlotStatus::Idle,
+            running: None,
             queue: VecDeque::new(),
         }
     }

--- a/src/controller/spec.rs
+++ b/src/controller/spec.rs
@@ -9,7 +9,7 @@ use crate::TaskSpec;
 /// Request to submit a task to the controller.
 ///
 /// Combines an admission policy and the actual task specification.
-/// The slot name is derived from the task name via [`slot_name`](Self::slot_name).
+/// The slot name comes from the task spec's slot (which falls back to the task name) via [`slot_name`](Self::slot_name).
 ///
 /// # Also
 ///
@@ -48,9 +48,9 @@ impl ControllerSpec {
         }
     }
 
-    /// Returns the slot name (derived from the task name).
+    /// Returns the slot name (admission key).
     pub fn slot_name(&self) -> &str {
-        self.task_spec.name()
+        self.task_spec.slot()
     }
 
     /// Convenience: Queue admission.
@@ -100,8 +100,15 @@ mod tests {
     }
 
     #[test]
-    fn slot_name_equals_task_name() {
+    fn slot_name_falls_back_to_task_name() {
         let cs = ControllerSpec::queue(make_spec("my-slot"));
         assert_eq!(cs.slot_name(), "my-slot");
+    }
+
+    #[test]
+    fn slot_name_uses_explicit_slot() {
+        let cs = ControllerSpec::queue(make_spec("runner-web-7").with_slot("web"));
+        assert_eq!(cs.slot_name(), "web");
+        assert_eq!(cs.task_spec.name(), "runner-web-7");
     }
 }

--- a/src/tasks/spec.rs
+++ b/src/tasks/spec.rs
@@ -1,5 +1,6 @@
 //! Task execution specification.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::{
@@ -11,8 +12,8 @@ use crate::{
 /// Bundles restart policy, backoff strategy, timeout, and max retries.
 ///
 /// - [`once`](Self::once) for fire-and-forget tasks.
-/// - [`restartable`](Self::restartable) for long-lived workers.
 /// - [`new`](Self::new) for full control over all parameters.
+/// - [`restartable`](Self::restartable) for long-lived workers.
 ///
 /// ## Creating a spec
 /// ```rust
@@ -49,6 +50,7 @@ pub struct TaskSpec {
     backoff: BackoffPolicy,
 
     task: TaskRef,
+    slot: Option<Arc<str>>,
 
     max_retries: u32,
 }
@@ -60,6 +62,7 @@ impl std::fmt::Debug for TaskSpec {
             .field("backoff", &self.backoff)
             .field("timeout", &self.timeout)
             .field("task", &self.task.name())
+            .field("slot", &self.slot())
             .field("max_retries", &self.max_retries)
             .finish()
     }
@@ -82,6 +85,7 @@ impl TaskSpec {
             timeout,
 
             task,
+            slot: None,
 
             max_retries: 0,
         }
@@ -95,6 +99,7 @@ impl TaskSpec {
             timeout: None,
 
             task,
+            slot: None,
 
             max_retries: 0,
         }
@@ -108,6 +113,7 @@ impl TaskSpec {
             timeout: None,
 
             task,
+            slot: None,
 
             max_retries: 0,
         }
@@ -123,6 +129,7 @@ impl TaskSpec {
             timeout: cfg.default_timeout(),
 
             task,
+            slot: None,
 
             max_retries: cfg.max_retries,
         }
@@ -136,6 +143,11 @@ impl TaskSpec {
     /// Returns the task name.
     pub fn name(&self) -> &str {
         self.task.name()
+    }
+
+    /// Returns the slot key used for admission control.
+    pub fn slot(&self) -> &str {
+        self.slot.as_deref().unwrap_or_else(|| self.task.name())
     }
 
     /// Returns the restart policy.
@@ -182,5 +194,37 @@ impl TaskSpec {
     pub fn with_max_retries(mut self, max_retries: u32) -> Self {
         self.max_retries = max_retries;
         self
+    }
+
+    /// Builder: set the admission slot key.
+    ///
+    /// Defaults to the task name.
+    pub fn with_slot(mut self, slot: impl Into<Arc<str>>) -> Self {
+        self.slot = Some(slot.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TaskFn;
+    use tokio_util::sync::CancellationToken;
+
+    fn task(name: &str) -> TaskRef {
+        TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) })
+    }
+
+    #[test]
+    fn slot_falls_back_to_task_name() {
+        let spec = TaskSpec::once(task("my-task"));
+        assert_eq!(spec.slot(), "my-task");
+    }
+
+    #[test]
+    fn with_slot_overrides_slot_but_not_name() {
+        let spec = TaskSpec::once(task("runner-web-7")).with_slot("web");
+        assert_eq!(spec.slot(), "web");
+        assert_eq!(spec.name(), "runner-web-7");
     }
 }


### PR DESCRIPTION
## 📝 Description
- `TaskSpec`: add an optional `slot` and `with_slot()` / `slot()`. 
- `ControllerSpec::slot_name()` now returns `task_spec.slot()` (was `name()`).
- `Controller`: slots are keyed by the **logical slot**. 

## 🔄 Related Issues
Resolves #72 

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally
