### PR TITLE
[clippy] fix warnings

### DIFF
--- a/benches/controller.rs
+++ b/benches/controller.rs
@@ -51,10 +51,11 @@ const RUNTIMES: [(&str, RtFactory); 2] = [
 ];
 
 fn bench_config() -> SupervisorConfig {
-    let mut cfg = SupervisorConfig::default();
-    cfg.bus_capacity = 16384;
-    cfg.grace = Duration::from_secs(5);
-    cfg
+    SupervisorConfig {
+        bus_capacity: 16384,
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    }
 }
 
 fn instant_task(name: &str) -> TaskSpec {

--- a/benches/dynamic.rs
+++ b/benches/dynamic.rs
@@ -50,10 +50,11 @@ const RUNTIMES: [(&str, RtFactory); 2] = [
 ];
 
 fn bench_config() -> SupervisorConfig {
-    let mut cfg = SupervisorConfig::default();
-    cfg.bus_capacity = 16384;
-    cfg.grace = Duration::from_secs(5);
-    cfg
+    SupervisorConfig {
+        bus_capacity: 16384,
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    }
 }
 
 fn worker_task(name: &str) -> TaskSpec {

--- a/benches/fanout.rs
+++ b/benches/fanout.rs
@@ -74,10 +74,11 @@ const N_TASKS: usize = 100;
 const SUB_NAMES: [&str; 8] = ["s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7"];
 
 fn bench_config() -> SupervisorConfig {
-    let mut cfg = SupervisorConfig::default();
-    cfg.bus_capacity = 16384;
-    cfg.grace = Duration::from_secs(5);
-    cfg
+    SupervisorConfig {
+        bus_capacity: 16384,
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    }
 }
 
 fn instant_task(name: &str) -> TaskSpec {

--- a/benches/lifecycle.rs
+++ b/benches/lifecycle.rs
@@ -53,10 +53,11 @@ const RUNTIMES: [(&str, RtFactory); 2] = [
 ];
 
 fn bench_config() -> SupervisorConfig {
-    let mut cfg = SupervisorConfig::default();
-    cfg.bus_capacity = 16384;
-    cfg.grace = Duration::from_secs(5);
-    cfg
+    SupervisorConfig {
+        bus_capacity: 16384,
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    }
 }
 
 fn instant_task(name: &str) -> TaskSpec {

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -75,10 +75,11 @@ impl Subscribe for CountingSubscriber {
 }
 
 fn bench_config() -> SupervisorConfig {
-    let mut cfg = SupervisorConfig::default();
-    cfg.bus_capacity = 16384;
-    cfg.grace = Duration::from_secs(5);
-    cfg
+    SupervisorConfig {
+        bus_capacity: 16384,
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    }
 }
 
 fn instant_task(name: &str) -> TaskSpec {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -139,14 +139,38 @@ impl SupervisorConfig {
     }
 }
 
+impl Default for SupervisorConfig {
+    /// Default configuration:
+    /// - `grace = 60s` (reasonable graceful shutdown window)
+    /// - `max_concurrent = 0` (unlimited)
+    /// - `bus_capacity = 1024` (good baseline)
+    /// - `timeout = 0s` (no timeout)
+    /// - `restart = RestartPolicy::OnFailure` (restart on errors only)
+    /// - `backoff = BackoffPolicy::default()` (constant 100ms, see [`BackoffPolicy`])
+    /// - `max_retries = 0` (unlimited)
+    fn default() -> Self {
+        Self {
+            grace: Duration::from_secs(60),
+            max_concurrent: 0,
+            bus_capacity: 1024,
+            timeout: Duration::from_secs(0),
+            restart: RestartPolicy::default(),
+            backoff: BackoffPolicy::default(),
+            max_retries: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn validate_rejects_zero_bus_capacity() {
-        let mut cfg = SupervisorConfig::default();
-        cfg.bus_capacity = 0;
+        let cfg = SupervisorConfig {
+            bus_capacity: 0,
+            ..Default::default()
+        };
         assert!(cfg.validate().is_err());
     }
 
@@ -195,27 +219,5 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(cfg.bus_capacity_clamped(), 1);
-    }
-}
-
-impl Default for SupervisorConfig {
-    /// Default configuration:
-    /// - `grace = 60s` (reasonable graceful shutdown window)
-    /// - `max_concurrent = 0` (unlimited)
-    /// - `bus_capacity = 1024` (good baseline)
-    /// - `timeout = 0s` (no timeout)
-    /// - `restart = RestartPolicy::OnFailure` (restart on errors only)
-    /// - `backoff = BackoffPolicy::default()` (constant 100ms, see [`BackoffPolicy`])
-    /// - `max_retries = 0` (unlimited)
-    fn default() -> Self {
-        Self {
-            grace: Duration::from_secs(60),
-            max_concurrent: 0,
-            bus_capacity: 1024,
-            timeout: Duration::from_secs(0),
-            restart: RestartPolicy::default(),
-            backoff: BackoffPolicy::default(),
-            max_retries: 0,
-        }
     }
 }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -376,6 +376,33 @@ impl Event {
     }
 }
 
+impl std::fmt::Debug for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("Event");
+        d.field("seq", &self.seq);
+        d.field("kind", &self.kind);
+        if let Some(ref task) = self.task {
+            d.field("task", task);
+        }
+        if let Some(attempt) = self.attempt {
+            d.field("attempt", &attempt);
+        }
+        if let Some(ref reason) = self.reason {
+            d.field("reason", reason);
+        }
+        if let Some(timeout_ms) = self.timeout_ms {
+            d.field("timeout_ms", &timeout_ms);
+        }
+        if let Some(delay_ms) = self.delay_ms {
+            d.field("delay_ms", &delay_ms);
+        }
+        if let Some(ref src) = self.backoff_source {
+            d.field("backoff_source", src);
+        }
+        d.finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,32 +461,5 @@ mod tests {
 
         let neg = Event::new(EventKind::ActorDead).with_exit_code(-1);
         assert_eq!(neg.exit_code, Some(-1));
-    }
-}
-
-impl std::fmt::Debug for Event {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("Event");
-        d.field("seq", &self.seq);
-        d.field("kind", &self.kind);
-        if let Some(ref task) = self.task {
-            d.field("task", task);
-        }
-        if let Some(attempt) = self.attempt {
-            d.field("attempt", &attempt);
-        }
-        if let Some(ref reason) = self.reason {
-            d.field("reason", reason);
-        }
-        if let Some(timeout_ms) = self.timeout_ms {
-            d.field("timeout_ms", &timeout_ms);
-        }
-        if let Some(delay_ms) = self.delay_ms {
-            d.field("delay_ms", &delay_ms);
-        }
-        if let Some(ref src) = self.backoff_source {
-            d.field("backoff_source", src);
-        }
-        d.finish()
     }
 }


### PR DESCRIPTION
## 📝 Description
Fix clippy warnings
- Replaced `Default::default()` + field reassignment with struct-update syntax
- moved `impl Default for SupervisorConfig` / `impl Debug for Event` above their #[cfg(test)] mod tests.

## 🔄 Related Issues
Resolves #74

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally

## 📸 Screenshots / Logs (if applicable)
Add any helpful outputs or logs.
