### PR TITLE
[fix] graceful shutdown does not enforce grace

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -89,9 +89,10 @@
 //! ## Shutdown timeline
 //!
 //! ```text
-//! OS signal → Supervisor publishes ShutdownRequested → cancel runtime_token
-//! → Registry.cancel_all(): cancel each task, await join, publish TaskRemoved
-//! → Supervisor.wait_all_with_grace(): AllStoppedWithinGrace OR GraceExceeded{grace, stuck}
+//! OS signal → Supervisor publishes ShutdownRequested
+//! → Supervisor.drain_with_grace() → Registry.cancel_all_within(grace):
+//!     cancel each task token, join bounded by grace, force-abort (JoinHandle::abort) stragglers, publish TaskRemoved
+//! → AllStoppedWithinGrace OR GraceExceeded{grace, stuck} → cancel runtime_token → close subscribers
 //! ```
 //!
 //! ## Notes

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -22,10 +22,10 @@
 //! - Registry owns JoinHandle + CancellationToken for each actor
 //! - Publishes `TaskAdded`/`TaskRemoved` for observability
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use crate::core::actor::{ActorExitReason, TaskActor, TaskActorParams};
@@ -154,8 +154,7 @@ impl Registry {
                     }
                 }
             }
-
-            me.cancel_all().await;
+            me.cancel_all_within(Duration::ZERO).await;
         });
     }
 
@@ -191,8 +190,15 @@ impl Registry {
         self.tasks.read().await.is_empty()
     }
 
