### PR TITLE
[core] introduce TaskId runtime identity

### DIFF
--- a/benches/dynamic.rs
+++ b/benches/dynamic.rs
@@ -123,8 +123,8 @@ fn bench_add_cancel(c: &mut Criterion) {
                         let spec = worker_task(&name);
 
                         let start = std::time::Instant::now();
-                        handle.add_and_wait(spec, wait).await.unwrap();
-                        let _ = handle.cancel(&name).await;
+                        let id = handle.add_and_wait(spec, wait).await.unwrap();
+                        let _ = handle.cancel(id).await;
                         total += start.elapsed();
                     }
 

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -99,15 +99,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add workers dynamically
     println!("Adding worker-a and worker-b...");
-    handle.add(make_worker("worker-a"))?;
-    handle.add(make_worker("worker-b"))?;
+    let id_a = handle.add(make_worker("worker-a"))?;
+    let id_b = handle.add(make_worker("worker-b"))?;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
     println!("Active: {:?}", handle.list().await);
 
     // Remove worker-a
     println!("\nRemoving worker-a...");
-    handle.remove("worker-a")?;
+    handle.remove(id_a)?;
     tokio::time::sleep(Duration::from_millis(200)).await;
     println!("Active: {:?}", handle.list().await);
 
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Cancel worker-b
     println!("Cancelling worker-b...");
-    let cancelled = handle.cancel("worker-b").await?;
+    let cancelled = handle.cancel(id_b).await?;
     println!("worker-b cancelled: {cancelled}");
     println!("worker-b alive: {}", handle.is_alive("worker-b").await);
 

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -263,10 +263,22 @@ impl Controller {
                                 .with_task(Arc::clone(&slot_name))
                                 .with_reason(format!("add_failed: {e}")),
                         );
+                        drop(slot);
+                        self.slots.remove(&*slot_name);
                     }
                 }
             }
             (SlotStatus::Running { .. }, AdmissionPolicy::Replace) => {
+                if let Some(rid) = slot.running_id
+                    && let Err(e) = sup.remove(rid)
+                {
+                    self.bus.publish(
+                        Event::new(EventKind::ControllerRejected)
+                            .with_task(Arc::clone(&slot_name))
+                            .with_reason(format!("remove_failed: {e}")),
+                    );
+                    return;
+                }
                 Self::replace_head_or_push(&mut slot, task_spec);
                 slot.status = SlotStatus::Terminating {
                     cancelled_at: Instant::now(),
@@ -276,15 +288,6 @@ impl Controller {
                         .with_task(Arc::clone(&slot_name))
                         .with_reason("running→terminating (replace)"),
                 );
-                if let Some(rid) = slot.running_id
-                    && let Err(e) = sup.remove(rid)
-                {
-                    self.bus.publish(
-                        Event::new(EventKind::ControllerRejected)
-                            .with_task(Arc::clone(&slot_name))
-                            .with_reason(format!("remove_failed: {e}")),
-                    );
-                }
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -23,7 +23,7 @@
 
 use std::{
     sync::{Arc, Weak},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use dashmap::DashMap;
@@ -33,8 +33,9 @@ use tokio_util::sync::CancellationToken;
 use tokio::sync::broadcast;
 
 use crate::{
-    Supervisor,
+    RuntimeError, Supervisor, TaskSpec,
     events::{Bus, Event, EventKind},
+    identity::TaskId,
 };
 
 use super::{
@@ -87,13 +88,7 @@ pub(crate) struct Controller {
     bus: Bus,
 
     slots: DashMap<Arc<str>, Arc<Mutex<SlotState>>>,
-
-    /// Reverse index: running task name → slot key.
-    ///
-    /// `TaskRemoved` carries only the task name, but slots are keyed by the logical slot (which may differ from the name).
-    ///  This index lets `on_task_finished` find the owning slot.
-    ///  An entry exists exactly while a task occupies a slot (inserted on start, removed on `TaskRemoved`).
-    running: DashMap<Arc<str>, Arc<str>>,
+    running: DashMap<TaskId, Arc<str>>,
 
     tx: mpsc::Sender<ControllerSpec>,
     rx: RwLock<Option<mpsc::Receiver<ControllerSpec>>>,
@@ -174,12 +169,13 @@ impl Controller {
         Ok(())
     }
 
-    /// Recovers slots that may be stuck in `Running`/`Terminating` after bus lag.
+    /// Recovers slots whose task vanished after a bus lag (a missed `TaskAdded`/`TaskRemoved`).
     ///
-    /// When the broadcast receiver falls behind, we may have missed `TaskRemoved` events.
-    /// Walk all slots and check if the task is still alive in the registry.
-    /// If not, treat it as finished.
+    /// Walks all non-`Idle` slots; if the occupying task is no longer in the registry (and an `Admitting` slot has exceeded the admit deadline),
+    /// the slot is freed and its queue advanced. All correlation/cleanup is keyed by [`TaskId`].
     async fn recover_stale_slots(&self) {
+        const ADMIT_DEADLINE: Duration = Duration::from_secs(5);
+
         let Some(sup) = self.supervisor.upgrade() else {
             return;
         };
@@ -199,59 +195,46 @@ impl Controller {
             if matches!(slot.status, SlotStatus::Idle) {
                 continue;
             }
+            if let SlotStatus::Admitting { since } = slot.status
+                && since.elapsed() < ADMIT_DEADLINE
+            {
+                continue;
+            }
 
-            let alive = match slot.running.as_deref() {
-                Some(name) => sup.registry_contains(name).await,
+            let alive = match slot.running_id {
+                Some(rid) => sup.contains_id(rid).await,
                 None => false,
             };
             if alive {
                 continue;
             }
 
-            if let Some(name) = slot.running.take() {
-                self.running.remove(&*name);
+            if let Some(id) = slot.running_id.take() {
+                self.running.remove(&id);
             }
             slot.status = SlotStatus::Idle;
 
-            if let Some(next_spec) = slot.queue.pop_front() {
-                let next_name: Arc<str> = Arc::from(next_spec.name());
-                if let Err(e) = sup.add_task(next_spec) {
-                    self.bus.publish(
-                        Event::new(EventKind::ControllerRejected)
-                            .with_task(Arc::clone(&slot_name))
-                            .with_reason(format!("recovery_start_failed: {e}")),
-                    );
-                    continue;
-                }
-                slot.status = SlotStatus::Running {
-                    started_at: Instant::now(),
-                };
-                slot.running = Some(Arc::clone(&next_name));
-                self.running.insert(next_name, Arc::clone(&slot_name));
-                self.bus.publish(
-                    Event::new(EventKind::ControllerSubmitted)
-                        .with_task(Arc::clone(&slot_name))
-                        .with_reason(format!("recovered_from_lag depth={}", slot.queue.len())),
-                );
-            } else {
+            self.start_next_from_queue(&sup, &mut slot, &slot_name);
+
+            if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
                 drop(slot);
                 self.slots.remove(&*slot_name);
             }
         }
     }
 
-    /// Handles a new task submission by applying admission policy to the slot.
+    /// Applies the admission policy for a new submission.
     ///
-    /// **Idle** (any policy): start immediately via `add_task`.
+    /// **Idle**: admit immediately, `add_task` mints the [`TaskId`] and the slot enters `Admitting`;
+    /// it becomes `Running` only when the matching `TaskAdded` is observed.
     ///
-    /// **Queue**: push to tail (FIFO). Rejected if per-slot queue is full.
+    /// **Queue**: push to tail (FIFO); rejected if the per-slot queue is full.
     ///
-    /// **Replace** (latest-wins): replaces the queue head (immediate successor).
-    /// - If `Running` → transition to `Terminating`, call `remove_task` once.
-    /// - If already `Terminating` → replace head only, do NOT call remove again.
-    /// - The next task actually starts in `on_task_finished` upon `TaskRemoved`.
+    /// **Replace** (latest-wins): replaces the queue head;
+    /// if the slot is `Running` the current task is removed now,
+    /// if `Admitting` it is removed once it appears (in [`on_task_added`](Self::on_task_added)).
     ///
-    /// **DropIfRunning**: silently reject if slot is `Running` or `Terminating`.
+    /// **DropIfRunning**: reject while the slot is busy (`Admitting`/`Running`/`Terminating`).
     async fn handle_submission(&self, spec: ControllerSpec) {
         let Some(sup) = self.supervisor.upgrade() else {
             return;
@@ -266,25 +249,22 @@ impl Controller {
 
         match (&slot.status, admission) {
             (SlotStatus::Idle, _) => {
-                let task_name: Arc<str> = Arc::from(task_spec.name());
-                if let Err(e) = sup.add_task(task_spec) {
-                    self.bus.publish(
-                        Event::new(EventKind::ControllerRejected)
-                            .with_task(Arc::clone(&slot_name))
-                            .with_reason(format!("add_failed: {}", e)),
-                    );
-                    return;
+                match self.start_in_slot(&sup, &mut slot, &slot_name, task_spec) {
+                    Ok(_id) => {
+                        self.bus.publish(
+                            Event::new(EventKind::ControllerSubmitted)
+                                .with_task(Arc::clone(&slot_name))
+                                .with_reason(format!("admission={admission:?} status=admitting")),
+                        );
+                    }
+                    Err(e) => {
+                        self.bus.publish(
+                            Event::new(EventKind::ControllerRejected)
+                                .with_task(Arc::clone(&slot_name))
+                                .with_reason(format!("add_failed: {e}")),
+                        );
+                    }
                 }
-                slot.status = SlotStatus::Running {
-                    started_at: Instant::now(),
-                };
-                slot.running = Some(Arc::clone(&task_name));
-                self.running.insert(task_name, Arc::clone(&slot_name));
-                self.bus.publish(
-                    Event::new(EventKind::ControllerSubmitted)
-                        .with_task(Arc::clone(&slot_name))
-                        .with_reason(format!("admission={:?} status=running", admission)),
-                );
             }
             (SlotStatus::Running { .. }, AdmissionPolicy::Replace) => {
                 Self::replace_head_or_push(&mut slot, task_spec);
@@ -296,13 +276,13 @@ impl Controller {
                         .with_task(Arc::clone(&slot_name))
                         .with_reason("running→terminating (replace)"),
                 );
-                if let Some(running) = slot.running.clone()
-                    && let Err(e) = sup.remove_task(&running)
+                if let Some(rid) = slot.running_id
+                    && let Err(e) = sup.remove(rid)
                 {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(&slot_name))
-                            .with_reason(format!("remove_failed: {}", e)),
+                            .with_reason(format!("remove_failed: {e}")),
                     );
                 }
                 self.bus.publish(
@@ -311,15 +291,23 @@ impl Controller {
                         .with_reason(format!("admission=Replace depth={}", slot.queue.len())),
                 );
             }
-            (SlotStatus::Running { .. }, AdmissionPolicy::Queue) => {
-                if self.reject_if_full(&slot_name, slot.queue.len()) {
-                    return;
-                }
-                slot.queue.push_back(task_spec);
+            (SlotStatus::Admitting { .. }, AdmissionPolicy::Replace) => {
+                Self::replace_head_or_push(&mut slot, task_spec);
+                slot.status = SlotStatus::Terminating {
+                    cancelled_at: Instant::now(),
+                };
+                self.bus.publish(
+                    Event::new(EventKind::ControllerSlotTransition)
+                        .with_task(Arc::clone(&slot_name))
+                        .with_reason("admitting→terminating (replace)"),
+                );
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
-                        .with_reason(format!("admission=Queue depth={}", slot.queue.len())),
+                        .with_reason(format!(
+                            "admission=Replace status=admitting depth={}",
+                            slot.queue.len()
+                        )),
                 );
             }
             (SlotStatus::Terminating { .. }, AdmissionPolicy::Replace) => {
@@ -333,7 +321,12 @@ impl Controller {
                         )),
                 );
             }
-            (SlotStatus::Terminating { .. }, AdmissionPolicy::Queue) => {
+            (
+                SlotStatus::Admitting { .. }
+                | SlotStatus::Running { .. }
+                | SlotStatus::Terminating { .. },
+                AdmissionPolicy::Queue,
+            ) => {
                 if self.reject_if_full(&slot_name, slot.queue.len()) {
                     return;
                 }
@@ -341,14 +334,15 @@ impl Controller {
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
-                        .with_reason(format!(
-                            "admission=Queue status=terminating depth={}",
-                            slot.queue.len()
-                        )),
+                        .with_reason(format!("admission=Queue depth={}", slot.queue.len())),
                 );
             }
-            (SlotStatus::Running { .. }, AdmissionPolicy::DropIfRunning)
-            | (SlotStatus::Terminating { .. }, AdmissionPolicy::DropIfRunning) => {
+            (
+                SlotStatus::Admitting { .. }
+                | SlotStatus::Running { .. }
+                | SlotStatus::Terminating { .. },
+                AdmissionPolicy::DropIfRunning,
+            ) => {
                 self.bus.publish(
                     Event::new(EventKind::ControllerRejected)
                         .with_task(Arc::clone(&slot_name))
@@ -358,61 +352,150 @@ impl Controller {
         }
     }
 
-    /// Handles bus events (terminal only).
+    /// Routes bus events that drive slot transitions, correlated by [`TaskId`].
     async fn handle_event(&self, event: Arc<Event>) {
-        if event.kind == EventKind::TaskRemoved {
-            self.on_task_finished(&event).await
+        match event.kind {
+            EventKind::TaskAdded => self.on_task_added(&event).await,
+            EventKind::TaskRemoved => self.on_task_finished(&event).await,
+            EventKind::TaskAddFailed => self.on_task_add_failed(&event).await,
+            _ => {}
         }
     }
 
-    /// Handles `TaskRemoved` for a task; frees the slot and optionally starts the queued next.
-    async fn on_task_finished(&self, event: &Event) {
-        let Some(removed) = event.task.as_deref() else {
+    /// `TaskAdded`: the admitted actor now exists - flip `Admitting` → `Running`.
+    /// If a `Replace` arrived while admitting (slot is `Terminating`), remove it now.
+    async fn on_task_added(&self, event: &Event) {
+        let Some(id) = event.id else {
             return;
         };
         let Some(sup) = self.supervisor.upgrade() else {
             return;
         };
-
-        let Some((_, slot_name)) = self.running.remove(removed) else {
+        let Some(slot_name) = self.running.get(&id).map(|e| e.clone()) else {
             return;
         };
         let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
             return;
         };
         let mut slot = slot_arc.lock().await;
+        if slot.running_id != Some(id) {
+            return;
+        }
+        match slot.status {
+            SlotStatus::Admitting { .. } => {
+                slot.status = SlotStatus::Running {
+                    started_at: Instant::now(),
+                };
+                self.bus.publish(
+                    Event::new(EventKind::ControllerSlotTransition)
+                        .with_task(slot_name)
+                        .with_reason("admitting→running"),
+                );
+            }
+            SlotStatus::Terminating { .. } => {
+                if let Some(rid) = slot.running_id
+                    && let Err(e) = sup.remove(rid)
+                {
+                    self.bus.publish(
+                        Event::new(EventKind::ControllerRejected)
+                            .with_task(slot_name)
+                            .with_reason(format!("remove_failed: {e}")),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
 
+    /// `TaskAddFailed`: admission was rejected (e.g. duplicate name)
+    /// free the slot and start the next queued task, so a slot can never wedge in `Admitting`.
+    async fn on_task_add_failed(&self, event: &Event) {
+        self.free_and_advance(event).await;
+    }
+
+    /// `TaskRemoved`: the occupying task ended - free the slot and start the next queued task.
+    /// Correlating by [`TaskId`] makes duplicate/stale removals harmless no-ops.
+    async fn on_task_finished(&self, event: &Event) {
+        self.free_and_advance(event).await;
+    }
+
+    /// Common terminal handling for `TaskRemoved`/`TaskAddFailed`:
+    /// resolve the owning slot by [`TaskId`], free it, and advance its queue.
+    ///
+    /// Idempotent: a stale/duplicate event whose id is no longer in the index is a no-op.
+    async fn free_and_advance(&self, event: &Event) {
+        let Some(id) = event.id else {
+            return;
+        };
+        let Some(sup) = self.supervisor.upgrade() else {
+            return;
+        };
+        let Some((_, slot_name)) = self.running.remove(&id) else {
+            return;
+        };
+        let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
+            return;
+        };
+        let mut slot = slot_arc.lock().await;
+        if slot.running_id != Some(id) {
+            return;
+        }
+
+        slot.running_id = None;
         slot.status = SlotStatus::Idle;
-        slot.running = None;
 
+        self.start_next_from_queue(&sup, &mut slot, &slot_name);
+
+        if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
+            drop(slot);
+            self.slots.remove(&*slot_name);
+        }
+    }
+
+    /// Admits `task_spec` into the slot: mints the identity via `add_task`, marks the slot `Admitting`, and records the reverse index.
+    /// The slot becomes `Running` on `TaskAdded`.
+    fn start_in_slot(
+        &self,
+        sup: &Arc<Supervisor>,
+        slot: &mut SlotState,
+        slot_name: &Arc<str>,
+        task_spec: TaskSpec,
+    ) -> Result<TaskId, RuntimeError> {
+        let id = sup.add_task(task_spec)?;
+        slot.status = SlotStatus::Admitting {
+            since: Instant::now(),
+        };
+        slot.running_id = Some(id);
+        self.running.insert(id, Arc::clone(slot_name));
+        Ok(id)
+    }
+
+    /// Pops and admits queued tasks until one is accepted or the queue drains.
+    /// Leaves the slot `Admitting` (one started) or `Idle` (queue empty / all failed).
+    fn start_next_from_queue(
+        &self,
+        sup: &Arc<Supervisor>,
+        slot: &mut SlotState,
+        slot_name: &Arc<str>,
+    ) {
         while let Some(next_spec) = slot.queue.pop_front() {
-            let next_name: Arc<str> = Arc::from(next_spec.name());
-            match sup.add_task(next_spec) {
-                Ok(()) => {
-                    slot.status = SlotStatus::Running {
-                        started_at: Instant::now(),
-                    };
-                    slot.running = Some(Arc::clone(&next_name));
-                    self.running.insert(next_name, Arc::clone(&slot_name));
+            match self.start_in_slot(sup, slot, slot_name, next_spec) {
+                Ok(_id) => {
                     self.bus.publish(
                         Event::new(EventKind::ControllerSubmitted)
-                            .with_task(Arc::clone(&slot_name))
+                            .with_task(Arc::clone(slot_name))
                             .with_reason(format!("started_from_queue depth={}", slot.queue.len())),
                     );
-                    break;
+                    return;
                 }
                 Err(e) => {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
-                            .with_task(Arc::clone(&slot_name))
+                            .with_task(Arc::clone(slot_name))
                             .with_reason(format!("queue_start_failed: {e}")),
                     );
                 }
             }
-        }
-        if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
-            drop(slot);
-            self.slots.remove(&*slot_name);
         }
     }
 
@@ -586,6 +669,54 @@ mod tests {
             running: DashMap::new(),
             tx,
             rx: RwLock::new(Some(rx)),
+        }
+    }
+
+    #[tokio::test]
+    async fn replace_supersedes_in_same_slot() {
+        let sup = Supervisor::builder(crate::SupervisorConfig::default())
+            .with_controller(ControllerConfig::default())
+            .build();
+        let handle = sup.serve();
+
+        let mk = |name: &'static str| -> ControllerSpec {
+            let task: TaskRef = TaskFn::arc(name, |ctx: CancellationToken| async move {
+                ctx.cancelled().await;
+                Ok(())
+            });
+            ControllerSpec::replace(TaskSpec::restartable(task).with_slot("s"))
+        };
+
+        handle.submit(mk("run-1")).await.unwrap();
+        handle.submit(mk("run-2")).await.unwrap();
+
+        let superseded = poll_until(std::time::Duration::from_secs(3), || async {
+            let alive = handle.snapshot().await;
+            alive.iter().any(|n| &**n == "run-2") && alive.iter().all(|n| &**n != "run-1")
+        })
+        .await;
+        assert!(
+            superseded,
+            "Replace must supersede run-1 with run-2 in the shared slot, not run both"
+        );
+
+        let _ = handle.shutdown().await;
+    }
+
+    async fn poll_until<F, Fut>(within: std::time::Duration, mut cond: F) -> bool
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = bool>,
+    {
+        let deadline = tokio::time::Instant::now() + within;
+        loop {
+            if cond().await {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
         }
     }
 }

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -2,9 +2,10 @@
 //!
 //! [`SlotState`] tracks the current status and pending queue for a single named slot.
 
-use std::{collections::VecDeque, sync::Arc, time::Instant};
+use std::{collections::VecDeque, time::Instant};
 
 use crate::TaskSpec;
+use crate::identity::TaskId;
 
 /// State of a single task slot.
 ///
@@ -13,11 +14,12 @@ use crate::TaskSpec;
 /// - [`AdmissionPolicy`](super::AdmissionPolicy) - determines how submissions interact with slot state
 /// - [`Controller`](super::Controller) - owns and manages slot states
 pub(super) struct SlotState {
-    /// Current status (idle, running, or terminating).
+    /// Current status (idle, admitting, running, or terminating).
     pub status: SlotStatus,
 
-    /// Name of the task currently occupying the slot (running or terminating).
-    pub running: Option<Arc<str>>,
+    /// Runtime identity of the task currently occupying the slot.
+    /// The canonical key used to address the task (removal) and correlate its events.
+    pub running_id: Option<TaskId>,
 
     /// Queue of pending tasks (FIFO order).
     pub queue: VecDeque<TaskSpec>,
@@ -28,6 +30,12 @@ pub(super) struct SlotState {
 pub(super) enum SlotStatus {
     /// No task running, ready to accept new submissions.
     Idle,
+
+    /// A task was submitted (`add_task` issued) and the slot is awaiting the `TaskAdded` confirmation before it is considered `Running`.
+    Admitting {
+        /// When admission was requested (for the admit deadline during lag recovery).
+        since: Instant,
+    },
 
     /// Task currently running.
     Running {
@@ -47,7 +55,7 @@ impl SlotState {
     pub fn new() -> Self {
         Self {
             status: SlotStatus::Idle,
-            running: None,
+            running_id: None,
             queue: VecDeque::new(),
         }
     }

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -71,6 +71,7 @@ use crate::{
     TaskError,
     core::runner::run_once,
     events::{Bus, Event, EventKind},
+    identity::TaskId,
     policies::{BackoffPolicy, RestartPolicy},
     tasks::Task,
 };
@@ -120,6 +121,8 @@ pub(crate) struct TaskActorParams {
 /// - [`Registry`](super::registry::Registry) - spawns and owns task actors
 /// - [`TaskSpec`](crate::TaskSpec) - user-facing configuration that maps to [`TaskActorParams`]
 pub(crate) struct TaskActor {
+    /// Runtime identity stamped on every lifecycle event this actor publishes.
+    id: TaskId,
     /// Task to execute.
     task: Arc<dyn Task>,
     /// Parameters for supervised task executions.
@@ -131,14 +134,16 @@ pub(crate) struct TaskActor {
 }
 
 impl TaskActor {
-    /// Creates a new task actor.
+    /// Creates a new task actor with its runtime identity.
     pub(crate) fn new(
         bus: Bus,
         task: Arc<dyn Task>,
         params: TaskActorParams,
         semaphore: Option<Arc<Semaphore>>,
+        id: TaskId,
     ) -> Self {
         Self {
+            id,
             task,
             params,
             bus,
@@ -152,6 +157,7 @@ impl TaskActor {
     /// (including backoff sleep) results in a clean exit without restarting, even with `RestartPolicy::Always`.
     pub(crate) async fn run(self, runtime_token: CancellationToken) -> ActorExitReason {
         let task_name: Arc<str> = Arc::from(self.task.name());
+        let id = self.id;
         let mut attempt: u32 = 0;
         let mut backoff_attempt: u32 = 0;
 
@@ -171,6 +177,7 @@ impl TaskActor {
                                 self.bus.publish(
                                     Event::new(EventKind::ActorExhausted)
                                         .with_task(task_name.clone())
+                        .with_id(id)
                                         .with_attempt(attempt)
                                         .with_reason("semaphore_closed")
                                 );
@@ -195,6 +202,7 @@ impl TaskActor {
             self.bus.publish(
                 Event::new(EventKind::TaskStarting)
                     .with_task(task_name.clone())
+                    .with_id(id)
                     .with_attempt(attempt),
             );
             let res = run_once(
@@ -202,6 +210,7 @@ impl TaskActor {
                 &child,
                 self.params.timeout,
                 attempt,
+                id,
                 &self.bus,
             )
             .await;
@@ -218,6 +227,7 @@ impl TaskActor {
                                     Event::new(EventKind::BackoffScheduled)
                                         .with_backoff_success()
                                         .with_task(task_name.clone())
+                                        .with_id(id)
                                         .with_attempt(attempt)
                                         .with_delay(d),
                                 );
@@ -231,6 +241,7 @@ impl TaskActor {
                             self.bus.publish(
                                 Event::new(EventKind::ActorExhausted)
                                     .with_task(task_name.clone())
+                                    .with_id(id)
                                     .with_attempt(attempt)
                                     .with_reason("policy_exhausted_success"),
                             );
@@ -241,6 +252,7 @@ impl TaskActor {
                 Err(e) if e.is_fatal() => {
                     let mut ev = Event::new(EventKind::ActorDead)
                         .with_task(task_name.clone())
+                        .with_id(id)
                         .with_attempt(attempt)
                         .with_reason(e.to_string());
                     if let Some(code) = e.exit_code() {
@@ -272,6 +284,7 @@ impl TaskActor {
                         };
                         let mut ev = Event::new(EventKind::ActorExhausted)
                             .with_task(task_name.clone())
+                            .with_id(id)
                             .with_attempt(attempt)
                             .with_reason(reason);
                         if let Some(code) = e.exit_code() {
@@ -288,6 +301,7 @@ impl TaskActor {
                         Event::new(EventKind::BackoffScheduled)
                             .with_backoff_failure()
                             .with_task(task_name.clone())
+                            .with_id(id)
                             .with_delay(delay)
                             .with_attempt(attempt)
                             .with_reason(e.to_string()),
@@ -348,6 +362,7 @@ mod tests {
             Arc::clone(&task),
             params(restart, max_retries),
             None,
+            TaskId::next(),
         )
     }
 

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -10,6 +10,7 @@ use tokio::sync::broadcast;
 
 use crate::error::RuntimeError;
 use crate::events::EventKind;
+use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
 use super::supervisor::Supervisor;
@@ -69,9 +70,9 @@ impl SupervisorHandle {
 
     /// Adds a new task to the supervisor at runtime.
     ///
-    /// Fire-and-forget: publishes `TaskAddRequested` and returns immediately.
-    /// The task will be spawned asynchronously by the registry listener.
-    pub fn add(&self, spec: TaskSpec) -> Result<(), RuntimeError> {
+    /// Fire-and-forget: mints the [`TaskId`], publishes `TaskAddRequested`, and returns immediately with the id.
+    /// The task is spawned asynchronously by the registry listener.
+    pub fn add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
         self.inner.add_task(spec)
     }
 
@@ -81,38 +82,34 @@ impl SupervisorHandle {
     /// then waits for the matching `TaskAdded`/`TaskAddFailed` event from the registry.
     ///
     /// Returns:
-    /// - `Ok(())` when the task is confirmed running,
+    /// - `Ok(TaskId)` when the task is confirmed running,
     /// - `Err(RuntimeError::TaskAlreadyExists)` if a task with the same name is already registered,
     /// - `Err(RuntimeError::TaskAddTimeout)` if no confirmation arrives within `timeout`.
+    ///
+    /// Correlation is by the minted [`TaskId`] (the canonical key), not the task name.
     pub async fn add_and_wait(
         &self,
         spec: TaskSpec,
         timeout: Duration,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<TaskId, RuntimeError> {
         let target: Arc<str> = Arc::from(spec.task().name());
         let mut rx = self.inner.subscribe_bus();
-        self.inner.add_task(spec)?;
+        let id = self.inner.add_task(spec)?;
 
         let target2 = Arc::clone(&target);
         let wait = async move {
             loop {
                 match rx.recv().await {
-                    Ok(ev)
-                        if ev.kind == EventKind::TaskAdded
-                            && ev.task.as_deref() == Some(&*target2) =>
-                    {
-                        return Ok(());
+                    Ok(ev) if ev.id == Some(id) && ev.kind == EventKind::TaskAdded => {
+                        return Ok(id);
                     }
-                    Ok(ev)
-                        if ev.kind == EventKind::TaskAddFailed
-                            && ev.task.as_deref() == Some(&*target2) =>
-                    {
+                    Ok(ev) if ev.id == Some(id) && ev.kind == EventKind::TaskAddFailed => {
                         return Err(RuntimeError::TaskAlreadyExists { name: target2 });
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if self.inner.registry_contains(&target2).await {
-                            return Ok(());
+                        if self.inner.contains_id(id).await {
+                            return Ok(id);
                         }
                     }
                     Err(broadcast::error::RecvError::Closed) => {
@@ -120,8 +117,8 @@ impl SupervisorHandle {
                     }
                 }
             }
-            if self.inner.registry_contains(&target2).await {
-                Ok(())
+            if self.inner.contains_id(id).await {
+                Ok(id)
             } else {
                 Err(RuntimeError::TaskAddTimeout {
                     name: target2,
@@ -143,15 +140,26 @@ impl SupervisorHandle {
     ///
     /// Fire-and-forget: publishes `TaskRemoveRequested` and returns immediately.
     /// The task will be cancelled and cleaned up asynchronously by the registry.
-    pub fn remove(&self, name: &str) -> Result<(), RuntimeError> {
-        self.inner.remove_task(name)
+    pub fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
+        self.inner.remove(id)
+    }
+
+    /// Removes the task currently holding `name` (label); `false` if no such task.
+    pub async fn remove_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
+        match self.inner.id_for_label(name).await {
+            Some(id) => {
+                self.inner.remove(id)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     /// Returns a sorted list of registered task names (from the registry).
     ///
     /// Includes tasks in any state: starting, running, stopping.
     /// See [`snapshot`](Self::snapshot) for only currently executing tasks.
-    pub async fn list(&self) -> Vec<Arc<str>> {
+    pub async fn list(&self) -> Vec<(TaskId, Arc<str>)> {
         self.inner.list_tasks().await
     }
 
@@ -168,20 +176,29 @@ impl SupervisorHandle {
         self.inner.is_alive(name).await
     }
 
-    /// Cancel a task by name and wait for confirmation.
+    /// Cancel a task by identity and wait for confirmation.
     ///
     /// Uses the default grace period from supervisor config.
-    pub async fn cancel(&self, name: &str) -> Result<bool, RuntimeError> {
-        self.inner.cancel(name).await
+    pub async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        self.inner.cancel(id).await
+    }
+
+    /// Cancel the task currently holding `name` (label), resolving to its identity.
+    /// Returns `false` if no task currently holds that label.
+    pub async fn cancel_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
+        match self.inner.id_for_label(name).await {
+            Some(id) => self.inner.cancel(id).await,
+            None => Ok(false),
+        }
     }
 
     /// Cancel a task with explicit timeout.
     pub async fn cancel_with_timeout(
         &self,
-        name: &str,
+        id: TaskId,
         wait_for: Duration,
     ) -> Result<bool, RuntimeError> {
-        self.inner.cancel_with_timeout(name, wait_for).await
+        self.inner.cancel_with_timeout(id, wait_for).await
     }
 
     /// Initiates graceful shutdown: cancels all tasks and waits for them to stop.

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -7,11 +7,13 @@
 //! ## Architecture
 //! ```text
 //! Supervisor ─► bus.publish(TaskAddRequested) ─► Bus (observability, fire-and-forget)
-//!            ─► cmd_tx.send(Add(spec)) ────────► Registry.spawn_listener()
-//!                                                   ├─► Add(spec)            ─► spawn_and_register
-//!                                                   ├─► Remove(name)         ─► cancel_and_remove
-//!                                                   ├─► ActorExhausted(name) ─► cleanup_task
-//!                                                   └─► ActorDead(name)      ─► cleanup_task
+//!            ─► cmd_tx.send(Add(id, spec)) ────► Registry.spawn_listener()
+//!                                                   ├─► Add(id, spec)      ─► spawn_and_register
+//!                                                   ├─► Remove(id)         ─► cancel_and_remove
+//!                                                   ├─► ActorExhausted(id) ─► cleanup_task
+//!                                                   └─► ActorDead(id)      ─► cleanup_task
+//!
+//! Tasks are keyed by the runtime [`TaskId`] (identity); the task name is a human label.
 //! ```
 //!
 //! ## Rules
@@ -30,6 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::core::actor::{ActorExitReason, TaskActor, TaskActorParams};
 use crate::events::{Bus, Event, EventKind};
+use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
 /// Command sent via guaranteed-delivery channel (mpsc).
@@ -37,15 +40,25 @@ use crate::tasks::TaskSpec;
 /// Separated from the broadcast bus to ensure control commands are never lost to `Lagged`.
 /// The Supervisor publishes observability events on the bus before sending the command.
 pub(crate) enum RegistryCommand {
-    /// Add a new task. Supervisor publishes `TaskAddRequested` on bus before sending.
-    Add(TaskSpec),
-    /// Remove a task by name. Supervisor publishes `TaskRemoveRequested` on bus before sending.
-    Remove(Arc<str>),
+    /// Add a new task with its runtime identity.
+    Add(TaskId, TaskSpec),
+    /// Remove a task by its runtime identity. Supervisor publishes `TaskRemoveRequested` first.
+    Remove(TaskId),
 }
 
 struct Handle {
     join: JoinHandle<ActorExitReason>,
     cancel: CancellationToken,
+    label: Arc<str>,
+}
+
+/// Registry maps held under a single lock so identity and label stay consistent.
+#[derive(Default)]
+struct Inner {
+    /// Identity → handle (the canonical map; the [`TaskId`] is the key).
+    tasks: HashMap<TaskId, Handle>,
+    /// Label → identity (optional dedup gate + label-addressed cancel/remove).
+    by_label: HashMap<Arc<str>, TaskId>,
 }
 
 /// Event-driven registry of active task actors.
@@ -58,7 +71,7 @@ struct Handle {
 /// - [`TaskActor`](super::actor::TaskActor) - per-task supervisor spawned by this registry
 /// - [`Bus`](crate::events::Bus) - delivers actor terminal events for cleanup
 pub(crate) struct Registry {
-    tasks: RwLock<HashMap<Arc<str>, Handle>>,
+    state: RwLock<Inner>,
     bus: Bus,
     runtime_token: CancellationToken,
     semaphore: Option<Arc<Semaphore>>,
@@ -75,7 +88,7 @@ impl Registry {
         cmd_rx: mpsc::UnboundedReceiver<RegistryCommand>,
     ) -> Arc<Self> {
         Arc::new(Self {
-            tasks: RwLock::new(HashMap::new()),
+            state: RwLock::new(Inner::default()),
             bus,
             runtime_token,
             semaphore,
@@ -131,11 +144,11 @@ impl Registry {
                     _ = rt.cancelled() => break,
 
                     cmd = cmd_rx.recv() => match cmd {
-                        Some(RegistryCommand::Add(spec)) => {
-                            me.spawn_and_register(spec).await;
+                        Some(RegistryCommand::Add(id, spec)) => {
+                            me.spawn_and_register(id, spec).await;
                         }
-                        Some(RegistryCommand::Remove(name)) => {
-                            me.remove_task(&name).await;
+                        Some(RegistryCommand::Remove(id)) => {
+                            me.remove_task(id).await;
                         }
                         None => break,
                     },
@@ -165,30 +178,39 @@ impl Registry {
     async fn handle_bus_event(&self, event: &Event) {
         match event.kind {
             EventKind::ActorExhausted | EventKind::ActorDead => {
-                if let Some(name) = &event.task {
-                    self.cleanup_task(name).await;
+                if let Some(id) = event.id {
+                    self.cleanup_task(id).await;
                 }
             }
             _ => {}
         }
     }
 
-    /// Returns sorted list of active task names.
-    pub async fn list(&self) -> Vec<Arc<str>> {
-        let tasks = self.tasks.read().await;
-        let mut names: Vec<Arc<str>> = tasks.keys().cloned().collect();
-        names.sort_unstable();
-        names
+    /// Returns active tasks as `(id, label)` pairs, sorted by identity.
+    pub async fn list(&self) -> Vec<(TaskId, Arc<str>)> {
+        let st = self.state.read().await;
+        let mut v: Vec<(TaskId, Arc<str>)> = st
+            .tasks
+            .iter()
+            .map(|(id, h)| (*id, h.label.clone()))
+            .collect();
+        v.sort_by_key(|(id, _)| *id);
+        v
     }
 
-    /// Returns `true` if the registry contains a task with the given name.
-    pub async fn contains(&self, name: &str) -> bool {
-        self.tasks.read().await.contains_key(name)
+    /// Returns `true` if a task with the given identity is registered.
+    pub async fn contains(&self, id: TaskId) -> bool {
+        self.state.read().await.tasks.contains_key(&id)
+    }
+
+    /// Resolves a label to the identity currently holding it (if any).
+    pub async fn id_for_label(&self, name: &str) -> Option<TaskId> {
+        self.state.read().await.by_label.get(name).copied()
     }
 
     /// Returns `true` if registry is empty.
     pub async fn is_empty(&self) -> bool {
-        self.tasks.read().await.is_empty()
+        self.state.read().await.tasks.is_empty()
     }
 
     /// Cancels all tasks, waits up to `grace` for cooperative exit, then force-aborts stragglers.
@@ -200,9 +222,10 @@ impl Registry {
     ///
     /// Always publishes `TaskRemoved` for every task (and `ActorDead` on panic).
     pub async fn cancel_all_within(&self, grace: Duration) -> Vec<Arc<str>> {
-        let handles: Vec<(Arc<str>, Handle)> = {
-            let mut tasks = self.tasks.write().await;
-            let drained = tasks.drain().collect::<Vec<_>>();
+        let handles: Vec<(TaskId, Handle)> = {
+            let mut st = self.state.write().await;
+            st.by_label.clear();
+            let drained = st.tasks.drain().collect::<Vec<_>>();
             self.empty_notify.notify_waiters();
             drained
         };
@@ -213,35 +236,38 @@ impl Registry {
         let deadline = tokio::time::Instant::now() + grace;
         let mut stuck = Vec::new();
 
-        for (name, h) in handles {
+        for (id, h) in handles {
+            let label = h.label.clone();
             let mut join = h.join;
             match tokio::time::timeout_at(deadline, &mut join).await {
-                Ok(res) => Self::report_join(&self.bus, &name, res),
+                Ok(res) => Self::report_join(&self.bus, id, &label, res),
                 Err(_elapsed) => {
                     join.abort();
                     let _ = join.await;
                     self.bus.publish(
                         Event::new(EventKind::TaskRemoved)
-                            .with_task(Arc::clone(&name))
+                            .with_task(Arc::clone(&label))
+                            .with_id(id)
                             .with_reason("force_terminated_after_grace"),
                     );
-                    stuck.push(name);
+                    stuck.push(label);
                 }
             }
         }
         stuck
     }
 
-    /// Spawns an actor and registers its handle.
-    async fn spawn_and_register(&self, spec: TaskSpec) {
-        let task_name: Arc<str> = Arc::from(spec.task().name());
+    /// Spawns an actor and registers its handle under the given runtime identity.
+    async fn spawn_and_register(&self, id: TaskId, spec: TaskSpec) {
+        let label: Arc<str> = Arc::from(spec.task().name());
 
-        let mut tasks = self.tasks.write().await;
-        if tasks.contains_key(&*task_name) {
-            drop(tasks);
+        let mut st = self.state.write().await;
+        if st.by_label.contains_key(&label) {
+            drop(st);
             self.bus.publish(
                 Event::new(EventKind::TaskAddFailed)
-                    .with_task(task_name)
+                    .with_task(label)
+                    .with_id(id)
                     .with_reason("already_exists"),
             );
             return;
@@ -259,92 +285,105 @@ impl Registry {
                 max_retries: spec.max_retries(),
             },
             self.semaphore.clone(),
+            id,
         );
 
         let task_token_clone = task_token.clone();
         let join_handle = tokio::spawn(async move { actor.run(task_token_clone).await });
 
-        let handle = Handle {
-            join: join_handle,
-            cancel: task_token,
-        };
+        st.tasks.insert(
+            id,
+            Handle {
+                join: join_handle,
+                cancel: task_token,
+                label: label.clone(),
+            },
+        );
+        st.by_label.insert(label.clone(), id);
+        drop(st);
 
-        tasks.insert(task_name.clone(), handle);
-        drop(tasks);
-
-        self.bus
-            .publish(Event::new(EventKind::TaskAdded).with_task(task_name));
+        self.bus.publish(
+            Event::new(EventKind::TaskAdded)
+                .with_task(label)
+                .with_id(id),
+        );
     }
 
-    /// Removes a task.
-    async fn remove_task(&self, name: &str) {
-        if let Some((handle, len_after)) = self.take_handle_with_len(name).await {
+    /// Removes a task by identity.
+    async fn remove_task(&self, id: TaskId) {
+        if let Some((handle, len_after)) = self.take_handle(id).await {
             self.notify_after_remove(len_after);
 
             handle.cancel.cancel();
-            self.spawn_join_report(Arc::from(name), handle.join);
+            self.spawn_join_report(id, handle.label, handle.join);
         } else {
             self.bus.publish(
                 Event::new(EventKind::TaskRemoved)
-                    .with_task(name)
+                    .with_id(id)
                     .with_reason("task_not_found"),
             );
         }
     }
 
-    /// Cleanup finished task.
-    async fn cleanup_task(&self, name: &str) {
-        if let Some((handle, len_after)) = self.take_handle_with_len(name).await {
+    /// Cleanup finished task by identity.
+    async fn cleanup_task(&self, id: TaskId) {
+        if let Some((handle, len_after)) = self.take_handle(id).await {
             self.notify_after_remove(len_after);
-            self.spawn_join_report(Arc::from(name), handle.join);
+            self.spawn_join_report(id, handle.label, handle.join);
         }
     }
 
-    /// Atomically remove handle from registry and return it with the new length.
-    async fn take_handle_with_len(&self, name: &str) -> Option<(Handle, usize)> {
-        let mut tasks = self.tasks.write().await;
-        let h = tasks.remove(name)?;
-        let len_after = tasks.len();
+    /// Atomically remove a handle by identity (and its label-index entry), returning it with the new task count.
+    async fn take_handle(&self, id: TaskId) -> Option<(Handle, usize)> {
+        let mut st = self.state.write().await;
+        let h = st.tasks.remove(&id)?;
+        st.by_label.remove(&h.label);
+        let len_after = st.tasks.len();
         Some((h, len_after))
     }
 
     /// Joins the actor handle in a detached task and reports its terminal events.
-    fn spawn_join_report(&self, name: Arc<str>, join: JoinHandle<ActorExitReason>) {
+    fn spawn_join_report(&self, id: TaskId, name: Arc<str>, join: JoinHandle<ActorExitReason>) {
         let bus = self.bus.clone();
         tokio::spawn(async move {
             let res = join.await;
-            Self::report_join(&bus, &name, res);
+            Self::report_join(&bus, id, &name, res);
         });
     }
 
     /// Removes and reports any actors whose task has already finished.
     async fn reap_finished(&self) {
-        let finished: Vec<Arc<str>> = {
-            let tasks = self.tasks.read().await;
-            tasks
+        let finished: Vec<TaskId> = {
+            let st = self.state.read().await;
+            st.tasks
                 .iter()
                 .filter(|(_, h)| h.join.is_finished())
-                .map(|(name, _)| name.clone())
+                .map(|(id, _)| *id)
                 .collect()
         };
-        for name in finished {
-            self.cleanup_task(&name).await;
+        for id in finished {
+            self.cleanup_task(id).await;
         }
     }
 
     /// Publish terminal events for a joined actor: `ActorDead` if it panicked, then always `TaskRemoved`.
     /// A cancelled (force-aborted) join is not a panic.
-    fn report_join(bus: &Bus, name: &str, res: Result<ActorExitReason, JoinError>) {
+    fn report_join(bus: &Bus, id: TaskId, name: &str, res: Result<ActorExitReason, JoinError>) {
         if let Err(e) = res
             && e.is_panic()
         {
             bus.publish(
                 Event::new(EventKind::ActorDead)
                     .with_task(name)
+                    .with_id(id)
                     .with_reason("actor_panic"),
             );
         }
-        bus.publish(Event::new(EventKind::TaskRemoved).with_task(name));
+        bus.publish(
+            Event::new(EventKind::TaskRemoved)
+                .with_task(name)
+                .with_id(id),
+        );
     }
 }
 
@@ -367,11 +406,12 @@ mod tests {
         while !join.is_finished() {
             tokio::task::yield_now().await;
         }
-        reg.tasks.write().await.insert(
-            Arc::from("done"),
+        reg.state.write().await.tasks.insert(
+            TaskId::next(),
             Handle {
                 join,
                 cancel: CancellationToken::new(),
+                label: Arc::from("done"),
             },
         );
         assert!(!reg.is_empty().await);
@@ -393,10 +433,14 @@ mod tests {
             child.cancelled().await;
             ActorExitReason::Cancelled
         });
-        reg.tasks
-            .write()
-            .await
-            .insert(Arc::from("running"), Handle { join, cancel });
+        reg.state.write().await.tasks.insert(
+            TaskId::next(),
+            Handle {
+                join,
+                cancel,
+                label: Arc::from("running"),
+            },
+        );
 
         reg.reap_finished().await;
         assert!(!reg.is_empty().await, "a running actor must not be reaped");

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -38,6 +38,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     error::TaskError,
     events::{Bus, Event, EventKind},
+    identity::TaskId,
     tasks::Task,
 };
 
@@ -79,6 +80,7 @@ pub async fn run_once<T: Task + ?Sized>(
     parent: &CancellationToken,
     timeout: Option<Duration>,
     attempt: u32,
+    id: TaskId,
     bus: &Bus,
 ) -> Result<(), TaskError> {
     let child = parent.child_token();
@@ -88,7 +90,7 @@ pub async fn run_once<T: Task + ?Sized>(
             Ok(r) => r,
             Err(_elapsed) => {
                 child.cancel();
-                publish_timeout(bus, task.name(), dur, attempt);
+                publish_timeout(bus, id, task.name(), dur, attempt);
                 Err(TaskError::Timeout { timeout: dur })
             }
         }
@@ -98,29 +100,34 @@ pub async fn run_once<T: Task + ?Sized>(
 
     match res {
         Ok(()) => {
-            publish_stopped(bus, task.name());
+            publish_stopped(bus, id, task.name());
             Ok(())
         }
         Err(TaskError::Canceled) => {
-            publish_stopped(bus, task.name());
+            publish_stopped(bus, id, task.name());
             Err(TaskError::Canceled)
         }
         Err(e) => {
-            publish_failed(bus, task.name(), attempt, &e);
+            publish_failed(bus, id, task.name(), attempt, &e);
             Err(e)
         }
     }
 }
 
 /// Publishes `TaskStopped` event (success or graceful cancellation).
-fn publish_stopped(bus: &Bus, name: &str) {
-    bus.publish(Event::new(EventKind::TaskStopped).with_task(name));
+fn publish_stopped(bus: &Bus, id: TaskId, name: &str) {
+    bus.publish(
+        Event::new(EventKind::TaskStopped)
+            .with_task(name)
+            .with_id(id),
+    );
 }
 
 /// Publishes `TaskFailed` event with error details.
-fn publish_failed(bus: &Bus, name: &str, attempt: u32, err: &TaskError) {
+fn publish_failed(bus: &Bus, id: TaskId, name: &str, attempt: u32, err: &TaskError) {
     let mut ev = Event::new(EventKind::TaskFailed)
         .with_task(name)
+        .with_id(id)
         .with_attempt(attempt)
         .with_reason(err.to_string());
     if let Some(code) = err.exit_code() {
@@ -130,10 +137,11 @@ fn publish_failed(bus: &Bus, name: &str, attempt: u32, err: &TaskError) {
 }
 
 /// Publishes `TimeoutHit` event (always followed by `TaskFailed`).
-fn publish_timeout(bus: &Bus, name: &str, dur: Duration, attempt: u32) {
+fn publish_timeout(bus: &Bus, id: TaskId, name: &str, dur: Duration, attempt: u32) {
     bus.publish(
         Event::new(EventKind::TimeoutHit)
             .with_task(name)
+            .with_id(id)
             .with_timeout(dur)
             .with_attempt(attempt),
     );
@@ -197,7 +205,7 @@ mod tests {
         let parent = CancellationToken::new();
         let timeout = Some(Duration::from_millis(50));
 
-        let result = run_once(&SlowTask, &parent, timeout, 1, &bus).await;
+        let result = run_once(&SlowTask, &parent, timeout, 1, TaskId::next(), &bus).await;
 
         match result {
             Err(TaskError::Timeout { timeout: dur }) => {
@@ -217,7 +225,7 @@ mod tests {
         let bus = Bus::new(16);
         let parent = CancellationToken::new();
 
-        let result = run_once(&OkTask, &parent, None, 1, &bus).await;
+        let result = run_once(&OkTask, &parent, None, 1, TaskId::next(), &bus).await;
         assert!(result.is_ok());
     }
 
@@ -226,7 +234,7 @@ mod tests {
         let bus = Bus::new(16);
         let parent = CancellationToken::new();
 
-        let result = run_once(&FailTask, &parent, None, 1, &bus).await;
+        let result = run_once(&FailTask, &parent, None, 1, TaskId::next(), &bus).await;
 
         assert!(
             matches!(result, Err(TaskError::Fail { .. })),
@@ -240,7 +248,15 @@ mod tests {
         let mut rx = bus.subscribe();
         let parent = CancellationToken::new();
 
-        let _ = run_once(&SlowTask, &parent, Some(Duration::from_millis(50)), 1, &bus).await;
+        let _ = run_once(
+            &SlowTask,
+            &parent,
+            Some(Duration::from_millis(50)),
+            1,
+            TaskId::next(),
+            &bus,
+        )
+        .await;
 
         let mut saw_timeout_hit = false;
         while let Ok(ev) = rx.try_recv() {

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -116,6 +116,7 @@ use crate::{
     core::SupervisorConfig,
     error::RuntimeError,
     events::{Bus, Event, EventKind},
+    identity::TaskId,
     subscribers::{Subscribe, SubscriberSet},
     tasks::TaskSpec,
 };
@@ -235,38 +236,48 @@ impl Supervisor {
         super::handle::SupervisorHandle::new(Arc::clone(self))
     }
 
-    /// Adds a new task to the supervisor at runtime.
+    /// Adds a new task to the supervisor at runtime, returning its minted [`TaskId`].
     ///
-    /// Publishes `TaskAddRequested` on bus (observability, fire-and-forget),
-    /// then sends `Add` command via mpsc (guaranteed delivery).
-    pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<(), RuntimeError> {
-        self.bus
-            .publish(Event::new(EventKind::TaskAddRequested).with_task(spec.task().name()));
+    /// Mints the runtime identity, publishes `TaskAddRequested` on bus (observability, fire-and-forget),
+    /// then sends the `Add` command via mpsc (guaranteed delivery).
+    pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        let id = TaskId::next();
+        self.bus.publish(
+            Event::new(EventKind::TaskAddRequested)
+                .with_task(spec.task().name())
+                .with_id(id),
+        );
         self.cmd_tx
-            .send(RegistryCommand::Add(spec))
-            .map_err(|_| RuntimeError::ShuttingDown)
+            .send(RegistryCommand::Add(id, spec))
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        Ok(id)
     }
 
-    /// Removes a task from the supervisor at runtime.
+    /// Removes a task from the supervisor at runtime, by its runtime identity.
     ///
     /// Publishes `TaskRemoveRequested` on bus (observability, fire-and-forget),
-    /// then sends `Remove` command via mpsc (guaranteed delivery).
-    pub(crate) fn remove_task(&self, name: &str) -> Result<(), RuntimeError> {
+    /// then sends the `Remove` command via mpsc (guaranteed delivery).
+    pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
         self.bus
-            .publish(Event::new(EventKind::TaskRemoveRequested).with_task(name));
+            .publish(Event::new(EventKind::TaskRemoveRequested).with_id(id));
         self.cmd_tx
-            .send(RegistryCommand::Remove(Arc::from(name)))
+            .send(RegistryCommand::Remove(id))
             .map_err(|_| RuntimeError::ShuttingDown)
     }
 
-    /// Returns a sorted list of currently active task names from the registry.
-    pub(crate) async fn list_tasks(&self) -> Vec<Arc<str>> {
+    /// Returns currently active tasks as `(id, label)` pairs from the registry.
+    pub(crate) async fn list_tasks(&self) -> Vec<(TaskId, Arc<str>)> {
         self.registry.list().await
     }
 
-    /// Checks if a task exists in the registry by name.
-    pub(crate) async fn registry_contains(&self, name: &str) -> bool {
-        self.registry.contains(name).await
+    /// Checks if a task with the given identity is registered.
+    pub(crate) async fn contains_id(&self, id: TaskId) -> bool {
+        self.registry.contains(id).await
+    }
+
+    /// Resolves a label to the identity currently holding it (if any).
+    pub(crate) async fn id_for_label(&self, name: &str) -> Option<TaskId> {
+        self.registry.id_for_label(name).await
     }
 
     /// Returns a new bus receiver for event subscription.
@@ -300,12 +311,12 @@ impl Supervisor {
         self.start();
 
         if !tasks.is_empty() {
-            let names: Vec<Arc<str>> = tasks.iter().map(|s| Arc::from(s.task().name())).collect();
             let mut rx = self.bus.subscribe();
+            let mut pending_ids = Vec::with_capacity(tasks.len());
             for spec in tasks {
-                self.add_task(spec)?;
+                pending_ids.push(self.add_task(spec)?);
             }
-            self.wait_tasks_registered(&mut rx, &names).await;
+            self.wait_tasks_registered(&mut rx, &pending_ids).await;
         }
         self.drive_shutdown().await
     }
@@ -314,9 +325,9 @@ impl Supervisor {
     async fn wait_tasks_registered(
         &self,
         rx: &mut broadcast::Receiver<Arc<Event>>,
-        names: &[Arc<str>],
+        ids: &[TaskId],
     ) {
-        let mut pending: Vec<Arc<str>> = names.to_vec();
+        let mut pending: Vec<TaskId> = ids.to_vec();
 
         let confirm = async {
             while !pending.is_empty() {
@@ -324,16 +335,16 @@ impl Supervisor {
                     Ok(ev)
                         if matches!(ev.kind, EventKind::TaskAdded | EventKind::TaskAddFailed) =>
                     {
-                        if let Some(name) = ev.task.as_deref() {
-                            pending.retain(|p| &**p != name);
+                        if let Some(id) = ev.id {
+                            pending.retain(|p| *p != id);
                         }
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(_)) => {
                         let mut still = Vec::new();
-                        for p in std::mem::take(&mut pending) {
-                            if !self.registry.contains(&p).await {
-                                still.push(p);
+                        for id in std::mem::take(&mut pending) {
+                            if !self.registry.contains(id).await {
+                                still.push(id);
                             }
                         }
                         pending = still;
@@ -368,31 +379,31 @@ impl Supervisor {
         self.alive.is_alive(name).await
     }
 
-    /// Cancel a task by name and wait for confirmation (`TaskRemoved`).
-    pub(crate) async fn cancel(&self, name: &str) -> Result<bool, RuntimeError> {
-        self.cancel_with_timeout(name, self.cfg.grace).await
+    /// Cancel a task by identity and wait for confirmation (`TaskRemoved`).
+    pub(crate) async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        self.cancel_with_timeout(id, self.cfg.grace).await
     }
 
     /// Cancel with explicit timeout.
     pub(crate) async fn cancel_with_timeout(
         &self,
-        name: &str,
+        id: TaskId,
         wait_for: Duration,
     ) -> Result<bool, RuntimeError> {
         let mut rx = self.bus.subscribe();
-        if !self.registry.contains(name).await {
+        if !self.registry.contains(id).await {
             return Ok(false);
         }
 
         self.bus.publish(
             Event::new(EventKind::TaskRemoveRequested)
-                .with_task(name)
+                .with_id(id)
                 .with_reason("manual_cancel"),
         );
         self.cmd_tx
-            .send(RegistryCommand::Remove(Arc::from(name)))
+            .send(RegistryCommand::Remove(id))
             .map_err(|_| RuntimeError::ShuttingDown)?;
-        self.wait_task_removed(&mut rx, name, wait_for).await
+        self.wait_task_removed(&mut rx, id, wait_for).await
     }
 
     /// Submits a task to the controller (if enabled).
@@ -486,36 +497,31 @@ impl Supervisor {
         }
     }
 
-    /// Waits for `TaskRemoved` event for the given task name, with timeout.
+    /// Waits for the `TaskRemoved` event for the given identity, with timeout.
     ///
     /// On `Lagged`, falls back to checking the registry directly.
     /// On `Closed`, checks registry as a last resort.
-    /// On timeout, re-checks the registry so a missed `TaskRemoved` is not reported as a spurious timeout.
+    /// On timeout, re-checks the registry so a missed `TaskRemoved` is not a spurious timeout.
     async fn wait_task_removed(
         &self,
         rx: &mut broadcast::Receiver<Arc<Event>>,
-        name: &str,
+        id: TaskId,
         wait_for: Duration,
     ) -> Result<bool, RuntimeError> {
-        let target: Arc<str> = Arc::from(name);
-
         let wait_for_event = async {
             loop {
                 match rx.recv().await {
-                    Ok(ev)
-                        if matches!(ev.kind, EventKind::TaskRemoved)
-                            && ev.task.as_deref() == Some(&*target) =>
-                    {
+                    Ok(ev) if matches!(ev.kind, EventKind::TaskRemoved) && ev.id == Some(id) => {
                         return Ok(true);
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if !self.registry.contains(&target).await {
+                        if !self.registry.contains(id).await {
                             return Ok(true);
                         }
                     }
                     Err(broadcast::error::RecvError::Closed) => {
-                        return Ok(!self.registry.contains(&target).await);
+                        return Ok(!self.registry.contains(id).await);
                     }
                 }
             }
@@ -524,9 +530,9 @@ impl Supervisor {
         match timeout(wait_for, wait_for_event).await {
             Ok(result) => result,
             Err(_) => {
-                if self.registry.contains(&target).await {
+                if self.registry.contains(id).await {
                     Err(RuntimeError::TaskRemoveTimeout {
-                        name: target,
+                        id,
                         timeout: wait_for,
                     })
                 } else {
@@ -638,18 +644,18 @@ mod tests {
             ctx.cancelled().await;
             Ok(())
         });
-        handle
+        let id = handle
             .add_and_wait(TaskSpec::restartable(t), Duration::from_secs(1))
             .await
             .expect("add should succeed");
 
-        let removed = handle.cancel("c").await.expect("cancel should not error");
+        let removed = handle.cancel(id).await.expect("cancel should not error");
         assert!(
             removed,
             "cancelling an existing task should report removed=true"
         );
 
-        let absent = handle.cancel("c").await.expect("cancel should not error");
+        let absent = handle.cancel(id).await.expect("cancel should not error");
         assert!(!absent, "cancelling a missing task should report false");
 
         let _ = handle.shutdown().await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+use crate::identity::TaskId;
+
 /// # Errors produced by the taskvisor runtime.
 ///
 /// These represent failures in the orchestration system itself.
@@ -41,10 +43,10 @@ pub enum RuntimeError {
         name: Arc<str>,
     },
     /// Timeout waiting for task removal confirmation.
-    #[error("timeout waiting for task '{name}' removal after {timeout:?}")]
+    #[error("timeout waiting for task {id} removal after {timeout:?}")]
     TaskRemoveTimeout {
-        /// The task name that timed out during removal.
-        name: Arc<str>,
+        /// The runtime identity that timed out during removal.
+        id: TaskId,
         /// How long we waited before giving up.
         timeout: Duration,
     },

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -33,6 +33,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::time::{Duration, SystemTime};
 
+use crate::identity::TaskId;
+
 /// Global sequence counter for event ordering.
 static EVENT_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -266,8 +268,13 @@ pub struct Event {
     pub reason: Option<Arc<str>>,
     /// Attempt count (starting from 1).
     pub attempt: Option<u32>,
-    /// Name of the task, if applicable.
+    /// Name of the task, if applicable. A free-form human **label** (not an identity).
     pub task: Option<Arc<str>>,
+    /// Runtime identity of the task run instance this event belongs to, if applicable.
+    ///
+    /// This is the canonical correlation key: unlike [`task`](Self::task) (a human label
+    /// that may repeat), a [`TaskId`] is unique per run instance and never reused.
+    pub id: Option<TaskId>,
     /// Numeric exit code, from a process-like runtime.
     /// `None` for events that have no process behind them.
     pub exit_code: Option<i32>,
@@ -290,6 +297,7 @@ impl Event {
             attempt: None,
             reason: None,
             task: None,
+            id: None,
             exit_code: None,
         }
     }
@@ -305,6 +313,13 @@ impl Event {
     #[inline]
     pub fn with_task(mut self, task: impl Into<Arc<str>>) -> Self {
         self.task = Some(task.into());
+        self
+    }
+
+    /// Attaches the runtime task identity ([`TaskId`]).
+    #[inline]
+    pub fn with_id(mut self, id: TaskId) -> Self {
+        self.id = Some(id);
         self
     }
 
@@ -395,6 +410,9 @@ impl std::fmt::Debug for Event {
         let mut d = f.debug_struct("Event");
         d.field("seq", &self.seq);
         d.field("kind", &self.kind);
+        if let Some(id) = self.id {
+            d.field("id", &id);
+        }
         if let Some(ref task) = self.task {
             d.field("task", task);
         }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -235,8 +235,9 @@ pub enum EventKind {
 }
 
 /// Reason for scheduling the next run/backoff.
+///
+/// A closed set (success vs failure); intentionally **not** `#[non_exhaustive]`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum BackoffSource {
     Success,
     Failure,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,61 @@
+//! # Runtime task identity.
+//!
+//! [`TaskId`] is the **runtime identity** of a single task run instance, minted by the supervisor when a task is admitted.
+//!
+//! ## Identity vs. label vs. slot
+//!
+//! - [`TaskId`] - *identity*: unique per run instance, owned by the runtime (this crate), never reused.
+//!   Use it to correlate lifecycle [`Event`](crate::Event)s and to address a task for cancellation/removal.
+//! - **name** ([`Task::name`](crate::Task::name)) - *human label*: free-form, **not** required to be unique.
+//!   Used for logs, metrics, and external resource naming.
+//! - **slot** ([`TaskSpec::slot`](crate::TaskSpec::slot)) - *admission key*: the logical unit the controller admits one-at-a-time.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-global monotonic source of task identities (starts at 1; 0 is never minted).
+static TASK_ID_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Unique runtime identity of a single task run instance.
+///
+/// Minted by the supervisor at admission time and carried on every lifecycle [`Event`](crate::Event) for that run via [`Event::id`](crate::Event::id).
+/// Unlike the task **name** (a free-form human label), a `TaskId` is unique and never reused, it unambiguously correlates events even when names repeat or runs overlap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TaskId(u64);
+
+impl TaskId {
+    /// Mints the next unique identity. Internal: only the runtime assigns identities.
+    #[inline]
+    pub(crate) fn next() -> Self {
+        TaskId(TASK_ID_SEQ.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Returns the raw numeric value (for logging / external correlation).
+    #[inline]
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_are_unique_and_monotonic() {
+        let a = TaskId::next();
+        let b = TaskId::next();
+        assert!(b.get() > a.get(), "ids must increase: {a} then {b}");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn never_mints_zero() {
+        assert!(TaskId::next().get() >= 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,9 @@
 
 pub mod prelude;
 
+mod identity;
+pub use identity::TaskId;
+
 mod core;
 pub use core::{Supervisor, SupervisorConfig, SupervisorHandle};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,5 +24,8 @@ pub use crate::subscribers::Subscribe;
 // Errors
 pub use crate::error::{RuntimeError, TaskError};
 
+// Runtime task identity
+pub use crate::identity::TaskId;
+
 // Re-export CancellationToken — every task needs it.
 pub use tokio_util::sync::CancellationToken;


### PR DESCRIPTION
## 📝 Description
Replaces the overloaded task name with a dedicated runtime identity: TaskId(u64).

Previously, the task name simultaneously acted as:
- the registry key;
- the deduplication key;
- the controller slot correlation key;
- the lifecycle event correlation key.

Coupling these responsibilities to a single user-provided string created multiple correctness issues and made several controller edge cases difficult to reason about.

Changes:
- The registry is keyed by TaskId.
- A secondary by_label index is maintained for label-based lookups and optional deduplication.
- All lifecycle events now carry TaskId.
- The controller correlates slots using TaskId rather than labels.
- Controller state transitions are driven by observed lifecycle events, introducing an explicit Admitting state before TaskAdded.

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally

## NOTES:
- add() and add_and_wait() now return TaskId.
- cancel() and remove() operate on TaskId.
- *_by_label convenience methods are provided for label-addressed workflows.
- list() now returns (TaskId, label) pairs.
- TaskRemoveTimeout now carries TaskId.