### PR TITLE
[fix] runtime startup and task registration semantics

### DIFF
--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -78,10 +78,12 @@ impl SupervisorHandle {
     /// Adds a task and waits for registration confirmation.
     ///
     /// Subscribes to the event bus **before** publishing `TaskAddRequested`,
-    /// then waits for the matching `TaskAdded` event from the registry.
+    /// then waits for the matching `TaskAdded`/`TaskAddFailed` event from the registry.
     ///
-    /// Returns `Ok(())` when the task is confirmed running, or `RuntimeError::TaskAddTimeout`
-    /// if confirmation doesn't arrive within `timeout`.
+    /// Returns:
+    /// - `Ok(())` when the task is confirmed running,
+    /// - `Err(RuntimeError::TaskAlreadyExists)` if a task with the same name is already registered,
+    /// - `Err(RuntimeError::TaskAddTimeout)` if no confirmation arrives within `timeout`.
     pub async fn add_and_wait(
         &self,
         spec: TaskSpec,
@@ -100,6 +102,12 @@ impl SupervisorHandle {
                             && ev.task.as_deref() == Some(&*target2) =>
                     {
                         return Ok(());
+                    }
+                    Ok(ev)
+                        if ev.kind == EventKind::TaskAddFailed
+                            && ev.task.as_deref() == Some(&*target2) =>
+                    {
+                        return Err(RuntimeError::TaskAlreadyExists { name: target2 });
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(_)) => {

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -240,7 +240,7 @@ impl Registry {
         if tasks.contains_key(&*task_name) {
             drop(tasks);
             self.bus.publish(
-                Event::new(EventKind::TaskAdded)
+                Event::new(EventKind::TaskAddFailed)
                     .with_task(task_name)
                     .with_reason("already_exists"),
             );

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -27,7 +27,7 @@
 //!     ├──► start()
 //!     ├──► subscribe to bus (before publishing!)
 //!     ├──► add initial tasks
-//!     ├──► wait for N TaskAdded confirmations
+//!     ├──► wait for each task's add outcome (TaskAdded/TaskAddFailed)
 //!     └──► drive_shutdown()
 //!           ├──► wait for signal or empty registry
 //!           └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
@@ -294,39 +294,56 @@ impl Supervisor {
     /// - Start event loop (via `start`)
     /// - Subscribe to bus **before** publishing (guarantees no missed events)
     /// - Publish TaskAddRequested for initial tasks
-    /// - Wait for N `TaskAdded` confirmations from registry listener
+    /// - Wait for each task's add outcome (`TaskAdded`/`TaskAddFailed`) before driving shutdown
     /// - Wait for shutdown signal or all tasks to exit
     pub async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
         self.start();
 
-        let expected = tasks.len();
-        if expected > 0 {
+        if !tasks.is_empty() {
+            let names: Vec<Arc<str>> = tasks.iter().map(|s| Arc::from(s.task().name())).collect();
             let mut rx = self.bus.subscribe();
             for spec in tasks {
                 self.add_task(spec)?;
             }
-            self.wait_tasks_registered(&mut rx, expected).await;
+            self.wait_tasks_registered(&mut rx, &names).await;
         }
         self.drive_shutdown().await
     }
 
-    /// Waits until registry listener confirms N tasks were registered.
+    /// Waits until every initially-added task has been processed by the registry.
     async fn wait_tasks_registered(
         &self,
         rx: &mut broadcast::Receiver<Arc<Event>>,
-        expected: usize,
+        names: &[Arc<str>],
     ) {
-        let mut registered = 0usize;
-        while registered < expected {
-            match rx.recv().await {
-                Ok(ev) if ev.kind == EventKind::TaskAdded => {
-                    registered += 1;
+        let mut pending: Vec<Arc<str>> = names.to_vec();
+
+        let confirm = async {
+            while !pending.is_empty() {
+                match rx.recv().await {
+                    Ok(ev)
+                        if matches!(ev.kind, EventKind::TaskAdded | EventKind::TaskAddFailed) =>
+                    {
+                        if let Some(name) = ev.task.as_deref() {
+                            pending.retain(|p| &**p != name);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        let mut still = Vec::new();
+                        for p in std::mem::take(&mut pending) {
+                            if !self.registry.contains(&p).await {
+                                still.push(p);
+                            }
+                        }
+                        pending = still;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
                 }
-                Ok(_) => continue,
-                Err(broadcast::error::RecvError::Lagged(_)) => break,
-                Err(broadcast::error::RecvError::Closed) => break,
             }
-        }
+        };
+        const CONFIRM_BACKSTOP: Duration = Duration::from_secs(5);
+        let _ = timeout(CONFIRM_BACKSTOP, confirm).await;
     }
 
     /// Initiates graceful shutdown: cancels all tasks and waits up to `grace` for them to stop.
@@ -577,5 +594,32 @@ mod tests {
             res.is_ok(),
             "cooperative shutdown should be Ok, got {res:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn add_and_wait_duplicate_name_returns_already_exists() {
+        let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+        let handle = sup.serve();
+
+        let make = || -> TaskRef {
+            TaskFn::arc("dup", |ctx: CancellationToken| async move {
+                ctx.cancelled().await;
+                Ok(())
+            })
+        };
+        handle
+            .add_and_wait(TaskSpec::restartable(make()), Duration::from_secs(1))
+            .await
+            .expect("first add should succeed");
+
+        let res = handle
+            .add_and_wait(TaskSpec::restartable(make()), Duration::from_secs(1))
+            .await;
+        assert!(
+            matches!(res, Err(RuntimeError::TaskAlreadyExists { .. })),
+            "duplicate add must return TaskAlreadyExists, got {res:?}"
+        );
+
+        let _ = handle.shutdown().await;
     }
 }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -149,6 +149,18 @@ pub enum EventKind {
     /// - `seq`: global sequence
     TaskAdded,
 
+    /// Task could not be added: a task with the same name is already registered.
+    ///
+    /// Published by Registry instead of `TaskAdded` when an `Add` command targets a name that already exists;
+    /// no new actor is spawned.
+    ///
+    /// Sets:
+    /// - `task`: task name
+    /// - `reason`: e.g. "already_exists"
+    /// - `at`: wall-clock timestamp
+    /// - `seq`: global sequence
+    TaskAddFailed,
+
     /// Request to remove a task from the supervisor.
     ///
     /// Sets:

--- a/src/subscribers/embedded/log.rs
+++ b/src/subscribers/embedded/log.rs
@@ -160,6 +160,14 @@ impl LogWriter {
                     or(e.task.as_deref(), "none")
                 );
             }
+            EventKind::TaskAddFailed => {
+                println!(
+                    "{} [task-add-failed] task={} reason=\"{}\"",
+                    seq,
+                    or(e.task.as_deref(), "none"),
+                    or(e.reason.as_deref(), "unknown")
+                );
+            }
             EventKind::TaskRemoveRequested => {
                 println!(
                     "{} [task-remove-requested] task={}",


### PR DESCRIPTION
## 📝 Description

Registration phase changes:
-  wait for a definitive outcome for every expected task;
-  reconcile progress against actual registry state after bus lag;
-  tolerate dropped registration events;
-  use a dedicated startup backstop timeout independent of shutdown grace settings.

Deduplicate changes:
- `add_and_wait()` reported success even though no task was created;
- `RuntimeError::TaskAlreadyExists` was effectively unreachable;
- New event added `TaskAddFailed`

## 🔄 Related Issues
Resolves #82

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally

## NOTES
- New event added `TaskAddFailed`