-    /// Cancels all tasks in the registry: cancel → join → TaskRemoved.
-    pub async fn cancel_all(&self) {
+    /// Cancels all tasks, waits up to `grace` for cooperative exit, then force-aborts stragglers.
+    ///
+    /// Steps:
+    /// - drain the registry and cancel every task token,
+    /// - join each actor, bounded by a single shared `grace` deadline,
+    /// - any actor still running when the deadline passes is force-terminated via [`JoinHandle::abort`] and reported in the returned "stuck" set.
+    ///
+    /// Always publishes `TaskRemoved` for every task (and `ActorDead` on panic).
+    pub async fn cancel_all_within(&self, grace: Duration) -> Vec<Arc<str>> {
         let handles: Vec<(Arc<str>, Handle)> = {
             let mut tasks = self.tasks.write().await;
             let drained = tasks.drain().collect::<Vec<_>>();
@@ -202,9 +208,27 @@ impl Registry {
         for (_, h) in &handles {
             h.cancel.cancel();
         }
+
+        let deadline = tokio::time::Instant::now() + grace;
+        let mut stuck = Vec::new();
+
         for (name, h) in handles {
-            self.join_and_report(&name, h.join).await;
+            let mut join = h.join;
+            match tokio::time::timeout_at(deadline, &mut join).await {
+                Ok(res) => self.report_join(&name, res),
+                Err(_elapsed) => {
+                    join.abort();
+                    let _ = join.await;
+                    self.bus.publish(
+                        Event::new(EventKind::TaskRemoved)
+                            .with_task(Arc::clone(&name))
+                            .with_reason("force_terminated_after_grace"),
+                    );
+                    stuck.push(name);
+                }
+            }
         }
+        stuck
     }
 
     /// Spawns an actor and registers its handle.
@@ -283,17 +307,23 @@ impl Registry {
         Some((h, len_after))
     }
 
-    /// Await join; report panic as ActorDead(actor_panic); always emit TaskRemoved.
+    /// Await join, then report terminal events for the actor.
     async fn join_and_report(&self, name: &str, join: JoinHandle<ActorExitReason>) {
-        match join.await {
-            Ok(_) => {}
-            Err(_) => {
-                self.bus.publish(
-                    Event::new(EventKind::ActorDead)
-                        .with_task(name)
-                        .with_reason("actor_panic"),
-                );
-            }
+        let res = join.await;
+        self.report_join(name, res);
+    }
+
+    /// Publish terminal events for a joined actor: `ActorDead` if it panicked, then always `TaskRemoved`.
+    /// A cancelled (force-aborted) join is not a panic.
+    fn report_join(&self, name: &str, res: Result<ActorExitReason, JoinError>) {
+        if let Err(e) = res
+            && e.is_panic()
+        {
+            self.bus.publish(
+                Event::new(EventKind::ActorDead)
+                    .with_task(name)
+                    .with_reason("actor_panic"),
+            );
         }
         self.bus
             .publish(Event::new(EventKind::TaskRemoved).with_task(name));

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -30,12 +30,10 @@
 //!     ├──► wait for N TaskAdded confirmations
 //!     └──► drive_shutdown()
 //!           ├──► wait for signal or empty registry
-//!           ├──► cancel all tasks
-//!           └──► wait_all_with_grace
+//!           └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
 //!
 //! Supervisor::shutdown()        // explicit graceful stop
-//!     ├──► cancel all tasks
-//!     └──► wait_all_with_grace
+//!     └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
 //! ```
 //!
 //! ## Runtime task management
@@ -331,11 +329,13 @@ impl Supervisor {
         }
     }
 
-    /// Initiates graceful shutdown: cancels all tasks and waits for them to stop.
+    /// Initiates graceful shutdown: cancels all tasks and waits up to `grace` for them to stop.
+    ///
+    /// Tasks that do not stop cooperatively within the configured grace period are force-terminated;
+    /// see [`drain_with_grace`](Self::drain_with_grace).
     pub(crate) async fn shutdown(&self) -> Result<(), RuntimeError> {
         self.bus.publish(Event::new(EventKind::ShutdownRequested));
-        self.registry.cancel_all().await;
-        let res = self.wait_all_with_grace().await;
+        let res = self.drain_with_grace().await;
         self.runtime_token.cancel();
         self.subs.close().await;
         res
@@ -445,8 +445,7 @@ impl Supervisor {
         let res = tokio::select! {
             _ = crate::core::shutdown::wait_for_shutdown_signal() => {
                 self.bus.publish(Event::new(EventKind::ShutdownRequested));
-                self.registry.cancel_all().await;
-                self.wait_all_with_grace().await
+                self.drain_with_grace().await
             }
             _ = self.registry.wait_until_empty() => {
                 Ok(())
@@ -457,23 +456,17 @@ impl Supervisor {
         res
     }
 
-    /// Waits for all tasks in registry with grace period timeout.
-    ///
-    /// Publishes terminal event (`AllStoppedWithinGrace` or `GraceExceeded`).
-    async fn wait_all_with_grace(&self) -> Result<(), RuntimeError> {
+    /// Cancels all tasks and waits up to `grace` for them to stop, force-aborting stragglers.
+    async fn drain_with_grace(&self) -> Result<(), RuntimeError> {
         let grace = self.cfg.grace;
-
-        match timeout(grace, self.registry.wait_until_empty()).await {
-            Ok(_) => {
-                self.bus
-                    .publish(Event::new(EventKind::AllStoppedWithinGrace));
-                Ok(())
-            }
-            Err(_) => {
-                self.bus.publish(Event::new(EventKind::GraceExceeded));
-                let stuck = self.snapshot().await;
-                Err(RuntimeError::GraceExceeded { grace, stuck })
-            }
+        let stuck = self.registry.cancel_all_within(grace).await;
+        if stuck.is_empty() {
+            self.bus
+                .publish(Event::new(EventKind::AllStoppedWithinGrace));
+            Ok(())
+        } else {
+            self.bus.publish(Event::new(EventKind::GraceExceeded));
+            Err(RuntimeError::GraceExceeded { grace, stuck })
         }
     }
 
@@ -518,5 +511,71 @@ impl Supervisor {
                 timeout: wait_for,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TaskFn, TaskRef};
+
+    #[tokio::test]
+    async fn shutdown_force_terminates_noncooperative_task_within_grace() {
+        let cfg = SupervisorConfig {
+            grace: Duration::from_millis(200),
+            ..Default::default()
+        };
+        let sup = Supervisor::new(cfg, vec![]);
+        let handle = sup.serve();
+
+        let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: CancellationToken| async move {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        });
+        handle
+            .add_and_wait(TaskSpec::once(stubborn), Duration::from_secs(1))
+            .await
+            .expect("task should register");
+
+        let res = tokio::time::timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("shutdown must return within grace, not block on the stuck task");
+
+        match res {
+            Err(RuntimeError::GraceExceeded { stuck, .. }) => {
+                assert!(
+                    stuck.iter().any(|n| &**n == "stubborn"),
+                    "stuck set must list the non-cooperative task, got {stuck:?}"
+                );
+            }
+            other => panic!("expected GraceExceeded listing the stuck task, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_cooperative_task_returns_ok() {
+        let cfg = SupervisorConfig {
+            grace: Duration::from_secs(5),
+            ..Default::default()
+        };
+        let sup = Supervisor::new(cfg, vec![]);
+        let handle = sup.serve();
+
+        let good: TaskRef = TaskFn::arc("good", |ctx: CancellationToken| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        handle
+            .add_and_wait(TaskSpec::restartable(good), Duration::from_secs(1))
+            .await
+            .expect("task should register");
+
+        let res = timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("cooperative shutdown must not hang");
+        assert!(
+            res.is_ok(),
+            "cooperative shutdown should be Ok, got {res:?}"
+        );
     }
 }


### PR DESCRIPTION
## 📝 Description
This was reworked by introducing `Registry::cancel_all_within(grace)`, which:
- signals cancellation to all tasks;
- waits for task completion within a shared grace deadline;
- force-aborts remaining tasks via JoinHandle::abort();
- returns the set of tasks that failed to stop gracefully.

`Supervisor::drain_with_grace()` now reports either:
- AllStoppedWithinGrace, or
- GraceExceeded { stuck }.

All unbounded joins were removed.

## 🔄 Related Issues
Resolves #78

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally
