### PR TITLE
[api] extend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "taskvisor"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 name              = "pipeline"
 required-features = ["controller"]
 
+[[example]]
+name              = "admission"
+required-features = ["controller"]
+
 [[bench]]
 name    = "lifecycle"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "taskvisor"
-version      = "0.2.1"
+version      = "0.3.0"
 edition      = "2024"
 rust-version = "1.90.0"
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ Every lifecycle change publishes an `Event` to the bus. Subscribe to observe the
 |--------------------------------------------|------------------------------------------------------|
 | **Lifecycle**                              |                                                      |
 | `TaskStarting`                             | Attempt is beginning                                 |
-| `TaskStopped`                              | Completed or cancelled gracefully                    |
+| `TaskStopped`                              | Attempt completed successfully                       |
+| `TaskCanceled`                             | Attempt exited via graceful cancellation             |
 | `TaskFailed`                               | Attempt failed (retryable or fatal)                  |
 | `TimeoutHit`                               | Attempt exceeded its timeout                         |
 | `BackoffScheduled`                         | Retry delay scheduled (includes delay duration)      |
@@ -407,7 +408,9 @@ let sup = Supervisor::builder(cfg)
 
 let handle = sup.serve();
 
-handle.submit(ControllerSpec::queue(spec)).await?;
+// submit() returns a pre-allocated TaskId immediately; 
+// the final admission result is reported asynchronously via ControllerSubmitted or ControllerRejected, both carrying the same TaskId.
+let id = handle.submit(ControllerSpec::queue(spec)).await?;
 handle.submit(ControllerSpec::replace(spec)).await?;
 handle.submit(ControllerSpec::drop_if_running(spec)).await?;
 

--- a/README.md
+++ b/README.md
@@ -34,20 +34,25 @@ Supervisor
 
 ## Why taskvisor?
 
-Tokio gives you `spawn` and `JoinHandle`, but no supervision: no restart policies, no backoff, and no events to tell you what happened.
-If a spawned task panics or fails, you only find out when you poll its `JoinHandle` - or never.
+taskvisor gives you a **supervised** handle instead: it restarts the task on failure with backoff, narrates every step through events, and hands you the task's final outcome.
 
-Taskvisor fills that gap:
+|     | Feature                   | What you get                                                                |
+|:---:|---------------------------|-----------------------------------------------------------------------------|
+| 🔁  | **Restart policies**      | `Never`, `OnFailure`, or `Always { interval }`: chosen per task             |
+|  ⏳  | **Backoff with jitter**   | Exponential, constant, or decorrelated; spreads retries out in time         |
+| 📡  | **Structured events**     | Every start, stop, failure, timeout, and backoff on a broadcast bus         |
+| 🔌  | **Pluggable subscribers** | Implement one method (`on_event`) for metrics, alerts, or logging           |
+| 🎯  | **Guaranteed outcomes**   | `await` a task's final `TaskOutcome`, even if events are dropped under load |
+| 🎛️ | **Dynamic management**    | Add, remove, cancel tasks at runtime via `SupervisorHandle`                 |
+| 🚦  | **Admission control**     | Optional slot controller: Queue / Replace / DropIfRunning                   |
+| 🚧  | **Concurrency limits**    | Global semaphore, per-task timeouts, max retries                            |
 
-|     | Feature                   | What you get                                                        |
-|:---:|---------------------------|---------------------------------------------------------------------|
-| 🔁  | **Restart policies**      | `Never`, `OnFailure`, or `Always { interval }`: chosen per task     |
-|  ⏳  | **Backoff with jitter**   | Exponential, constant, or decorrelated; spreads retries out in time |
-| 📡  | **Structured events**     | Every start, stop, failure, timeout, and backoff on a broadcast bus |
-| 🔌  | **Pluggable subscribers** | Implement one method (`on_event`) for metrics, alerts, or logging   |
-| 🎛️ | **Dynamic management**    | Add, remove, cancel tasks at runtime via `SupervisorHandle`         |
-| 🚦  | **Admission control**     | Optional slot controller: Queue / Replace / DropIfRunning           |
-| 🚧  | **Concurrency limits**    | Global semaphore, per-task timeouts, max retries                    |
+**What's distinctive:** most supervision crates stop at restart + backoff:
+
+- **Observability as a first-class plane** - a typed lifecycle event bus with pluggable subscribers, not a status field you poll.
+- **Guaranteed outcomes** - `add_and_watch` / `submit_and_watch` hand you a `TaskOutcome` for every task, on a channel that survives bus lag.
+- **Admission control** - slot policies (Queue / Replace / DropIfRunning) for "only one deploy at a time" or "debounce this", built in.
+- **Plain async fns, no `Clone` bound** - task state lives behind `&self` and survives restarts; you don't rebuild it on every retry.
 
 Taskvisor is not a replacement for tokio or tower. 
 It works at a higher level: you write the task, and taskvisor runs it, restarts it on failure with backoff, and tells you what happened through events.
@@ -55,9 +60,21 @@ It works at a higher level: you write the task, and taskvisor runs it, restarts 
 It is also not an actor framework: there are no addressable actors, mailboxes, or message passing.
 Taskvisor supervises **tasks** (plain async functions), not actors.
 
+## When to use taskvisor
+
+Reach for it when you have **resident background tasks** that must stay up for the life of the process - queue consumers, pollers, sync loops, connection keepers, periodic jobs - and you want them restarted on failure, observable through events, and manageable (add / remove / await) at runtime.
+
+**Not the right tool if:**
+
+| You want…                                  | Use instead                                                                                     |
+|--------------------------------------------|-------------------------------------------------------------------------------------------------|
+| To retry a single future                   | [backon](https://crates.io/crates/backon) / [tokio-retry](https://crates.io/crates/tokio-retry) |
+| Durable, distributed jobs with storage     | [apalis](https://crates.io/crates/apalis)                                                       |
+| The actor model (addresses, mailboxes)     | [ractor](https://crates.io/crates/ractor) / [kameo](https://crates.io/crates/kameo)             |
+| Structured subsystem shutdown, no restarts | [tokio-graceful-shutdown](https://crates.io/crates/tokio-graceful-shutdown)                     |
+
 > **Roadmap:** 
-> taskvisor is the supervision core of *Solti*, a larger task-orchestration toolkit in
-> development on top of it (subprocess execution, HTTP/gRPC API, metrics, dashboards). 
+> taskvisor is the supervision core of *Solti*, a larger task-orchestration toolkit in development on top of it (subprocess execution, HTTP/gRPC API, metrics, dashboards). 
 > 
 > Taskvisor stands on its own today: the rest is future work.
 
@@ -65,7 +82,7 @@ Taskvisor supervises **tasks** (plain async functions), not actors.
 
 ```toml
 [dependencies]
-taskvisor = "0.2"
+taskvisor = "0.3"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -328,6 +345,22 @@ let spec = TaskSpec::restartable(task)
     .with_restart(RestartPolicy::Always { interval: Some(Duration::from_secs(30)) });
 ```
 
+### Await a task's final result
+
+```rust,ignore
+// add_and_watch returns a TaskWaiter resolving to the final TaskOutcome.
+// Delivery is guaranteed (oneshot, not subject to event-bus lag).
+let (id, waiter) = handle
+    .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+    .await?;
+
+match waiter.wait().await? {
+    TaskOutcome::Completed => println!("{id} done"),
+    TaskOutcome::Failed { reason, .. } => eprintln!("{id} failed: {reason}"),
+    other => eprintln!("{id} ended with {other:?}"),
+}
+```
+
 ## Events
 
 Every lifecycle change publishes an `Event` to the bus. Subscribe to observe them.
@@ -414,6 +447,11 @@ let id = handle.submit(ControllerSpec::queue(spec)).await?;
 handle.submit(ControllerSpec::replace(spec)).await?;
 handle.submit(ControllerSpec::drop_if_running(spec)).await?;
 
+// ...or await the outcome directly. If the slot never admits it (busy, queue full,
+// superseded, removed, shutting down) the waiter resolves to TaskOutcome::Rejected.
+let (id, waiter) = handle.submit_and_watch(ControllerSpec::queue(spec)).await?;
+let outcome = waiter.wait().await?;
+
 handle.shutdown().await?;
 ```
 
@@ -440,18 +478,22 @@ cargo run --example periodic
 cargo run --example multiple
 cargo run --example metrics
 cargo run --example dynamic
+cargo run --example outcomes
 cargo run --example pipeline --features controller
+cargo run --example admission --features controller
 ```
 
-| Example                                   | What it shows                                                |
-|-------------------------------------------|--------------------------------------------------------------|
-| [basic.rs](examples/basic.rs)             | Minimal hello-world, one task runs once                      |
-| [worker.rs](examples/worker.rs)           | Long-running worker with graceful Ctrl+C shutdown            |
-| [periodic.rs](examples/periodic.rs)       | Cron-like periodic task via `RestartPolicy::Always`          |
-| [multiple.rs](examples/multiple.rs)       | Three tasks with different policies and backoff              |
-| [metrics.rs](examples/metrics.rs)         | Custom `Subscribe` implementation for metrics                |
-| [dynamic.rs](examples/dynamic.rs)         | `serve()` + `SupervisorHandle`: add/remove/cancel at runtime |
-| [pipeline.rs](examples/pipeline.rs)       | Controller admission policies: Queue, Replace, DropIfRunning |
+| Example                                   | What it shows                                                  |
+|-------------------------------------------|----------------------------------------------------------------|
+| [basic.rs](examples/basic.rs)             | Minimal hello-world, one task runs once                        |
+| [worker.rs](examples/worker.rs)           | Long-running worker with graceful Ctrl+C shutdown              |
+| [periodic.rs](examples/periodic.rs)       | Cron-like periodic task via `RestartPolicy::Always`            |
+| [multiple.rs](examples/multiple.rs)       | Three tasks with different policies and backoff                |
+| [metrics.rs](examples/metrics.rs)         | Custom `Subscribe` implementation for metrics                  |
+| [dynamic.rs](examples/dynamic.rs)         | `serve()` + `SupervisorHandle`: add/remove/cancel at runtime   |
+| [outcomes.rs](examples/outcomes.rs)       | `add_and_watch`: await a task's final `TaskOutcome`            |
+| [pipeline.rs](examples/pipeline.rs)       | Controller admission policies: Queue, Replace, DropIfRunning   |
+| [admission.rs](examples/admission.rs)     | `submit_and_watch`: await admission outcome (incl. `Rejected`) |
 
 ## Optional features
 
@@ -461,7 +503,7 @@ cargo run --example pipeline --features controller
 | `logging`    | Built-in `LogWriter` subscriber - event output to stdout (demo/reference)             |
 
 ```toml
-taskvisor = { version = "0.2", features = ["controller", "logging"] }
+taskvisor = { version = "0.3", features = ["controller", "logging"] }
 ```
 
 ## Contributing

--- a/examples/admission.rs
+++ b/examples/admission.rs
@@ -1,0 +1,119 @@
+//! # Admission
+//!
+//! Awaits the outcome of a **controller** submission with `submit_and_watch`.
+//!
+//! This is the slot-based counterpart of [`outcomes.rs`](outcomes.rs)'s `add_and_watch`:
+//! the controller decides whether to admit, queue, or reject each submission, and the returned `TaskWaiter` resolves to the final [`TaskOutcome`] either way.
+//!
+//! ## The key distinction: admitted vs. rejected
+//!
+//! `handle.submit(spec)` is fire-and-forget: `Ok(id)` means *enqueued*, not *admitted*.
+//! The admission decision is asynchronous. `submit_and_watch` lets you await the result:
+//!
+//! - If the slot **admits** the task, the waiter resolves to its real terminal outcome (`Completed`, `Failed`, `Canceled`, ...) once it has run.
+//! - If the slot **never admits** it - busy under `DropIfRunning`, queue full, superseded by a later `Replace`, removed while queued, or shutting down
+//!   The waiter resolves to [`TaskOutcome::Rejected`], carrying the reason. The task body never ran.
+//!
+//! This closes a real gap: with plain `submit`, a rejected submission is only visible as a `ControllerRejected` event on the lossy bus.
+//! With `submit_and_watch` the rejection is a guaranteed, awaitable result.
+//!
+//! ## What this shows
+//!
+//! - `handle.submit_and_watch(ControllerSpec::...)`: submit and get `(TaskId, TaskWaiter)`.
+//! - An **admitted** `Queue` job resolving to `Completed`.
+//! - A **rejected** `DropIfRunning` job (slot busy) resolving to `Rejected { reason }`.
+//!
+//! ## Enabling the feature
+//!
+//! ```toml
+//! [dependencies]
+//! taskvisor = { version = "...", features = ["controller"] }
+//! ```
+//!
+//! ## Runtime flavor
+//!
+//! We use `current_thread` here because a single-threaded runtime is enough for examples and tests.
+//!
+//! *It can be used with `#[tokio::main]` (defaults to multi-thread): taskvisor works with both.*
+//!
+//! ## Run
+//!
+//! ```bash
+//! cargo run --example admission --features controller
+//! ```
+//!
+//! ## Next
+//!
+//! | Example                      | What it adds                                   |
+//! |------------------------------|------------------------------------------------|
+//! | [`pipeline.rs`](pipeline.rs) | All three admission policies, side by side     |
+//! | [`outcomes.rs`](outcomes.rs) | The direct-path waiter (`add_and_watch`)       |
+
+#[cfg(not(feature = "controller"))]
+compile_error!(
+    "This example requires the `controller` feature: cargo run --example admission --features controller"
+);
+
+use std::time::Duration;
+
+use taskvisor::ControllerSpec;
+use taskvisor::prelude::*;
+
+/// A job that runs for `dur`, observing cancellation.
+fn job(name: &'static str, dur: Duration) -> TaskSpec {
+    let task: TaskRef = TaskFn::arc(name, move |ctx: CancellationToken| async move {
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => Ok(()),
+            _ = ctx.cancelled() => Err(TaskError::Canceled),
+        }
+    });
+    // Same slot "deploy" for every submission, so they contend for one slot.
+    TaskSpec::once(task).with_slot("deploy")
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sup = Supervisor::builder(SupervisorConfig::default())
+        .with_controller(taskvisor::ControllerConfig::default())
+        .build();
+    let handle = sup.serve();
+
+    println!("Slot 'deploy' admits at most one task at a time.\n");
+
+    // 1) The slot is idle: this submission is admitted and starts running.
+    println!("1) submit deploy-v1 (Queue) to the idle slot");
+    let (_id, v1) = handle
+        .submit_and_watch(ControllerSpec::queue(job(
+            "deploy-v1",
+            Duration::from_millis(200),
+        )))
+        .await?;
+    // Give it a moment to actually occupy the slot.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    println!("    deploy-v1 admitted, now running\n");
+
+    // 2) While deploy-v1 holds the slot, a DropIfRunning submission is refused.
+    //     submit() would only fire a ControllerRejected event on the lossy bus;
+    //     submit_and_watch() lets us *await* the rejection as a guaranteed result.
+    println!("2) submit deploy-v2 (DropIfRunning) while the slot is busy");
+    let (_id, v2) = handle
+        .submit_and_watch(ControllerSpec::drop_if_running(job(
+            "deploy-v2",
+            Duration::from_millis(200),
+        )))
+        .await?;
+    match v2.wait().await? {
+        TaskOutcome::Rejected { reason } => {
+            println!("    deploy-v2 -> Rejected ({reason}) — never ran\n");
+        }
+        other => println!("    deploy-v2 -> {other:?} (unexpected)\n"),
+    }
+
+    // 3) The admitted task still finishes normally.
+    println!("3) await the admitted task");
+    println!("    deploy-v1 -> {:?}", v1.wait().await?);
+
+    handle.shutdown().await?;
+    println!("\nDone.");
+    Ok(())
+}

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -65,6 +65,7 @@
 //!
 //! | Example                      | What it adds                                    |
 //! |------------------------------|-------------------------------------------------|
+//! | [`outcomes.rs`](outcomes.rs) | Await a task's final result with `add_and_watch` |
 //! | [`pipeline.rs`](pipeline.rs) | Admission control with the `controller` feature |
 
 use std::time::Duration;

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -113,13 +113,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::time::sleep(Duration::from_millis(50)).await;
 
             if n <= 3 {
-                println!("[flaky-job] attempt #{n} — fail");
+                println!("[flaky-job] attempt #{n}: fail");
                 Err(TaskError::Fail {
                     reason: format!("attempt #{n}"),
                     exit_code: None,
                 })
             } else {
-                println!("[flaky-job] attempt #{n} — success!");
+                println!("[flaky-job] attempt #{n}: success!");
                 Ok(())
             }
         }

--- a/examples/outcomes.rs
+++ b/examples/outcomes.rs
@@ -1,0 +1,133 @@
+//! # Outcomes
+//!
+//! Awaits the **final result** of a supervised task with `add_and_watch` + `TaskWaiter`.
+//!
+//! This is the supervised analogue of awaiting a `tokio::JoinHandle`:
+//! you get back a single, guaranteed `TaskOutcome` once the task has *fully* terminated - after every retry the restart policy allows.
+//!
+//! ## Two planes, one truth
+//!
+//! Taskvisor reports task progress on **two** channels:
+//!
+//! | Plane                          | Delivery                          | Granularity                       |
+//! |--------------------------------|-----------------------------------|-----------------------------------|
+//! | Events (`Subscribe`)           | Lossy broadcast bus (may drop)    | Every attempt: start/fail/backoff |
+//! | Outcome (`add_and_watch`)      | Guaranteed `oneshot` (never lost) | One terminal result per task      |
+//!
+//! Use **events** for live progress, metrics, and logging.
+//! Use the **outcome** when you just need to know how a task ended.
+//!
+//! ## What this shows
+//!
+//! - `handle.add_and_watch(spec, timeout)`: register a task and get `(TaskId, TaskWaiter)`.
+//! - `waiter.wait().await`: block until the task terminates, returning a `TaskOutcome`.
+//! - The three outcomes you will most often see:
+//!   - [`TaskOutcome::Completed`] - a one-shot job that succeeded.
+//!   - [`TaskOutcome::Failed`] - retries exhausted; carries the final reason + exit code.
+//!   - [`TaskOutcome::Canceled`] - stopped via `cancel` / `remove` / shutdown.
+//!
+//! Other variants exist for the edges:
+//!  - `Fatal` - a `TaskError::Fatal`,
+//!  - `ForceAborted` - ignored cancellation, killed after the grace period
+//!  - `Panicked` - an actor-level panic; panics in the task *body* are caught and surface as `Failed`.
+//!
+//! ## Controller analogue
+//!
+//! With the `controller` feature, `handle.submit_and_watch(spec)` is the slot-based counterpart.
+//! If a submission is never admitted (slot busy, queue full, superseded, removed, or shutting down) the waiter resolves to `TaskOutcome::Rejected`.
+//!
+//! ## Runtime flavor
+//!
+//! We use `current_thread` here because a single-threaded runtime is enough for examples and tests.
+//!
+//! *It can be used with `#[tokio::main]` (defaults to multi-thread): taskvisor works with both.*
+//!
+//! ## Run
+//!
+//! ```bash
+//! cargo run --example outcomes
+//! ```
+//!
+//! ## Next
+//!
+//! | Example                      | What it adds                                    |
+//! |------------------------------|-------------------------------------------------|
+//! | [`dynamic.rs`](dynamic.rs)   | Add / remove / cancel tasks at runtime          |
+//! | [`pipeline.rs`](pipeline.rs) | Slot-based admission control (`controller`)     |
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use taskvisor::prelude::*;
+
+const ADD_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+    let handle = sup.serve();
+
+    // 1) A one-shot job that succeeds -> Completed.
+    println!("=== Completed ===");
+    let job: TaskRef = TaskFn::arc("import", |_ctx: CancellationToken| async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Ok(())
+    });
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::once(job), ADD_TIMEOUT)
+        .await?;
+    println!("  import -> {:?}\n", waiter.wait().await?);
+
+    // 2) A task that always fails, with a bounded retry budget -> Failed.
+    //    Note the outcome's reason/exit_code are identical to the ActorExhausted event.
+    println!("=== Failed (retries exhausted) ===");
+    let attempts = Arc::new(AtomicU32::new(0));
+    let flaky: TaskRef = TaskFn::arc("sync", move |_ctx: CancellationToken| {
+        let attempts = Arc::clone(&attempts);
+        async move {
+            let n = attempts.fetch_add(1, Ordering::Relaxed) + 1;
+            println!("  sync attempt #{n} failing...");
+            Err(TaskError::Fail {
+                reason: "upstream 503".into(),
+                exit_code: Some(75),
+            })
+        }
+    });
+    let spec = TaskSpec::restartable(flaky)
+        .with_backoff(BackoffPolicy {
+            first: Duration::from_millis(20),
+            ..BackoffPolicy::default()
+        })
+        .with_max_retries(2);
+    match handle
+        .add_and_watch(spec, ADD_TIMEOUT)
+        .await?
+        .1
+        .wait()
+        .await?
+    {
+        TaskOutcome::Failed { reason, exit_code } => {
+            println!("  sync -> Failed: {reason} (exit_code={exit_code:?})\n");
+        }
+        other => println!("  sync -> {other:?}\n"),
+    }
+
+    // 3) A long-running worker we cancel -> Canceled.
+    println!("=== Canceled ===");
+    let worker: TaskRef = TaskFn::arc("worker", |ctx: CancellationToken| async move {
+        ctx.cancelled().await;
+        Ok(())
+    });
+    let (id, waiter) = handle
+        .add_and_watch(TaskSpec::restartable(worker), ADD_TIMEOUT)
+        .await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    println!("  cancelling worker...");
+    handle.cancel(id).await?;
+    println!("  worker -> {:?}\n", waiter.wait().await?);
+
+    handle.shutdown().await?;
+    println!("Done.");
+    Ok(())
+}

--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -1,8 +1,7 @@
 //! # Pipeline
 //!
 //! Uses the optional `controller` feature to demonstrate slot-based admission control.
-//! This is useful when you need to limit concurrency per logical operation - e.g.,
-//! "only one deploy at a time" or "queue report generation".
+//! This is useful when you need to limit concurrency per logical operation - e.g., "only one deploy at a time" or "queue report generation".
 //!
 //! ## What is the controller?
 //!

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -27,13 +27,14 @@ use std::{
 };
 
 use dashmap::DashMap;
-use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use tokio::sync::broadcast;
 
 use crate::{
     RuntimeError, Supervisor, TaskSpec,
+    core::{OutcomeTx, TaskOutcome},
     events::{Bus, Event, EventKind},
     identity::TaskId,
 };
@@ -49,6 +50,7 @@ use super::{
 struct Submission {
     id: TaskId,
     spec: ControllerSpec,
+    done: Option<OutcomeTx>,
 }
 
 /// Handle for submitting tasks to the controller.
@@ -64,7 +66,11 @@ impl ControllerHandle {
     pub async fn submit(&self, spec: ControllerSpec) -> Result<TaskId, ControllerError> {
         let id = TaskId::next();
         self.tx
-            .send(Submission { id, spec })
+            .send(Submission {
+                id,
+                spec,
+                done: None,
+            })
             .await
             .map_err(|_| ControllerError::Closed)?;
         Ok(id)
@@ -76,12 +82,35 @@ impl ControllerHandle {
     pub fn try_submit(&self, spec: ControllerSpec) -> Result<TaskId, ControllerError> {
         let id = TaskId::next();
         self.tx
-            .try_send(Submission { id, spec })
+            .try_send(Submission {
+                id,
+                spec,
+                done: None,
+            })
             .map_err(|e| match e {
                 mpsc::error::TrySendError::Full(_) => ControllerError::Full,
                 mpsc::error::TrySendError::Closed(_) => ControllerError::Closed,
             })?;
         Ok(id)
+    }
+
+    /// Submit a task (async) and return a `oneshot` receiver resolving to its final [`TaskOutcome`]:
+    /// `Rejected` if admission is refused, otherwise the task's terminal outcome once it has run.
+    pub async fn submit_and_watch(
+        &self,
+        spec: ControllerSpec,
+    ) -> Result<(TaskId, oneshot::Receiver<TaskOutcome>), ControllerError> {
+        let id = TaskId::next();
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Submission {
+                id,
+                spec,
+                done: Some(tx),
+            })
+            .await
+            .map_err(|_| ControllerError::Closed)?;
+        Ok((id, rx))
     }
 }
 
@@ -104,6 +133,7 @@ pub(crate) struct Controller {
 
     slots: DashMap<Arc<str>, Arc<Mutex<SlotState>>>,
     running: DashMap<TaskId, Arc<str>>,
+    watchers: DashMap<TaskId, OutcomeTx>,
 
     tx: mpsc::Sender<Submission>,
     rx: RwLock<Option<mpsc::Receiver<Submission>>>,
@@ -122,10 +152,22 @@ impl Controller {
             bus,
             slots: DashMap::new(),
             running: DashMap::new(),
+            watchers: DashMap::new(),
             tx,
             rx: RwLock::new(Some(rx)),
             shutting_down: std::sync::atomic::AtomicBool::new(false),
         })
+    }
+
+    /// Resolves a watched submission's waiter with [`TaskOutcome::Rejected`], if any.
+    ///
+    /// No-op for unwatched submissions (`submit`/`try_submit`) and for ids already handed to the registry at admission.
+    fn finalize_rejected(&self, id: TaskId, reason: &str) {
+        if let Some((_, tx)) = self.watchers.remove(&id) {
+            let _ = tx.send(TaskOutcome::Rejected {
+                reason: Arc::from(reason),
+            });
+        }
     }
 
     /// Returns `true` once shutdown has been observed on the bus.
@@ -189,6 +231,10 @@ impl Controller {
                     }
                 }
             }
+        }
+        let pending: Vec<TaskId> = self.watchers.iter().map(|e| *e.key()).collect();
+        for id in pending {
+            self.finalize_rejected(id, "controller_shutting_down");
         }
         Ok(())
     }
@@ -276,21 +322,34 @@ impl Controller {
 
     /// Applies the admission policy for a new submission.
     ///
-    /// **Idle**: admit immediately, `add_task` mints the [`TaskId`] and the slot enters `Admitting`;
-    /// it becomes `Running` only when the matching `TaskAdded` is observed.
+    /// The body is a match on `(slot status, admission policy)`;
+    /// this table is the same grid, so it should stay in lockstep with the arms below:
     ///
-    /// **Queue**: push to tail (FIFO); rejected if the per-slot queue is full.
+    /// ```text
+    /// │              │ Queue                   │ Replace                                │ DropIfRunning │
+    /// │──────────────┼─────────────────────────┼────────────────────────────────────────┼───────────────│
+    /// │ Idle         │ admit → Admitting       │ (start_in_slot; same for every policy) │               │
+    /// │──────────────┼─────────────────────────┼────────────────────────────────────────┼───────────────│
+    /// │ Admitting    │ enqueue (or queue_full) │ replace head → Terminating             │ reject        │
+    /// │ Running      │ enqueue (or queue_full) │ remove running → Terminating           │ reject        │
+    /// │ Terminating  │ enqueue (or queue_full) │ replace head (stay)                    │ reject        │
+    /// ```
     ///
-    /// **Replace** (latest-wins): replaces the queue head;
-    /// if the slot is `Running` the current task is removed now,
-    /// if `Admitting` it is removed once it appears (in [`on_task_added`](Self::on_task_added)).
+    /// - **Idle**: admit immediately; slot enters `Admitting`, becomes `Running` on `TaskAdded`.
+    /// - **Queue**: push to tail (FIFO); rejected if the per-slot queue is full.
+    /// - **Replace** (latest-wins): replaces the queue head; the running/admitting task is removed now (Running) or once it appears (Admitting, in [`on_task_added`](Self::on_task_added)).
+    /// - **DropIfRunning**: reject while the slot is busy (`Admitting`/`Running`/`Terminating`).
     ///
-    /// **DropIfRunning**: reject while the slot is busy (`Admitting`/`Running`/`Terminating`).
+    /// A submission carrying a watcher (`done`) is parked in [`watchers`](Self::finalize_rejected) and resolved exactly once:
+    /// handed to the registry on admission, or `Rejected` at any of the rejection arms above (plus `controller_shutting_down` if shutdown was observed).
     async fn handle_submission(&self, sub: Submission) {
         let Some(sup) = self.supervisor.upgrade() else {
             return;
         };
-        let Submission { id, spec } = sub;
+        let Submission { id, spec, done } = sub;
+        if let Some(tx) = done {
+            self.watchers.insert(id, tx);
+        }
         if self.is_shutting_down() {
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
@@ -298,6 +357,7 @@ impl Controller {
                     .with_id(id)
                     .with_reason("controller_shutting_down"),
             );
+            self.finalize_rejected(id, "controller_shutting_down");
             return;
         }
 
@@ -320,12 +380,14 @@ impl Controller {
                         );
                     }
                     Err(e) => {
+                        let reason = format!("add_failed: {e}");
                         self.bus.publish(
                             Event::new(EventKind::ControllerRejected)
                                 .with_task(Arc::clone(&slot_name))
                                 .with_id(id)
-                                .with_reason(format!("add_failed: {e}")),
+                                .with_reason(reason.clone()),
                         );
+                        self.finalize_rejected(id, &reason);
                         drop(slot);
                         self.slots.remove(&*slot_name);
                     }
@@ -335,12 +397,14 @@ impl Controller {
                 if let Some(rid) = slot.running_id
                     && let Err(e) = sup.remove(rid)
                 {
+                    let reason = format!("remove_failed: {e}");
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(&slot_name))
                             .with_id(id)
-                            .with_reason(format!("remove_failed: {e}")),
+                            .with_reason(reason.clone()),
                     );
+                    self.finalize_rejected(id, &reason);
                     return;
                 }
                 self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
@@ -414,12 +478,14 @@ impl Controller {
                 | SlotStatus::Terminating { .. },
                 AdmissionPolicy::DropIfRunning,
             ) => {
+                let reason = format!("dropped: slot busy ({})", slot.status.label());
                 self.bus.publish(
                     Event::new(EventKind::ControllerRejected)
                         .with_task(Arc::clone(&slot_name))
                         .with_id(id)
-                        .with_reason(format!("dropped: slot busy (status={:?})", slot.status)),
+                        .with_reason(reason.clone()),
                 );
+                self.finalize_rejected(id, &reason);
             }
         }
     }
@@ -439,8 +505,7 @@ impl Controller {
         }
     }
 
-    /// `TaskRemoveRequested`: if the id belongs to a queued, not-yet-admitted submission, remove it from its slot queue
-    /// and acknowledge with `ControllerRejected("removed_from_queue")`.
+    /// `TaskRemoveRequested`: if the id belongs to a queued, not-yet-admitted submission, remove it from its slot queue and acknowledge with `ControllerRejected("removed_from_queue")`.
     async fn on_remove_requested(&self, event: &Event) {
         let Some(id) = event.id else {
             return;
@@ -466,6 +531,7 @@ impl Controller {
                     .with_id(id)
                     .with_reason("removed_from_queue"),
             );
+            self.finalize_rejected(id, "removed_from_queue");
             if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
                 drop(slot);
                 self.slots.remove(&*slot_name);
@@ -519,8 +585,7 @@ impl Controller {
         }
     }
 
-    /// `TaskAddFailed`: admission was rejected (e.g. duplicate name)
-    /// free the slot and start the next queued task, so a slot can never wedge in `Admitting`.
+    /// `TaskAddFailed`: admission was rejected (e.g. duplicate name) free the slot and start the next queued task, so a slot can never wedge in `Admitting`.
     async fn on_task_add_failed(&self, event: &Event) {
         self.free_and_advance(event).await;
     }
@@ -533,8 +598,6 @@ impl Controller {
 
     /// Common terminal handling for `TaskRemoved`/`TaskAddFailed`:
     /// resolve the owning slot by [`TaskId`], free it, and advance its queue.
-    ///
-    /// Idempotent: a stale/duplicate event whose id is no longer in the index is a no-op.
     async fn free_and_advance(&self, event: &Event) {
         let Some(id) = event.id else {
             return;
@@ -577,7 +640,8 @@ impl Controller {
         id: TaskId,
         task_spec: TaskSpec,
     ) -> Result<(), RuntimeError> {
-        sup.add_task_with_id(id, task_spec)?;
+        let done = self.watchers.remove(&id).map(|(_, tx)| tx);
+        sup.add_task_with_id_watched(id, task_spec, done)?;
         slot.status = SlotStatus::Admitting {
             since: Instant::now(),
         };
@@ -606,12 +670,14 @@ impl Controller {
                     return;
                 }
                 Err(e) => {
+                    let reason = format!("queue_start_failed: {e}");
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(slot_name))
                             .with_id(next_id)
-                            .with_reason(format!("queue_start_failed: {e}")),
+                            .with_reason(reason.clone()),
                     );
+                    self.finalize_rejected(next_id, &reason);
                 }
             }
         }
@@ -631,15 +697,14 @@ impl Controller {
     #[inline]
     fn reject_if_full(&self, slot_name: &str, id: TaskId, slot_len: usize) -> bool {
         if slot_len >= self.config.max_slot_queue {
+            let reason = format!("queue_full: {}/{}", slot_len, self.config.max_slot_queue);
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(slot_name)
                     .with_id(id)
-                    .with_reason(format!(
-                        "queue_full: {}/{}",
-                        slot_len, self.config.max_slot_queue
-                    )),
+                    .with_reason(reason.clone()),
             );
+            self.finalize_rejected(id, &reason);
             true
         } else {
             false
@@ -648,8 +713,7 @@ impl Controller {
 
     /// Replaces the queue head with the new submission (latest-wins) or pushes it.
     ///
-    /// A displaced queued submission is rejected with `superseded_by_replace`,
-    /// carrying its id, so submitters can observe that it will never run.
+    /// A displaced queued submission is rejected with `superseded_by_replace`, carrying its id, so submitters can observe that it will never run.
     fn replace_head_or_push(
         &self,
         slot: &mut SlotState,
@@ -665,6 +729,7 @@ impl Controller {
                     .with_id(displaced_id)
                     .with_reason("superseded_by_replace"),
             );
+            self.finalize_rejected(displaced_id, "superseded_by_replace");
         } else {
             slot.queue.push_front((id, task_spec));
         }
@@ -826,6 +891,7 @@ mod tests {
             bus,
             slots: DashMap::new(),
             running: DashMap::new(),
+            watchers: DashMap::new(),
             tx,
             rx: RwLock::new(Some(rx)),
             shutting_down: std::sync::atomic::AtomicBool::new(false),

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -46,27 +46,42 @@ use super::{
     spec::ControllerSpec,
 };
 
+struct Submission {
+    id: TaskId,
+    spec: ControllerSpec,
+}
+
 /// Handle for submitting tasks to the controller.
 #[derive(Clone)]
 pub(crate) struct ControllerHandle {
-    tx: mpsc::Sender<ControllerSpec>,
+    tx: mpsc::Sender<Submission>,
 }
 
 impl ControllerHandle {
     /// Submit a task (async, waits if queue is full).
-    pub async fn submit(&self, spec: ControllerSpec) -> Result<(), ControllerError> {
+    ///
+    /// Returns the pre-minted [`TaskId`].
+    pub async fn submit(&self, spec: ControllerSpec) -> Result<TaskId, ControllerError> {
+        let id = TaskId::next();
         self.tx
-            .send(spec)
+            .send(Submission { id, spec })
             .await
-            .map_err(|_| ControllerError::Closed)
+            .map_err(|_| ControllerError::Closed)?;
+        Ok(id)
     }
 
     /// Try to submit without blocking (fails if queue full).
-    pub fn try_submit(&self, spec: ControllerSpec) -> Result<(), ControllerError> {
-        self.tx.try_send(spec).map_err(|e| match e {
-            mpsc::error::TrySendError::Full(_) => ControllerError::Full,
-            mpsc::error::TrySendError::Closed(_) => ControllerError::Closed,
-        })
+    ///
+    /// Returns the pre-minted [`TaskId`].
+    pub fn try_submit(&self, spec: ControllerSpec) -> Result<TaskId, ControllerError> {
+        let id = TaskId::next();
+        self.tx
+            .try_send(Submission { id, spec })
+            .map_err(|e| match e {
+                mpsc::error::TrySendError::Full(_) => ControllerError::Full,
+                mpsc::error::TrySendError::Closed(_) => ControllerError::Closed,
+            })?;
+        Ok(id)
     }
 }
 
@@ -90,8 +105,8 @@ pub(crate) struct Controller {
     slots: DashMap<Arc<str>, Arc<Mutex<SlotState>>>,
     running: DashMap<TaskId, Arc<str>>,
 
-    tx: mpsc::Sender<ControllerSpec>,
-    rx: RwLock<Option<mpsc::Receiver<ControllerSpec>>>,
+    tx: mpsc::Sender<Submission>,
+    rx: RwLock<Option<mpsc::Receiver<Submission>>>,
 
     shutting_down: std::sync::atomic::AtomicBool,
 }
@@ -154,8 +169,8 @@ impl Controller {
             tokio::select! {
                 _ = token.cancelled() => break,
 
-                Some(spec) = rx.recv() => {
-                    self.handle_submission(spec).await;
+                Some(sub) = rx.recv() => {
+                    self.handle_submission(sub).await;
                 }
                 result = bus_rx.recv() => {
                     match result {
@@ -271,14 +286,16 @@ impl Controller {
     /// if `Admitting` it is removed once it appears (in [`on_task_added`](Self::on_task_added)).
     ///
     /// **DropIfRunning**: reject while the slot is busy (`Admitting`/`Running`/`Terminating`).
-    async fn handle_submission(&self, spec: ControllerSpec) {
+    async fn handle_submission(&self, sub: Submission) {
         let Some(sup) = self.supervisor.upgrade() else {
             return;
         };
+        let Submission { id, spec } = sub;
         if self.is_shutting_down() {
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(spec.slot_name().to_owned())
+                    .with_id(id)
                     .with_reason("controller_shutting_down"),
             );
             return;
@@ -293,11 +310,12 @@ impl Controller {
 
         match (&slot.status, admission) {
             (SlotStatus::Idle, _) => {
-                match self.start_in_slot(&sup, &mut slot, &slot_name, task_spec) {
-                    Ok(_id) => {
+                match self.start_in_slot(&sup, &mut slot, &slot_name, id, task_spec) {
+                    Ok(()) => {
                         self.bus.publish(
                             Event::new(EventKind::ControllerSubmitted)
                                 .with_task(Arc::clone(&slot_name))
+                                .with_id(id)
                                 .with_reason(format!("admission={admission:?} status=admitting")),
                         );
                     }
@@ -305,6 +323,7 @@ impl Controller {
                         self.bus.publish(
                             Event::new(EventKind::ControllerRejected)
                                 .with_task(Arc::clone(&slot_name))
+                                .with_id(id)
                                 .with_reason(format!("add_failed: {e}")),
                         );
                         drop(slot);
@@ -319,11 +338,12 @@ impl Controller {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(&slot_name))
+                            .with_id(id)
                             .with_reason(format!("remove_failed: {e}")),
                     );
                     return;
                 }
-                Self::replace_head_or_push(&mut slot, task_spec);
+                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
                 slot.status = SlotStatus::Terminating {
                     cancelled_at: Instant::now(),
                 };
@@ -335,11 +355,12 @@ impl Controller {
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
+                        .with_id(id)
                         .with_reason(format!("admission=Replace depth={}", slot.queue.len())),
                 );
             }
             (SlotStatus::Admitting { .. }, AdmissionPolicy::Replace) => {
-                Self::replace_head_or_push(&mut slot, task_spec);
+                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
                 slot.status = SlotStatus::Terminating {
                     cancelled_at: Instant::now(),
                 };
@@ -351,6 +372,7 @@ impl Controller {
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
+                        .with_id(id)
                         .with_reason(format!(
                             "admission=Replace status=admitting depth={}",
                             slot.queue.len()
@@ -358,10 +380,11 @@ impl Controller {
                 );
             }
             (SlotStatus::Terminating { .. }, AdmissionPolicy::Replace) => {
-                Self::replace_head_or_push(&mut slot, task_spec);
+                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
+                        .with_id(id)
                         .with_reason(format!(
                             "admission=Replace status=terminating depth={}",
                             slot.queue.len()
@@ -374,13 +397,14 @@ impl Controller {
                 | SlotStatus::Terminating { .. },
                 AdmissionPolicy::Queue,
             ) => {
-                if self.reject_if_full(&slot_name, slot.queue.len()) {
+                if self.reject_if_full(&slot_name, id, slot.queue.len()) {
                     return;
                 }
-                slot.queue.push_back(task_spec);
+                slot.queue.push_back((id, task_spec));
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
+                        .with_id(id)
                         .with_reason(format!("admission=Queue depth={}", slot.queue.len())),
                 );
             }
@@ -393,6 +417,7 @@ impl Controller {
                 self.bus.publish(
                     Event::new(EventKind::ControllerRejected)
                         .with_task(Arc::clone(&slot_name))
+                        .with_id(id)
                         .with_reason(format!("dropped: slot busy (status={:?})", slot.status)),
                 );
             }
@@ -405,11 +430,47 @@ impl Controller {
             EventKind::TaskAdded => self.on_task_added(&event).await,
             EventKind::TaskRemoved => self.on_task_finished(&event).await,
             EventKind::TaskAddFailed => self.on_task_add_failed(&event).await,
+            EventKind::TaskRemoveRequested => self.on_remove_requested(&event).await,
             EventKind::ShutdownRequested => {
                 self.shutting_down
                     .store(true, std::sync::atomic::Ordering::Release);
             }
             _ => {}
+        }
+    }
+
+    /// `TaskRemoveRequested`: if the id belongs to a queued, not-yet-admitted submission, remove it from its slot queue
+    /// and acknowledge with `ControllerRejected("removed_from_queue")`.
+    async fn on_remove_requested(&self, event: &Event) {
+        let Some(id) = event.id else {
+            return;
+        };
+        let slot_keys: Vec<Arc<str>> = self
+            .slots
+            .iter()
+            .map(|entry| Arc::clone(entry.key()))
+            .collect();
+
+        for slot_name in slot_keys {
+            let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
+                continue;
+            };
+            let mut slot = slot_arc.lock().await;
+            let Some(pos) = slot.queue.iter().position(|(qid, _)| *qid == id) else {
+                continue;
+            };
+            slot.queue.remove(pos);
+            self.bus.publish(
+                Event::new(EventKind::ControllerRejected)
+                    .with_task(Arc::clone(&slot_name))
+                    .with_id(id)
+                    .with_reason("removed_from_queue"),
+            );
+            if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
+                drop(slot);
+                self.slots.remove(&*slot_name);
+            }
+            return;
         }
     }
 
@@ -505,22 +566,24 @@ impl Controller {
         }
     }
 
-    /// Admits `task_spec` into the slot: mints the identity via `add_task`, marks the slot `Admitting`, and records the reverse index.
+    /// Admits `task_spec` into the slot under its **pre-minted** identity,
+    /// marks the slot `Admitting`, and records the reverse index.
     /// The slot becomes `Running` on `TaskAdded`.
     fn start_in_slot(
         &self,
         sup: &Arc<Supervisor>,
         slot: &mut SlotState,
         slot_name: &Arc<str>,
+        id: TaskId,
         task_spec: TaskSpec,
-    ) -> Result<TaskId, RuntimeError> {
-        let id = sup.add_task(task_spec)?;
+    ) -> Result<(), RuntimeError> {
+        sup.add_task_with_id(id, task_spec)?;
         slot.status = SlotStatus::Admitting {
             since: Instant::now(),
         };
         slot.running_id = Some(id);
         self.running.insert(id, Arc::clone(slot_name));
-        Ok(id)
+        Ok(())
     }
 
     /// Pops and admits queued tasks until one is accepted or the queue drains.
@@ -531,12 +594,13 @@ impl Controller {
         slot: &mut SlotState,
         slot_name: &Arc<str>,
     ) {
-        while let Some(next_spec) = slot.queue.pop_front() {
-            match self.start_in_slot(sup, slot, slot_name, next_spec) {
-                Ok(_id) => {
+        while let Some((next_id, next_spec)) = slot.queue.pop_front() {
+            match self.start_in_slot(sup, slot, slot_name, next_id, next_spec) {
+                Ok(()) => {
                     self.bus.publish(
                         Event::new(EventKind::ControllerSubmitted)
                             .with_task(Arc::clone(slot_name))
+                            .with_id(next_id)
                             .with_reason(format!("started_from_queue depth={}", slot.queue.len())),
                     );
                     return;
@@ -545,6 +609,7 @@ impl Controller {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(slot_name))
+                            .with_id(next_id)
                             .with_reason(format!("queue_start_failed: {e}")),
                     );
                 }
@@ -564,11 +629,12 @@ impl Controller {
     }
 
     #[inline]
-    fn reject_if_full(&self, slot_name: &str, slot_len: usize) -> bool {
+    fn reject_if_full(&self, slot_name: &str, id: TaskId, slot_len: usize) -> bool {
         if slot_len >= self.config.max_slot_queue {
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(slot_name)
+                    .with_id(id)
                     .with_reason(format!(
                         "queue_full: {}/{}",
                         slot_len, self.config.max_slot_queue
@@ -580,12 +646,27 @@ impl Controller {
         }
     }
 
-    #[inline]
-    fn replace_head_or_push(slot: &mut SlotState, task_spec: crate::TaskSpec) {
+    /// Replaces the queue head with the new submission (latest-wins) or pushes it.
+    ///
+    /// A displaced queued submission is rejected with `superseded_by_replace`,
+    /// carrying its id, so submitters can observe that it will never run.
+    fn replace_head_or_push(
+        &self,
+        slot: &mut SlotState,
+        slot_name: &Arc<str>,
+        id: TaskId,
+        task_spec: crate::TaskSpec,
+    ) {
         if let Some(head) = slot.queue.front_mut() {
-            *head = task_spec;
+            let (displaced_id, _) = std::mem::replace(head, (id, task_spec));
+            self.bus.publish(
+                Event::new(EventKind::ControllerRejected)
+                    .with_task(Arc::clone(slot_name))
+                    .with_id(displaced_id)
+                    .with_reason("superseded_by_replace"),
+            );
         } else {
-            slot.queue.push_front(task_spec);
+            slot.queue.push_front((id, task_spec));
         }
     }
 }
@@ -601,37 +682,62 @@ mod tests {
         TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
     }
 
-    #[test]
-    fn replace_head_or_push_into_empty_queue() {
-        let mut slot = SlotState::new();
-        Controller::replace_head_or_push(&mut slot, make_spec("first"));
-
-        assert_eq!(slot.queue.len(), 1);
-        assert_eq!(slot.queue.front().unwrap().name(), "first");
+    fn slot_arc_name() -> Arc<str> {
+        Arc::from("s")
     }
 
     #[test]
-    fn replace_head_or_push_replaces_existing_head() {
+    fn replace_head_or_push_into_empty_queue() {
+        let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
         let mut slot = SlotState::new();
-        slot.queue.push_back(make_spec("old-head"));
-        slot.queue.push_back(make_spec("tail"));
+        ctrl.replace_head_or_push(
+            &mut slot,
+            &slot_arc_name(),
+            TaskId::next(),
+            make_spec("first"),
+        );
 
-        Controller::replace_head_or_push(&mut slot, make_spec("new-head"));
+        assert_eq!(slot.queue.len(), 1);
+        assert_eq!(slot.queue.front().unwrap().1.name(), "first");
+    }
+
+    #[test]
+    fn replace_head_or_push_replaces_existing_head_and_rejects_displaced() {
+        let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
+        let mut rx = ctrl.bus.subscribe();
+        let mut slot = SlotState::new();
+        let displaced = TaskId::next();
+        slot.queue.push_back((displaced, make_spec("old-head")));
+        slot.queue.push_back((TaskId::next(), make_spec("tail")));
+
+        ctrl.replace_head_or_push(
+            &mut slot,
+            &slot_arc_name(),
+            TaskId::next(),
+            make_spec("new-head"),
+        );
 
         assert_eq!(slot.queue.len(), 2, "queue depth should not grow");
-        assert_eq!(slot.queue.front().unwrap().name(), "new-head");
-        assert_eq!(slot.queue.back().unwrap().name(), "tail");
+        assert_eq!(slot.queue.front().unwrap().1.name(), "new-head");
+        assert_eq!(slot.queue.back().unwrap().1.name(), "tail");
+
+        let ev = rx.try_recv().expect("displaced head must be rejected");
+        assert_eq!(ev.kind, EventKind::ControllerRejected);
+        assert_eq!(ev.id, Some(displaced));
+        assert_eq!(ev.reason.as_deref(), Some("superseded_by_replace"));
     }
 
     #[test]
     fn replace_head_multiple_times_keeps_depth_1() {
+        let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
         let mut slot = SlotState::new();
-        Controller::replace_head_or_push(&mut slot, make_spec("v1"));
-        Controller::replace_head_or_push(&mut slot, make_spec("v2"));
-        Controller::replace_head_or_push(&mut slot, make_spec("v3"));
+        let name = slot_arc_name();
+        ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v1"));
+        ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v2"));
+        ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v3"));
 
         assert_eq!(slot.queue.len(), 1);
-        assert_eq!(slot.queue.front().unwrap().name(), "v3");
+        assert_eq!(slot.queue.front().unwrap().1.name(), "v3");
     }
 
     #[test]
@@ -642,8 +748,8 @@ mod tests {
             max_slot_queue: 3,
         };
         let ctrl = make_controller(config, bus);
-        assert!(!ctrl.reject_if_full("slot", 0));
-        assert!(!ctrl.reject_if_full("slot", 2));
+        assert!(!ctrl.reject_if_full("slot", TaskId::next(), 0));
+        assert!(!ctrl.reject_if_full("slot", TaskId::next(), 2));
     }
 
     #[test]
@@ -654,8 +760,8 @@ mod tests {
             max_slot_queue: 3,
         };
         let ctrl = make_controller(config, bus);
-        assert!(ctrl.reject_if_full("slot", 3));
-        assert!(ctrl.reject_if_full("slot", 10));
+        assert!(ctrl.reject_if_full("slot", TaskId::next(), 3));
+        assert!(ctrl.reject_if_full("slot", TaskId::next(), 10));
     }
 
     #[test]
@@ -835,7 +941,7 @@ mod tests {
             Ok(())
         });
         let mut queue = std::collections::VecDeque::new();
-        queue.push_back(TaskSpec::restartable(queued));
+        queue.push_back((TaskId::next(), TaskSpec::restartable(queued)));
         ctrl.slots.insert(
             Arc::from("s"),
             Arc::new(Mutex::new(SlotState {

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -22,7 +22,7 @@ pub(super) struct SlotState {
     pub running_id: Option<TaskId>,
 
     /// Queue of pending tasks (FIFO order).
-    pub queue: VecDeque<TaskSpec>,
+    pub queue: VecDeque<(TaskId, TaskSpec)>,
 }
 
 /// Status of a task slot.
@@ -102,18 +102,14 @@ mod tests {
     fn queue_push_pop_fifo() {
         let mut slot = SlotState::new();
 
-        let task_a = make_spec("a");
-        let task_b = make_spec("b");
-        let task_c = make_spec("c");
-
-        slot.queue.push_back(task_a);
-        slot.queue.push_back(task_b);
-        slot.queue.push_back(task_c);
+        slot.queue.push_back((TaskId::next(), make_spec("a")));
+        slot.queue.push_back((TaskId::next(), make_spec("b")));
+        slot.queue.push_back((TaskId::next(), make_spec("c")));
 
         assert_eq!(slot.queue.len(), 3);
-        assert_eq!(slot.queue.pop_front().unwrap().name(), "a");
-        assert_eq!(slot.queue.pop_front().unwrap().name(), "b");
-        assert_eq!(slot.queue.pop_front().unwrap().name(), "c");
+        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "a");
+        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "b");
+        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "c");
         assert!(slot.queue.is_empty());
     }
 

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -50,6 +50,20 @@ pub(super) enum SlotStatus {
     },
 }
 
+impl SlotStatus {
+    /// Short, stable, human-readable name (for event/outcome reason strings).
+    ///
+    /// Unlike the derived `Debug`, this never leaks the internal `Instant` timestamps.
+    pub fn label(&self) -> &'static str {
+        match self {
+            SlotStatus::Idle => "idle",
+            SlotStatus::Admitting { .. } => "admitting",
+            SlotStatus::Running { .. } => "running",
+            SlotStatus::Terminating { .. } => "terminating",
+        }
+    }
+}
+
 impl SlotState {
     /// Creates a new idle slot.
     pub fn new() -> Self {

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -76,28 +76,45 @@ use crate::{
     tasks::Task,
 };
 
-/// Reason why a task actor exited.
+/// Reason why a task actor exited, carrying the final result of the last attempt.
 ///
-/// Used to determine what event to publish and whether to clean up the task from registry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Used to determine what event to publish, whether to clean up the task from registry, and which [`TaskOutcome`](crate::TaskOutcome)
+/// to deliver to a watcher (see [`Registry::report_join`](super::registry::Registry)).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ActorExitReason {
-    /// Actor exhausted its restart policy and will not restart.
+    /// Final attempt succeeded and the restart policy forbids another run.
     ///
     /// Occurs when:
-    /// - `RestartPolicy::Never` and task completed (success or failure)
-    /// - `RestartPolicy::OnFailure` and task completed successfully
-    PolicyExhausted,
+    /// - `RestartPolicy::Never` and the task completed successfully
+    /// - `RestartPolicy::OnFailure` and the task completed successfully
+    Completed,
 
-    /// Actor was canceled due to shut down signal or explicit removal.
+    /// Final attempt failed and no further retries are allowed.
     ///
-    /// The task detected `CancellationToken::is_cancelled()` and exited gracefully.
-    Cancelled,
+    /// Occurs when:
+    /// - `RestartPolicy::Never` and the task failed
+    /// - the error is not retryable (and not fatal)
+    /// - the retry budget (`max_retries`) is exhausted
+    Exhausted {
+        /// Final failure message (same string as the `ActorExhausted` event reason).
+        reason: Arc<str>,
+        /// Numeric exit code from a process-like runtime, if any.
+        exit_code: Option<i32>,
+    },
+
+    /// Actor was canceled due shutdown signal, explicit removal, or the task itself reporting `TaskError::Canceled`.
+    Canceled,
 
     /// Actor died due to a fatal error that should not be retried.
     ///
     /// Occurs when:
     /// - Task returned `TaskError::Fatal`
-    Fatal,
+    Fatal {
+        /// Fatal error message.
+        reason: Arc<str>,
+        /// Numeric exit code from a process-like runtime, if any.
+        exit_code: Option<i32>,
+    },
 }
 
 /// Configuration parameters for a task actor.
@@ -163,7 +180,7 @@ impl TaskActor {
 
         loop {
             if runtime_token.is_cancelled() {
-                return ActorExitReason::Cancelled;
+                return ActorExitReason::Canceled;
             }
             let permit = match &self.semaphore {
                 Some(sem) => {
@@ -181,11 +198,11 @@ impl TaskActor {
                                         .with_attempt(attempt)
                                         .with_reason("semaphore_closed"),
                                 );
-                                return ActorExitReason::Cancelled;
+                                return ActorExitReason::Canceled;
                             }
                         },
                         _ = runtime_token.cancelled() => {
-                            return ActorExitReason::Cancelled;
+                            return ActorExitReason::Canceled;
                         }
                     }
                 }
@@ -193,7 +210,7 @@ impl TaskActor {
             };
             if runtime_token.is_cancelled() {
                 drop(permit);
-                return ActorExitReason::Cancelled;
+                return ActorExitReason::Canceled;
             }
 
             let child = runtime_token.child_token();
@@ -232,7 +249,7 @@ impl TaskActor {
                                         .with_delay(d),
                                 );
                                 if !Self::sleep_cancellable(d, &runtime_token).await {
-                                    return ActorExitReason::Cancelled;
+                                    return ActorExitReason::Canceled;
                                 }
                             } else {
                                 tokio::task::yield_now().await;
@@ -240,6 +257,9 @@ impl TaskActor {
                             continue;
                         }
                         RestartPolicy::OnFailure | RestartPolicy::Never => {
+                            if runtime_token.is_cancelled() {
+                                return ActorExitReason::Canceled;
+                            }
                             self.bus.publish(
                                 Event::new(EventKind::ActorExhausted)
                                     .with_task(task_name.clone())
@@ -247,25 +267,28 @@ impl TaskActor {
                                     .with_attempt(attempt)
                                     .with_reason("policy_exhausted_success"),
                             );
-                            return ActorExitReason::PolicyExhausted;
+                            return ActorExitReason::Completed;
                         }
                     }
                 }
                 Err(e) if e.is_fatal() => {
+                    let reason: Arc<str> = Arc::from(e.to_string());
+                    let exit_code = e.exit_code();
+
                     let mut ev = Event::new(EventKind::ActorDead)
                         .with_task(task_name.clone())
                         .with_id(id)
                         .with_attempt(attempt)
-                        .with_reason(e.to_string());
-                    if let Some(code) = e.exit_code() {
+                        .with_reason(Arc::clone(&reason));
+                    if let Some(code) = exit_code {
                         ev = ev.with_exit_code(code);
                     }
                     self.bus.publish(ev);
-                    return ActorExitReason::Fatal;
+                    return ActorExitReason::Fatal { reason, exit_code };
                 }
                 Err(TaskError::Canceled) => {
                     if runtime_token.is_cancelled() {
-                        return ActorExitReason::Cancelled;
+                        return ActorExitReason::Canceled;
                     }
                     self.bus.publish(
                         Event::new(EventKind::ActorExhausted)
@@ -274,7 +297,7 @@ impl TaskActor {
                             .with_attempt(attempt)
                             .with_reason("task_returned_canceled"),
                     );
-                    return ActorExitReason::PolicyExhausted;
+                    return ActorExitReason::Canceled;
                 }
                 Err(e) => {
                     let policy_allows_retry = matches!(
@@ -286,24 +309,26 @@ impl TaskActor {
                         self.params.max_retries > 0 && backoff_attempt >= self.params.max_retries;
 
                     if !(policy_allows_retry && error_is_retryable) || retries_exhausted {
-                        let reason = if retries_exhausted {
-                            format!(
+                        let reason: Arc<str> = if retries_exhausted {
+                            Arc::from(format!(
                                 "max_retries_exceeded({}/{}): {}",
                                 backoff_attempt, self.params.max_retries, e
-                            )
+                            ))
                         } else {
-                            e.to_string()
+                            Arc::from(e.to_string())
                         };
+                        let exit_code = e.exit_code();
+
                         let mut ev = Event::new(EventKind::ActorExhausted)
                             .with_task(task_name.clone())
                             .with_id(id)
                             .with_attempt(attempt)
-                            .with_reason(reason);
-                        if let Some(code) = e.exit_code() {
+                            .with_reason(Arc::clone(&reason));
+                        if let Some(code) = exit_code {
                             ev = ev.with_exit_code(code);
                         }
                         self.bus.publish(ev);
-                        return ActorExitReason::PolicyExhausted;
+                        return ActorExitReason::Exhausted { reason, exit_code };
                     }
 
                     let delay = self.params.backoff.next(backoff_attempt);
@@ -319,7 +344,7 @@ impl TaskActor {
                             .with_reason(e.to_string()),
                     );
                     if !Self::sleep_cancellable(delay, &runtime_token).await {
-                        return ActorExitReason::Cancelled;
+                        return ActorExitReason::Canceled;
                     }
                 }
             }
@@ -448,31 +473,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn never_ok_returns_policy_exhausted() {
+    async fn never_ok_returns_completed() {
         let a = actor(Arc::new(OkTask), RestartPolicy::Never, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::PolicyExhausted);
+        assert_eq!(reason, ActorExitReason::Completed);
     }
 
     #[tokio::test]
-    async fn on_failure_ok_returns_policy_exhausted() {
+    async fn on_failure_ok_returns_completed() {
         let a = actor(Arc::new(OkTask), RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::PolicyExhausted);
+        assert_eq!(reason, ActorExitReason::Completed);
     }
 
     #[tokio::test]
-    async fn fatal_error_returns_fatal() {
+    async fn fatal_error_returns_fatal_with_reason() {
         let a = actor(Arc::new(FatalTask), RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::Fatal);
+        match reason {
+            ActorExitReason::Fatal { reason, exit_code } => {
+                assert!(
+                    reason.contains("fatal"),
+                    "reason must carry the error: {reason}"
+                );
+                assert_eq!(exit_code, None);
+            }
+            other => panic!("expected Fatal, got {other:?}"),
+        }
     }
 
     #[tokio::test]
-    async fn max_retries_exhausted_returns_policy_exhausted() {
+    async fn max_retries_exhausted_returns_exhausted_with_reason() {
         let a = actor(Arc::new(FailTask), RestartPolicy::OnFailure, 3);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::PolicyExhausted);
+        match reason {
+            ActorExitReason::Exhausted { reason, .. } => {
+                assert!(
+                    reason.contains("max_retries_exceeded"),
+                    "reason must mention exhausted budget: {reason}"
+                );
+            }
+            other => panic!("expected Exhausted, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -485,7 +527,7 @@ mod tests {
             0,
         );
         let reason = a.run(token).await;
-        assert_eq!(reason, ActorExitReason::Cancelled);
+        assert_eq!(reason, ActorExitReason::Canceled);
     }
 
     #[tokio::test]
@@ -493,6 +535,6 @@ mod tests {
         let task = Arc::new(CountedTask::new(2));
         let a = actor(task, RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::PolicyExhausted);
+        assert_eq!(reason, ActorExitReason::Completed);
     }
 }

--- a/src/core/alive.rs
+++ b/src/core/alive.rs
@@ -20,7 +20,7 @@
 //! - **Entry removed** on `TaskRemoved` (not just set to false; the entry is fully cleaned up).
 //! - Read operations (`snapshot`, `is_alive`) are **eventually consistent**.
 //! - Events with `seq <= last_seq` for the same identity are **rejected** (stale).
-//! - **Alive = false** on `TaskStopped`, `TaskFailed`, `ActorExhausted`, `ActorDead`.
+//! - **Alive = false** on `TaskStopped`, `TaskCanceled`, `TaskFailed`, `ActorExhausted`, `ActorDead`.
 //! - **Alive = true** on `TaskStarting`.
 
 use std::{collections::HashMap, sync::Arc};
@@ -89,6 +89,19 @@ impl AliveTracker {
     /// update(TaskStarting, seq=99)  → ignored (stale)
     /// ```
     pub async fn update(&self, ev: &Event) -> bool {
+        let relevant = matches!(
+            ev.kind,
+            EventKind::TaskStarting
+                | EventKind::TaskStopped
+                | EventKind::TaskCanceled
+                | EventKind::TaskFailed
+                | EventKind::ActorExhausted
+                | EventKind::ActorDead
+                | EventKind::TaskRemoved
+        );
+        if !relevant {
+            return false;
+        }
         let key = match (ev.id, ev.task.as_deref()) {
             (Some(id), _) => AliveKey::Id(id),
             (None, Some(name)) => AliveKey::Name(Arc::from(name)),
@@ -120,6 +133,7 @@ impl AliveTracker {
         let next_alive = match ev.kind {
             EventKind::TaskStarting => true,
             EventKind::TaskStopped
+            | EventKind::TaskCanceled
             | EventKind::TaskFailed
             | EventKind::ActorExhausted
             | EventKind::ActorDead => false,
@@ -172,6 +186,28 @@ mod tests {
         let mut e = Event::new(kind).with_task(task).with_id(id);
         e.seq = seq;
         e
+    }
+
+    #[tokio::test]
+    async fn non_lifecycle_events_do_not_pollute_entries() {
+        let tracker = AliveTracker::new();
+        let id = crate::identity::TaskId::next();
+
+        tracker
+            .update(&evi(EventKind::BackoffScheduled, "slot-name", 1, id))
+            .await;
+        tracker
+            .update(&evi(EventKind::TaskStarting, "real-name", 2, id))
+            .await;
+
+        assert!(
+            tracker.is_alive("real-name").await,
+            "lifecycle event must bind the id to the lifecycle task name"
+        );
+        assert!(
+            !tracker.is_alive("slot-name").await,
+            "non-lifecycle event must not have created an entry"
+        );
     }
 
     #[tokio::test]

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -13,6 +13,7 @@ use crate::events::EventKind;
 use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
+use super::outcome::TaskWaiter;
 use super::supervisor::Supervisor;
 
 /// Handle for managing a running supervisor.
@@ -95,7 +96,58 @@ impl SupervisorHandle {
         let target: Arc<str> = Arc::from(spec.task().name());
         let mut rx = self.inner.subscribe_bus();
         let id = self.inner.add_task(spec)?;
+        self.wait_registered(&mut rx, id, target, timeout).await
+    }
 
+    /// Adds a task, waits for registration confirmation, and returns an awaitable [`TaskWaiter`] resolving to the task's final [`TaskOutcome`](crate::TaskOutcome).
+    ///
+    /// The outcome channel is created **atomically with registration** (it travels with the `Add` command over the guaranteed-delivery mpsc).
+    /// There is no window in which the task can finish before the waiter exists, and the outcome cannot be lost to event-bus lag.
+    ///
+    /// Registration semantics are identical to [`add_and_wait`](Self::add_and_wait):
+    ///
+    /// - `Ok((TaskId, TaskWaiter))` when the task is confirmed running,
+    /// - `Err(RuntimeError::TaskAlreadyExists)` if the name is already registered,
+    /// - `Err(RuntimeError::TaskAddTimeout)` if no confirmation arrives within `timeout`.
+    ///
+    /// ## Example
+    /// ```rust,no_run
+    /// # use std::time::Duration;
+    /// # use taskvisor::prelude::*;
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+    /// # let handle = sup.serve();
+    /// let job: TaskRef = TaskFn::arc("job", |_ctx: CancellationToken| async { Ok(()) });
+    /// let (_id, waiter) = handle
+    ///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+    ///     .await?;
+    ///
+    /// let outcome = waiter.wait().await?;
+    /// assert!(outcome.is_success());
+    /// # Ok(()) }
+    /// ```
+    pub async fn add_and_watch(
+        &self,
+        spec: TaskSpec,
+        timeout: Duration,
+    ) -> Result<(TaskId, TaskWaiter), RuntimeError> {
+        let target: Arc<str> = Arc::from(spec.task().name());
+        let mut rx = self.inner.subscribe_bus();
+        let (id, done_rx) = self.inner.add_task_watched(spec)?;
+        self.wait_registered(&mut rx, id, target, timeout).await?;
+        Ok((id, TaskWaiter::new(id, done_rx)))
+    }
+
+    /// Waits for the registry's `TaskAdded`/`TaskAddFailed` confirmation for `id`.
+    ///
+    /// On bus `Lagged`/`Closed` falls back to the registry state (`contains_id`) instead of failing spuriously.
+    async fn wait_registered(
+        &self,
+        rx: &mut broadcast::Receiver<Arc<crate::Event>>,
+        id: TaskId,
+        target: Arc<str>,
+        timeout: Duration,
+    ) -> Result<TaskId, RuntimeError> {
         let target2 = Arc::clone(&target);
         let wait = async move {
             loop {
@@ -217,6 +269,9 @@ impl SupervisorHandle {
 
     /// Submits a task to the controller (if enabled), returning its pre-minted [`TaskId`].
     ///
+    /// Fire-and-forget: `Ok(id)` means the submission was enqueued, not admitted.
+    /// To **await the final outcome** (including admission rejection), use [`submit_and_watch`](Self::submit_and_watch).
+    ///
     /// Requires the `controller` feature flag.
     #[cfg(feature = "controller")]
     pub async fn submit(
@@ -238,5 +293,24 @@ impl SupervisorHandle {
         spec: crate::controller::ControllerSpec,
     ) -> Result<TaskId, crate::controller::ControllerError> {
         self.inner.try_submit(spec)
+    }
+
+    /// Submits a task to the controller and returns an awaitable [`TaskWaiter`] resolving to its final [`TaskOutcome`](crate::TaskOutcome)
+    /// the controller-path analogue of [`add_and_watch`](Self::add_and_watch).
+    ///
+    /// The outcome is delivered on the guaranteed completion plane (a `oneshot`, immune to bus lag).
+    /// If the controller never admits the submission (slot busy under `DropIfRunning`, queue full, superseded by a later `Replace`, removed while queued, or shutting down)
+    /// the waiter resolves to [`TaskOutcome::Rejected`](crate::TaskOutcome::Rejected) - the task body never ran.
+    ///
+    /// Otherwise, it resolves like [`add_and_watch`](Self::add_and_watch) once the admitted task fully terminates.
+    ///
+    /// Requires the `controller` feature flag.
+    #[cfg(feature = "controller")]
+    pub async fn submit_and_watch(
+        &self,
+        spec: crate::controller::ControllerSpec,
+    ) -> Result<(TaskId, TaskWaiter), crate::controller::ControllerError> {
+        let (id, rx) = self.inner.submit_and_watch(spec).await?;
+        Ok((id, TaskWaiter::new(id, rx)))
     }
 }

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -215,27 +215,28 @@ impl SupervisorHandle {
         self.inner.shutdown().await
     }
 
-    /// Submits a task to the controller (if enabled).
+    /// Submits a task to the controller (if enabled), returning its pre-minted [`TaskId`].
     ///
     /// Requires the `controller` feature flag.
     #[cfg(feature = "controller")]
     pub async fn submit(
         &self,
         spec: crate::controller::ControllerSpec,
-    ) -> Result<(), crate::controller::ControllerError> {
+    ) -> Result<TaskId, crate::controller::ControllerError> {
         self.inner.submit(spec).await
     }
 
-    /// Tries to submit a task without blocking.
+    /// Tries to submit a task without blocking, returning its pre-minted [`TaskId`].
     ///
     /// Returns `ControllerError::Full` if the queue is full.
+    /// See [`submit`](Self::submit) for the enqueued-vs-admitted semantics.
     ///
     /// Requires the `controller` feature flag.
     #[cfg(feature = "controller")]
     pub fn try_submit(
         &self,
         spec: crate::controller::ControllerSpec,
-    ) -> Result<(), crate::controller::ControllerError> {
+    ) -> Result<TaskId, crate::controller::ControllerError> {
         self.inner.try_submit(spec)
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -118,11 +118,17 @@ pub use config::SupervisorConfig;
 mod handle;
 pub use handle::SupervisorHandle;
 
+mod outcome;
+pub use outcome::{TaskOutcome, TaskWaiter};
+
 mod supervisor;
 pub use supervisor::Supervisor;
 
 mod actor;
 mod alive;
-mod registry;
 mod runner;
 mod shutdown;
+
+mod registry;
+#[cfg(feature = "controller")]
+pub(crate) use registry::OutcomeTx;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,7 +27,7 @@
 //! - **Supervisor** → `ShutdownRequested`, `TaskAddRequested`, `TaskRemoveRequested`
 //! - **Registry**   → `TaskAdded{name}`, `TaskRemoved{name}`
 //! - **TaskActor**  → `TaskStarting{attempt}`, `BackoffScheduled{delay}`, `ActorExhausted`, `ActorDead`
-//! - **Runner**     → `TaskStopped` (success/cancel), `TaskFailed` (fail/fatal/timeout), `TimeoutHit`
+//! - **Runner**     → `TaskStopped` (success), `TaskCanceled` (graceful cancel), `TaskFailed` (fail/fatal/timeout), `TimeoutHit`
 //! - **SubscriberSet (workers)** → `SubscriberOverflow`, `SubscriberPanicked`
 //!
 //! Consumers (subscribe to Bus):
@@ -57,7 +57,7 @@
 //!   Supervisor ─────────► │ ShutdownRequested                                                  │
 //!   Registry   ─────────► │ TaskAdded / TaskRemoved                                            │
 //!   TaskActor  ─────────► │ TaskStarting / BackoffScheduled / ActorExhausted / ActorDead       │
-//!   Runner     ─────────► │ TaskStopped / TaskFailed / TimeoutHit                              │
+//!   Runner     ─────────► │ TaskStopped / TaskCanceled / TaskFailed / TimeoutHit               │
 //!   SubscriberSet ──────► │ SubscriberOverflow / SubscriberPanicked                            │
 //!                         └──┬──────────────────────────────────────────┬──────────────────────┘
 //!              Supervisor::subscriber_listener()         Registry::spawn_listener()
@@ -82,7 +82,7 @@
 //! runner::run_once()
 //!   - derive child token
 //!   - if timeout set → time::timeout(fut); on elapsed: cancel child, publish TimeoutHit, Timeout
-//!   - on Ok or Err(Canceled) → publish TaskStopped
+//!   - on Ok → publish TaskStopped; on Err(Canceled) → publish TaskCanceled
 //!   - on Err(Fail/Fatal/Timeout) → publish TaskFailed
 //! ```
 //!

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -1,0 +1,244 @@
+//! # Task completion outcomes and the awaitable [`TaskWaiter`].
+//!
+//! [`TaskOutcome`] is the **final** result of a supervised task run: it is produced exactly once,
+//! after the actor's retry loop has finished and its `JoinHandle` has been joined by the registry.
+//!
+//! [`TaskWaiter`] is the receiving half of a `oneshot` channel created at
+//! registration time by [`SupervisorHandle::add_and_watch`](crate::SupervisorHandle::add_and_watch).
+//!
+//! ## Architecture: one sender, resolved at exactly one site
+//!
+//! The `oneshot` sender is minted at registration and travels with the task until a single site resolves it.
+//! There are two birth points (direct vs. controller) and a closed set of resolution sites - **every** terminal path resolves
+//! the sender - waiter can never hang:
+//!
+//! ```text
+//!  BIRTH                                  TRAVELS IN              RESOLVED AT (exactly one)
+//!  ─────                                  ──────────              ─────────────────────────
+//!  add_and_watch(spec) ───────────┐
+//!    oneshot::channel()           ├─► RegistryCommand::Add ─► Registry Handle.done ─┐
+//!    returns (id, TaskWaiter{rx}) │     (mpsc, guaranteed)                          │
+//!                                 │                                                 ▼
+//!  submit_and_watch(spec) ────────┘                              ┌─ report_join (cooperative join)
+//!    oneshot::channel()                                          │    Ok(Completed)  → Completed
+//!    Controller.watchers[id]=tx ──► admitted ─► start_in_slot ───┤    Ok(Exhausted)  → Failed
+//!    (parked until admitted or rejected)       hands tx to Add   │    Ok(Fatal)      → Fatal
+//!         │                                                      │    Ok(Canceled)   → Canceled
+//!         │                                                      │    Err(panic)     → Panicked
+//!         └─ never admitted ─► finalize_rejected ─► Rejected     └─ force-abort path → ForceAborted
+//! ```
+//!
+//! ## Rules
+//!
+//! - The outcome is delivered via `oneshot` (guaranteed, not subject to bus `Lagged` loss).
+//! - The channel is created **atomically with registration**: there is no window in which the task can finish before the waiter exists.
+//! - **Exactly-once by construction**: the sender has a single owner (the registry `Handle`, or the controller `watchers` map before admission);
+//!   ownership transfers to exactly one resolution site, so the waiter is resolved once and never leaks.
+//! - Dropping a [`TaskWaiter`] is always safe: the matching `send` becomes a no-op.
+//! - The outcome reflects the **final** attempt only; per-attempt results are observable via [`Subscribe`](crate::Subscribe) events.
+//! - `Rejected` is controller-only: a submission that is never admitted (slot busy, queue full, superseded, removed while queued, shutting down) resolves there.
+
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+
+use crate::error::RuntimeError;
+use crate::identity::TaskId;
+
+/// Final result of a supervised task run.
+///
+/// Delivered exactly once per task, after the actor has fully terminated (retry loop finished **and** the actor's `JoinHandle` joined).
+///
+/// ## `TaskOutcome` vs lifecycle events (one truth, two planes)
+///
+/// `TaskOutcome` is the **authoritative terminal classification** of a run; it is delivered on the guaranteed completion plane (a `oneshot`, immune to bus lag).
+/// The [`EventKind`](crate::EventKind) events on the lossy observability bus are the per-attempt narration of the *same* run - they may be dropped under load and
+/// a single `EventKind` (notably `ActorExhausted`) is intentionally reused for several terminal outcomes, discriminated only by its `reason` string.
+///
+/// When you need *the* final result, read the outcome; use events for live progress and metrics.
+///
+/// | `TaskOutcome`                        | Terminal event(s) on the bus                                          | Notes                                                    |
+/// |--------------------------------------|-----------------------------------------------------------------------|----------------------------------------------------------|
+/// | [`Completed`](Self::Completed)       | `ActorExhausted` (reason `policy_exhausted_success`)                  | success under `Never`/`OnFailure`                        |
+/// | [`Failed`](Self::Failed)             | `ActorExhausted` (reason = failure / `max_retries_exceeded(..)`)      | `reason`/`exit_code` are **byte-identical** to the event |
+/// | [`Fatal`](Self::Fatal)               | `ActorDead` (reason = fatal message)                                  | `reason`/`exit_code` byte-identical to the event         |
+/// | [`Canceled`](Self::Canceled)         | `TaskCanceled`, or `ActorExhausted` (reason `task_returned_canceled`) | cooperative stop                                         |
+/// | [`ForceAborted`](Self::ForceAborted) | `TaskRemoved` (reason `force_terminated_after_grace`)                 | ignored cancellation                                     |
+/// | [`Panicked`](Self::Panicked)         | `ActorDead` (reason `actor_panic`)                                    | actor-level panic (not a task-body panic)                |
+/// | [`Rejected`](Self::Rejected)         | `ControllerRejected` (reason = the same string)                       | never admitted; controller path only                     |
+///
+/// # Also
+///
+/// - [`SupervisorHandle::add_and_watch`](crate::SupervisorHandle::add_and_watch) - obtains a [`TaskWaiter`]
+/// - [`SupervisorHandle::submit_and_watch`](crate::SupervisorHandle::submit_and_watch) - controller-path waiter
+/// - [`RestartPolicy`](crate::RestartPolicy) / [`BackoffPolicy`](crate::BackoffPolicy) - decide how many attempts happen first
+/// - [`EventKind`](crate::EventKind) - per-attempt observability on the event bus
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskOutcome {
+    /// Final attempt succeeded and the restart policy did not require another run.
+    Completed,
+
+    /// Final attempt failed and no further retries were allowed (non-retryable error, `RestartPolicy::Never`, or `max_retries` exhausted).
+    Failed {
+        /// Final failure message (byte-identical to the `ActorExhausted` event reason).
+        reason: Arc<str>,
+        /// Numeric exit code from a process-like runtime; `None` for logical errors.
+        exit_code: Option<i32>,
+    },
+
+    /// Task returned [`TaskError::Fatal`](crate::TaskError::Fatal); no retries were attempted.
+    Fatal {
+        /// Fatal error message (byte-identical to the `ActorDead` event reason).
+        reason: Arc<str>,
+        /// Numeric exit code from a process-like runtime; `None` for logical errors.
+        exit_code: Option<i32>,
+    },
+
+    /// Task was canceled: shutdown, explicit [`remove`](crate::SupervisorHandle::remove)/
+    /// [`cancel`](crate::SupervisorHandle::cancel), or the task itself returned [`TaskError::Canceled`](crate::TaskError::Canceled).
+    Canceled,
+
+    /// Task ignored cooperative cancellation and was force-aborted after the grace period.
+    ForceAborted,
+
+    /// The actor itself panicked (a bug guard; panics in the **task body** are caught earlier and surface as [`Failed`](Self::Failed) after retries).
+    Panicked,
+
+    /// The submission was never admitted into a running task:
+    /// the slot was busy (`DropIfRunning`), the per-slot queue was full, the submission was superseded by a later `Replace`,
+    /// it was removed while still queued, or the controller was shutting down. **The task body never ran.**
+    ///
+    /// Only produced on the controller path ([`submit_and_watch`](crate::SupervisorHandle::submit_and_watch)).
+    Rejected {
+        /// Why admission was refused (matches the `ControllerRejected` event reason).
+        reason: Arc<str>,
+    },
+}
+
+impl TaskOutcome {
+    /// Returns `true` if the task finished successfully.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(self, TaskOutcome::Completed)
+    }
+
+    /// Stable machine-readable label (for metrics/logging).
+    #[must_use]
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            TaskOutcome::Completed => "outcome_completed",
+            TaskOutcome::Failed { .. } => "outcome_failed",
+            TaskOutcome::Fatal { .. } => "outcome_fatal",
+            TaskOutcome::Canceled => "outcome_canceled",
+            TaskOutcome::ForceAborted => "outcome_force_aborted",
+            TaskOutcome::Panicked => "outcome_panicked",
+            TaskOutcome::Rejected { .. } => "outcome_rejected",
+        }
+    }
+}
+
+/// Awaitable handle resolving to the [`TaskOutcome`] of a single task run.
+///
+/// Created by [`SupervisorHandle::add_and_watch`](crate::SupervisorHandle::add_and_watch).
+/// Consumed by [`wait`](Self::wait) (a task terminates exactly once, so the outcome is delivered exactly once).
+///
+/// ## Example
+/// ```rust,no_run
+/// # use std::time::Duration;
+/// # use taskvisor::prelude::*;
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+/// # let handle = sup.serve();
+/// let job: TaskRef = TaskFn::arc("job", |_ctx: CancellationToken| async { Ok(()) });
+/// let (id, waiter) = handle
+///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+///     .await?;
+///
+/// match waiter.wait().await? {
+///     TaskOutcome::Completed => println!("{id} done"),
+///     other => eprintln!("{id} ended with {other:?}"),
+/// }
+/// # Ok(()) }
+/// ```
+#[derive(Debug)]
+#[must_use = "a TaskWaiter does nothing unless awaited via `.wait()`"]
+pub struct TaskWaiter {
+    id: TaskId,
+    rx: oneshot::Receiver<TaskOutcome>,
+}
+
+impl TaskWaiter {
+    /// Creates a waiter for the given task identity (crate-internal).
+    pub(crate) fn new(id: TaskId, rx: oneshot::Receiver<TaskOutcome>) -> Self {
+        Self { id, rx }
+    }
+
+    /// Runtime identity of the task this waiter observes.
+    #[must_use]
+    pub fn id(&self) -> TaskId {
+        self.id
+    }
+
+    /// Waits for the task to fully terminate and returns its final outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError::ShuttingDown`] if the runtime dropped the sending half without resolving the outcome (registry stopped before the task was processed).
+    /// During a normal shutdown tasks resolve to [`TaskOutcome::Canceled`] / [`TaskOutcome::ForceAborted`] instead.
+    pub async fn wait(self) -> Result<TaskOutcome, RuntimeError> {
+        self.rx.await.map_err(|_| RuntimeError::ShuttingDown)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_stable_and_distinct() {
+        let outcomes = [
+            TaskOutcome::Completed,
+            TaskOutcome::Failed {
+                reason: Arc::from("x"),
+                exit_code: None,
+            },
+            TaskOutcome::Fatal {
+                reason: Arc::from("x"),
+                exit_code: Some(1),
+            },
+            TaskOutcome::Canceled,
+            TaskOutcome::ForceAborted,
+            TaskOutcome::Panicked,
+        ];
+        let labels: std::collections::HashSet<&str> =
+            outcomes.iter().map(|o| o.as_label()).collect();
+        assert_eq!(labels.len(), outcomes.len(), "labels must be distinct");
+    }
+
+    #[test]
+    fn only_completed_is_success() {
+        assert!(TaskOutcome::Completed.is_success());
+        assert!(!TaskOutcome::Canceled.is_success());
+        assert!(!TaskOutcome::Panicked.is_success());
+    }
+
+    #[tokio::test]
+    async fn waiter_resolves_with_sent_outcome() {
+        let (tx, rx) = oneshot::channel();
+        let waiter = TaskWaiter::new(TaskId::next(), rx);
+        tx.send(TaskOutcome::Completed).unwrap();
+        assert_eq!(waiter.wait().await.unwrap(), TaskOutcome::Completed);
+    }
+
+    #[tokio::test]
+    async fn waiter_maps_dropped_sender_to_shutting_down() {
+        let (tx, rx) = oneshot::channel::<TaskOutcome>();
+        let waiter = TaskWaiter::new(TaskId::next(), rx);
+        drop(tx);
+        assert!(matches!(
+            waiter.wait().await,
+            Err(RuntimeError::ShuttingDown)
+        ));
+    }
+}

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -26,22 +26,23 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
+use tokio::sync::{Notify, RwLock, Semaphore, mpsc, oneshot};
 use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use crate::core::actor::{ActorExitReason, TaskActor, TaskActorParams};
+use crate::core::outcome::TaskOutcome;
 use crate::events::{Bus, Event, EventKind};
 use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
+/// One-shot sender resolving a [`TaskWaiter`](crate::TaskWaiter) with the final outcome.
+pub(crate) type OutcomeTx = oneshot::Sender<TaskOutcome>;
+
 /// Command sent via guaranteed-delivery channel (mpsc).
-///
-/// Separated from the broadcast bus to ensure control commands are never lost to `Lagged`.
-/// The Supervisor publishes observability events on the bus before sending the command.
 pub(crate) enum RegistryCommand {
-    /// Add a new task with its runtime identity.
-    Add(TaskId, TaskSpec),
+    /// Add a new task with its runtime identity and an optional outcome watcher.
+    Add(TaskId, TaskSpec, Option<OutcomeTx>),
     /// Remove a task by its runtime identity. Supervisor publishes `TaskRemoveRequested` first.
     Remove(TaskId),
 }
@@ -50,6 +51,7 @@ struct Handle {
     join: JoinHandle<ActorExitReason>,
     cancel: CancellationToken,
     label: Arc<str>,
+    done: Option<OutcomeTx>,
 }
 
 /// Registry maps held under a single lock so identity and label stay consistent.
@@ -180,8 +182,8 @@ impl Registry {
                     _ = rt.cancelled() => break,
 
                     cmd = cmd_rx.recv() => match cmd {
-                        Some(RegistryCommand::Add(id, spec)) => {
-                            me.spawn_and_register(id, spec).await;
+                        Some(RegistryCommand::Add(id, spec, done)) => {
+                            me.spawn_and_register(id, spec, done).await;
                         }
                         Some(RegistryCommand::Remove(id)) => {
                             me.remove_task(id).await;
@@ -280,12 +282,15 @@ impl Registry {
             match tokio::time::timeout_at(deadline, &mut join).await {
                 Ok(res) => {
                     Self::pending_dec(&self.pending_joins, id);
-                    Self::report_join(&self.bus, id, &label, res);
+                    Self::report_join(&self.bus, id, &label, res, h.done);
                 }
                 Err(_elapsed) => {
                     join.abort();
                     let _ = join.await;
                     Self::pending_dec(&self.pending_joins, id);
+                    if let Some(done) = h.done {
+                        let _ = done.send(TaskOutcome::ForceAborted);
+                    }
                     self.bus.publish(
                         Event::new(EventKind::TaskRemoved)
                             .with_task(Arc::clone(&label))
@@ -300,12 +305,16 @@ impl Registry {
     }
 
     /// Spawns an actor and registers its handle under the given runtime identity.
-    async fn spawn_and_register(&self, id: TaskId, spec: TaskSpec) {
+    ///
+    /// On a duplicate label the optional `done` sender is dropped, which resolves a pending [`TaskWaiter`](crate::TaskWaiter) with `RuntimeError::ShuttingDown`;
+    /// `add_and_watch` callers never observe that, because they see `TaskAddFailed` first and the waiter is discarded before being handed out.
+    async fn spawn_and_register(&self, id: TaskId, spec: TaskSpec, done: Option<OutcomeTx>) {
         let label: Arc<str> = Arc::from(spec.task().name());
 
         let mut st = self.state.write().await;
         if st.by_label.contains_key(&label) {
             drop(st);
+            drop(done);
             self.bus.publish(
                 Event::new(EventKind::TaskAddFailed)
                     .with_task(label)
@@ -339,6 +348,7 @@ impl Registry {
                 join: join_handle,
                 cancel: task_token,
                 label: label.clone(),
+                done,
             },
         );
         st.by_label.insert(label.clone(), id);
@@ -358,7 +368,7 @@ impl Registry {
             self.notify_after_remove(len_after);
 
             handle.cancel.cancel();
-            self.spawn_join_report(id, handle.label, handle.join, Some(self.grace));
+            self.spawn_join_report(id, handle.label, handle.join, Some(self.grace), handle.done);
         } else {
             Self::pending_dec(&self.pending_joins, id);
             self.bus.publish(
@@ -374,7 +384,7 @@ impl Registry {
         Self::pending_inc(&self.pending_joins, id);
         if let Some((handle, len_after)) = self.take_handle(id).await {
             self.notify_after_remove(len_after);
-            self.spawn_join_report(id, handle.label, handle.join, None);
+            self.spawn_join_report(id, handle.label, handle.join, None, handle.done);
         } else {
             Self::pending_dec(&self.pending_joins, id);
         }
@@ -396,6 +406,7 @@ impl Registry {
         name: Arc<str>,
         join: JoinHandle<ActorExitReason>,
         force_after: Option<Duration>,
+        done: Option<OutcomeTx>,
     ) {
         let bus = self.bus.clone();
         let pending = Arc::clone(&self.pending_joins);
@@ -405,12 +416,15 @@ impl Registry {
                 Some(grace) => match tokio::time::timeout(grace, &mut join).await {
                     Ok(res) => {
                         Self::pending_dec(&pending, id);
-                        Self::report_join(&bus, id, &name, res);
+                        Self::report_join(&bus, id, &name, res, done);
                     }
                     Err(_) => {
                         join.abort();
                         let _ = join.await;
                         Self::pending_dec(&pending, id);
+                        if let Some(done) = done {
+                            let _ = done.send(TaskOutcome::ForceAborted);
+                        }
                         bus.publish(
                             Event::new(EventKind::TaskRemoved)
                                 .with_task(name)
@@ -422,7 +436,7 @@ impl Registry {
                 None => {
                     let res = join.await;
                     Self::pending_dec(&pending, id);
-                    Self::report_join(&bus, id, &name, res);
+                    Self::report_join(&bus, id, &name, res, done);
                 }
             }
         });
@@ -444,9 +458,14 @@ impl Registry {
     }
 
     /// Publish terminal events for a joined actor: `ActorDead` if it panicked, then always `TaskRemoved`.
-    /// A cancelled (force-aborted) join is not a panic.
-    fn report_join(bus: &Bus, id: TaskId, name: &str, res: Result<ActorExitReason, JoinError>) {
-        if let Err(e) = res
+    fn report_join(
+        bus: &Bus,
+        id: TaskId,
+        name: &str,
+        res: Result<ActorExitReason, JoinError>,
+        done: Option<OutcomeTx>,
+    ) {
+        if let Err(e) = &res
             && e.is_panic()
         {
             bus.publish(
@@ -456,11 +475,30 @@ impl Registry {
                     .with_reason("actor_panic"),
             );
         }
+        if let Some(done) = done {
+            let _ = done.send(Self::outcome_of(res));
+        }
         bus.publish(
             Event::new(EventKind::TaskRemoved)
                 .with_task(name)
                 .with_id(id),
         );
+    }
+
+    /// Maps a joined actor result to the public [`TaskOutcome`].
+    fn outcome_of(res: Result<ActorExitReason, JoinError>) -> TaskOutcome {
+        match res {
+            Ok(ActorExitReason::Completed) => TaskOutcome::Completed,
+            Ok(ActorExitReason::Canceled) => TaskOutcome::Canceled,
+            Ok(ActorExitReason::Exhausted { reason, exit_code }) => {
+                TaskOutcome::Failed { reason, exit_code }
+            }
+            Ok(ActorExitReason::Fatal { reason, exit_code }) => {
+                TaskOutcome::Fatal { reason, exit_code }
+            }
+            Err(e) if e.is_panic() => TaskOutcome::Panicked,
+            Err(_aborted) => TaskOutcome::ForceAborted,
+        }
     }
 }
 
@@ -479,7 +517,7 @@ mod tests {
     async fn reap_finished_removes_completed_handles() {
         let reg = registry();
 
-        let join = tokio::spawn(async { ActorExitReason::PolicyExhausted });
+        let join = tokio::spawn(async { ActorExitReason::Completed });
         while !join.is_finished() {
             tokio::task::yield_now().await;
         }
@@ -489,6 +527,7 @@ mod tests {
                 join,
                 cancel: CancellationToken::new(),
                 label: Arc::from("done"),
+                done: None,
             },
         );
         assert!(!reg.is_empty().await);
@@ -508,7 +547,7 @@ mod tests {
         let child = cancel.clone();
         let join = tokio::spawn(async move {
             child.cancelled().await;
-            ActorExitReason::Cancelled
+            ActorExitReason::Canceled
         });
         reg.state.write().await.tasks.insert(
             TaskId::next(),
@@ -516,6 +555,7 @@ mod tests {
                 join,
                 cancel,
                 label: Arc::from("running"),
+                done: None,
             },
         );
 

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -12,7 +12,7 @@
 //!   task.spawn() ─► Ok(()) ─► publish TaskStopped
 //!
 //! Cancellation:
-//!   task.spawn() ─► Err(Canceled) ─► publish TaskStopped (graceful exit)
+//!   task.spawn() ─► Err(Canceled) ─► publish TaskCanceled (graceful exit)
 //!
 //! Failure:
 //!   task.spawn() ─► Err(Fail/Fatal) ─► publish TaskFailed
@@ -29,9 +29,9 @@
 //! ## Rules
 //!
 //! - `TimeoutHit` is an **informational** event published **before** `TaskFailed` on timeout *(it is not a terminal event itself)*
-//! - `Canceled` is treated as graceful exit → `TaskStopped` (not `TaskFailed`).
+//! - `Canceled` is treated as graceful exit → `TaskCanceled` (not `TaskFailed`).
 //! - A **panic** in the task body (or in `spawn()` itself) is caught and converted to a retryable [`TaskError::Fail`] with reason `task panicked: ...` - restart policy applies.
-//! - Always publishes **exactly one** terminal event per attempt: `TaskStopped` or `TaskFailed`.
+//! - Always publishes **exactly one** terminal event per attempt: `TaskStopped`, `TaskCanceled`, or `TaskFailed`.
 //! - Derives **child token** per attempt (isolated cancellation).
 //! - Child cancellation does **not** affect parent.
 
@@ -102,13 +102,13 @@ fn panic_to_error(payload: &(dyn std::any::Any + Send)) -> TaskError {
 ///
 /// - Parent cancellation propagates to child token
 /// - Task **should** return `Err(TaskError::Canceled)` when detecting cancellation
-/// - `Canceled` is treated as **graceful exit**, publishes `TaskStopped` (not `TaskFailed`)
+/// - `Canceled` is treated as **graceful exit**, publishes `TaskCanceled` (not `TaskFailed`)
 /// - Child cancellation does **not** affect parent (isolated per attempt)
 ///
 /// ### Event semantics
 ///
 /// Always publishes **exactly one** terminal event per attempt:
-/// - `TaskStopped` on `Ok(())` or `Err(Canceled)` (graceful completion)
+/// - `TaskStopped` on `Ok(())`, `TaskCanceled` on `Err(Canceled)` (graceful exits)
 /// - `TaskFailed` on `Err(Fail/Fatal/Timeout)` (actual errors)
 ///
 /// `TimeoutHit` is informational and published **before** `TaskFailed` on timeout.
@@ -146,11 +146,11 @@ pub async fn run_once<T: Task + ?Sized>(
 
     match res {
         Ok(()) => {
-            publish_stopped(bus, id, task.name());
+            publish_stopped(bus, id, task.name(), attempt);
             Ok(())
         }
         Err(TaskError::Canceled) => {
-            publish_stopped(bus, id, task.name());
+            publish_canceled(bus, id, task.name(), attempt);
             Err(TaskError::Canceled)
         }
         Err(e) => {
@@ -160,12 +160,27 @@ pub async fn run_once<T: Task + ?Sized>(
     }
 }
 
-/// Publishes `TaskStopped` event (success or graceful cancellation).
-fn publish_stopped(bus: &Bus, id: TaskId, name: &str) {
+/// Publishes `TaskStopped` event.
+///
+/// successful attempt.
+fn publish_stopped(bus: &Bus, id: TaskId, name: &str, attempt: u32) {
     bus.publish(
         Event::new(EventKind::TaskStopped)
             .with_task(name)
-            .with_id(id),
+            .with_id(id)
+            .with_attempt(attempt),
+    );
+}
+
+/// Publishes `TaskCanceled` event.
+///
+/// graceful cancellation of an attempt.
+fn publish_canceled(bus: &Bus, id: TaskId, name: &str, attempt: u32) {
+    bus.publish(
+        Event::new(EventKind::TaskCanceled)
+            .with_task(name)
+            .with_id(id)
+            .with_attempt(attempt),
     );
 }
 
@@ -182,7 +197,9 @@ fn publish_failed(bus: &Bus, id: TaskId, name: &str, attempt: u32, err: &TaskErr
     bus.publish(ev);
 }
 
-/// Publishes `TimeoutHit` event (always followed by `TaskFailed`).
+/// Publishes `TimeoutHit` event.
+///
+/// always followed by `TaskFailed`.
 fn publish_timeout(bus: &Bus, id: TaskId, name: &str, dur: Duration, attempt: u32) {
     bus.publish(
         Event::new(EventKind::TimeoutHit)
@@ -264,6 +281,27 @@ mod tests {
                 panic!("expected TaskError::Timeout, got: {other:?}");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_success_publishes_stopped_with_attempt() {
+        let bus = Bus::new(16);
+        let mut rx = bus.subscribe();
+        let parent = CancellationToken::new();
+
+        let _ = run_once(&OkTask, &parent, None, 3, TaskId::next(), &bus).await;
+
+        let mut stopped_attempt = None;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, EventKind::TaskStopped) {
+                stopped_attempt = ev.attempt;
+            }
+        }
+        assert_eq!(
+            stopped_attempt,
+            Some(3),
+            "TaskStopped must carry the attempt number"
+        );
     }
 
     #[tokio::test]

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -238,11 +238,16 @@ impl Supervisor {
     }
 
     /// Adds a new task to the supervisor at runtime, returning its minted [`TaskId`].
-    ///
-    /// Mints the runtime identity, publishes `TaskAddRequested` on bus (observability, fire-and-forget),
-    /// then sends the `Add` command via mpsc (guaranteed delivery).
     pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        let id = TaskId::next();
+        self.add_task_with_id(TaskId::next(), spec)
+    }
+
+    /// Adds a task under a **pre-minted** identity.
+    pub(crate) fn add_task_with_id(
+        &self,
+        id: TaskId,
+        spec: TaskSpec,
+    ) -> Result<TaskId, RuntimeError> {
         self.bus.publish(
             Event::new(EventKind::TaskAddRequested)
                 .with_task(spec.task().name())
@@ -408,24 +413,24 @@ impl Supervisor {
         self.wait_task_removed(&mut rx, id, wait_for).await
     }
 
-    /// Submits a task to the controller (if enabled).
+    /// Submits a task to the controller (if enabled), returning the pre-minted [`TaskId`].
     #[cfg(feature = "controller")]
     pub(crate) async fn submit(
         &self,
         spec: crate::controller::ControllerSpec,
-    ) -> Result<(), crate::controller::ControllerError> {
+    ) -> Result<TaskId, crate::controller::ControllerError> {
         match self.controller.get() {
             Some(ctrl) => ctrl.handle().submit(spec).await,
             None => Err(crate::controller::ControllerError::NotConfigured),
         }
     }
 
-    /// Tries to submit a task without blocking.
+    /// Tries to submit a task without blocking, returning the pre-minted [`TaskId`].
     #[cfg(feature = "controller")]
     pub(crate) fn try_submit(
         &self,
         spec: crate::controller::ControllerSpec,
-    ) -> Result<(), crate::controller::ControllerError> {
+    ) -> Result<TaskId, crate::controller::ControllerError> {
         match self.controller.get() {
             Some(ctrl) => ctrl.handle().try_submit(spec),
             None => Err(crate::controller::ControllerError::NotConfigured),

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -1,7 +1,6 @@
 //! # Supervisor: orchestrates task actors and graceful shutdown.
 //!
-//! The [`Supervisor`] owns the runtime components and orchestrates task execution lifecycle
-//! from spawn to graceful termination.
+//! The [`Supervisor`] owns the runtime components and orchestrates task execution lifecycle from spawn to graceful termination.
 //!
 //! - Spawn task actors via event-driven registry
 //! - Dynamically add/remove tasks at runtime via events
@@ -239,14 +238,36 @@ impl Supervisor {
 
     /// Adds a new task to the supervisor at runtime, returning its minted [`TaskId`].
     pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        self.add_task_with_id(TaskId::next(), spec)
+        self.add_task_inner(TaskId::next(), spec, None)
     }
 
-    /// Adds a task under a **pre-minted** identity.
-    pub(crate) fn add_task_with_id(
+    /// Adds a task under a **pre-minted** identity with an optional outcome watcher.
+    #[cfg(feature = "controller")]
+    pub(crate) fn add_task_with_id_watched(
         &self,
         id: TaskId,
         spec: TaskSpec,
+        done: Option<crate::core::registry::OutcomeTx>,
+    ) -> Result<TaskId, RuntimeError> {
+        self.add_task_inner(id, spec, done)
+    }
+
+    /// Adds a new task and returns a `oneshot` receiver resolving to its final [`TaskOutcome`](crate::TaskOutcome).
+    pub(crate) fn add_task_watched(
+        &self,
+        spec: TaskSpec,
+    ) -> Result<(TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>), RuntimeError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let id = self.add_task_inner(TaskId::next(), spec, Some(tx))?;
+        Ok((id, rx))
+    }
+
+    /// Publishes `TaskAddRequested` and sends the `Add` command with an optional outcome watcher.
+    fn add_task_inner(
+        &self,
+        id: TaskId,
+        spec: TaskSpec,
+        done: Option<crate::core::registry::OutcomeTx>,
     ) -> Result<TaskId, RuntimeError> {
         self.bus.publish(
             Event::new(EventKind::TaskAddRequested)
@@ -254,15 +275,12 @@ impl Supervisor {
                 .with_id(id),
         );
         self.cmd_tx
-            .send(RegistryCommand::Add(id, spec))
+            .send(RegistryCommand::Add(id, spec, done))
             .map_err(|_| RuntimeError::ShuttingDown)?;
         Ok(id)
     }
 
     /// Removes a task from the supervisor at runtime, by its runtime identity.
-    ///
-    /// Publishes `TaskRemoveRequested` on bus (observability, fire-and-forget),
-    /// then sends the `Remove` command via mpsc (guaranteed delivery).
     pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
         self.bus
             .publish(Event::new(EventKind::TaskRemoveRequested).with_id(id));
@@ -433,6 +451,21 @@ impl Supervisor {
     ) -> Result<TaskId, crate::controller::ControllerError> {
         match self.controller.get() {
             Some(ctrl) => ctrl.handle().try_submit(spec),
+            None => Err(crate::controller::ControllerError::NotConfigured),
+        }
+    }
+
+    /// Submits a task to the controller and returns a watcher for its final outcome.
+    #[cfg(feature = "controller")]
+    pub(crate) async fn submit_and_watch(
+        &self,
+        spec: crate::controller::ControllerSpec,
+    ) -> Result<
+        (TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>),
+        crate::controller::ControllerError,
+    > {
+        match self.controller.get() {
+            Some(ctrl) => ctrl.handle().submit_and_watch(spec).await,
             None => Err(crate::controller::ControllerError::NotConfigured),
         }
     }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -90,13 +90,23 @@ pub enum EventKind {
     /// - `seq`: global sequence
     TaskStarting,
 
-    /// Task has stopped (finished successfully **or** was cancelled gracefully).
+    /// Task attempt finished successfully.
     ///
     /// Sets:
     /// - `task`: task name
+    /// - `attempt`: attempt number
     /// - `at`: wall-clock timestamp
     /// - `seq`: global sequence
     TaskStopped,
+
+    /// Task attempt exited via graceful cancellation (`TaskError::Canceled` returned while its token was cancelled).
+    ///
+    /// Sets:
+    /// - `task`: task name
+    /// - `attempt`: attempt number
+    /// - `at`: wall-clock timestamp
+    /// - `seq`: global sequence
+    TaskCanceled,
 
     /// Task failed with a (non-fatal) error for this attempt.
     ///
@@ -210,11 +220,12 @@ pub enum EventKind {
     ActorDead,
 
     #[cfg(feature = "controller")]
-    /// Controller submission rejected (queue full, add failed, etc).
+    /// Controller submission rejected (queue full, add failed, superseded, etc).
     ///
     /// Sets:
     /// - `task`: slot name
-    /// - `reason`: rejection reason ("queue_full", "add_failed: ...", etc)
+    /// - `id`: the rejected submission's [`TaskId`]
+    /// - `reason`: rejection reason ("queue_full", "add_failed: ...", "superseded_by_replace", "controller_shutting_down", etc)
     ControllerRejected,
 
     #[cfg(feature = "controller")]
@@ -222,6 +233,7 @@ pub enum EventKind {
     ///
     /// Sets:
     /// - `task`: slot name
+    /// - `id`: the submission's [`TaskId`]
     /// - `reason`: "admission={admission} status={status} depth={N}"
     ControllerSubmitted,
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -34,6 +34,12 @@ impl TaskId {
     pub fn get(self) -> u64 {
         self.0
     }
+
+    /// `TaskId` from its raw value.
+    #[inline]
+    pub fn from_raw(raw: u64) -> Self {
+        TaskId(raw)
+    }
 }
 
 impl std::fmt::Display for TaskId {
@@ -57,5 +63,12 @@ mod tests {
     #[test]
     fn never_mints_zero() {
         assert!(TaskId::next().get() >= 1);
+    }
+
+    #[test]
+    fn from_raw_round_trips() {
+        let id = TaskId::from_raw(42);
+        assert_eq!(id.get(), 42);
+        assert_eq!(id, TaskId::from_raw(42));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@
 //!
 //! **Taskvisor** is a lightweight task orchestration library for Rust.
 //!
-//! It provides primitives to define, supervise, and restart async tasks
-//! with configurable policies. The crate is designed as a building block
-//! for higher-level orchestrators and agents.
+//! It provides primitives to define, supervise, and restart async tasks with configurable policies.
+//! The crate is designed as a building block for higher-level orchestrators and agents.
 //!
 //! ## Architecture
 //! ### Overview
@@ -96,6 +95,7 @@
 //! | **Subscriber API**| Hook into task lifecycle events (logging, metrics, custom subscribers).| [`Subscribe`]                          |
 //! | **Policies**      | Configure restart/backoff strategies for tasks.                        | [`RestartPolicy`], [`BackoffPolicy`]   |
 //! | **Supervision**   | Manage groups of tasks and their lifecycle.                            | [`Supervisor`], [`SupervisorHandle`]   |
+//! | **Completion**    | Opt in (via `*_and_watch`) to await a task's final result.             | [`TaskWaiter`], [`TaskOutcome`]        |
 //! | **Errors**        | Typed errors for orchestration and task execution.                     | [`TaskError`], [`RuntimeError`]        |
 //! | **Tasks**         | Define tasks as functions or specs, easy to compose and run.           | [`TaskRef`], [`TaskFn`], [`TaskSpec`]  |
 //! | **Configuration** | Centralize runtime settings.                                           | [`SupervisorConfig`]                   |
@@ -142,7 +142,9 @@ mod identity;
 pub use identity::TaskId;
 
 mod core;
-pub use core::{Supervisor, SupervisorBuilder, SupervisorConfig, SupervisorHandle};
+pub use core::{
+    Supervisor, SupervisorBuilder, SupervisorConfig, SupervisorHandle, TaskOutcome, TaskWaiter,
+};
 
 mod tasks;
 pub use tasks::{BoxTaskFuture, Task, TaskFn, TaskRef, TaskSpec};

--- a/src/policies/backoff.rs
+++ b/src/policies/backoff.rs
@@ -1,6 +1,7 @@
 //! # Backoff policy for retrying tasks.
 //!
 //! [`BackoffPolicy`] controls how retry delays grow after repeated failures.
+//! 
 //! It is parameterized by:
 //! - [`BackoffPolicy::factor`] the multiplicative growth factor.
 //! - [`BackoffPolicy::first`] the initial delay.

--- a/src/policies/backoff.rs
+++ b/src/policies/backoff.rs
@@ -1,7 +1,7 @@
 //! # Backoff policy for retrying tasks.
 //!
 //! [`BackoffPolicy`] controls how retry delays grow after repeated failures.
-//! 
+//!
 //! It is parameterized by:
 //! - [`BackoffPolicy::factor`] the multiplicative growth factor.
 //! - [`BackoffPolicy::first`] the initial delay.

--- a/src/policies/jitter.rs
+++ b/src/policies/jitter.rs
@@ -58,9 +58,8 @@ impl Default for JitterPolicy {
 impl JitterPolicy {
     /// Applies jitter to the given delay.
     ///
-    /// `Decorrelated` has no previous-delay context here, so it falls back to **full jitter**
-    /// (random in `[0, delay]`) rather than silently returning the input. For the true
-    /// decorrelated recurrence use [`apply_decorrelated`](Self::apply_decorrelated).
+    /// `Decorrelated` has no previous-delay context here, so it falls back to **full jitter** (random in `[0, delay]`) rather than silently returning the input.
+    /// For the true decorrelated recurrence use [`apply_decorrelated`](Self::apply_decorrelated).
     #[must_use]
     pub fn apply(&self, delay: Duration) -> Duration {
         match self {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,9 @@
 //! ```
 
 // Core
-pub use crate::core::{Supervisor, SupervisorBuilder, SupervisorConfig, SupervisorHandle};
+pub use crate::core::{
+    Supervisor, SupervisorBuilder, SupervisorConfig, SupervisorHandle, TaskOutcome, TaskWaiter,
+};
 
 // Tasks
 pub use crate::tasks::{BoxTaskFuture, Task, TaskFn, TaskRef, TaskSpec};

--- a/src/subscribers/embedded/log.rs
+++ b/src/subscribers/embedded/log.rs
@@ -93,6 +93,9 @@ impl LogWriter {
             EventKind::TaskStopped => {
                 println!("{} [stopped] task={}", seq, or(e.task.as_deref(), "none"));
             }
+            EventKind::TaskCanceled => {
+                println!("{} [canceled] task={}", seq, or(e.task.as_deref(), "none"));
+            }
             EventKind::TaskFailed => {
                 println!(
                     "{} [failed] task={} reason=\"{}\" attempt={}",

--- a/src/subscribers/subscriber.rs
+++ b/src/subscribers/subscriber.rs
@@ -16,8 +16,7 @@
 //!
 //! ## Rules
 //!
-//! - Queue overflow drops the event **for this subscriber only** and publishes`EventKind::SubscriberOverflow`;
-//!   other subscribers are unaffected.
+//! - Queue overflow drops the event **for this subscriber only** and publishes`EventKind::SubscriberOverflow`; other subscribers are unaffected.
 //! - Events are processed sequentially (FIFO) per subscriber.
 //! - Subscribers do not block publishers or each other.
 //! - A slow subscriber only affects its own queue.

--- a/src/tasks/task.rs
+++ b/src/tasks/task.rs
@@ -44,13 +44,11 @@ pub type TaskRef = Arc<dyn Task>;
 pub trait Task: Send + Sync + 'static {
     /// Task name used in logs, metrics, and shutdown diagnostics.
     ///
-    /// Names must be unique among **currently registered** tasks (a duplicate add is rejected),
-    /// but may be reused after the previous holder is removed.
+    /// Names must be unique among **currently registered** tasks (a duplicate add is rejected), but may be reused after the previous holder is removed.
     fn name(&self) -> &str;
 
     /// Creates a new future that runs the task until completion or cancellation.
     ///
-    /// Called once per attempt. Takes `&self` - each call must return an
-    /// independent future with no side effects from previous runs.
+    /// Called once per attempt. Takes `&self` - each call must return an independent future with no side effects from previous runs.
     fn spawn(&self, ctx: CancellationToken) -> BoxTaskFuture;
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -35,6 +35,152 @@ fn logging_once(name: &str, log: Arc<Mutex<Vec<String>>>) -> TaskRef {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn submit_returns_task_id_carried_by_events() {
+    let (handle, collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        let id = handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("id-task")).with_slot("s"),
+            ))
+            .await
+            .expect("submit ok");
+
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                collector
+                    .find_all(EventKind::TaskAdded)
+                    .iter()
+                    .any(|e| e.id == Some(id))
+            })
+            .await,
+            "TaskAdded must carry the id returned by submit()"
+        );
+        assert!(
+            collector
+                .find_all(EventKind::ControllerSubmitted)
+                .iter()
+                .any(|e| e.id == Some(id)),
+            "ControllerSubmitted must carry the submitted id"
+        );
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejected_submission_event_carries_its_id() {
+    let (handle, collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("occupant-rej")).with_slot("s"),
+            ))
+            .await
+            .expect("first submit ok");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                handle.is_alive("occupant-rej").await
+            })
+            .await
+        );
+
+        let rejected_id = handle
+            .submit(ControllerSpec::drop_if_running(
+                TaskSpec::restartable(make_coop("dropped")).with_slot("s"),
+            ))
+            .await
+            .expect("submit accepted into channel");
+
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                collector
+                    .find_all(EventKind::ControllerRejected)
+                    .iter()
+                    .any(|e| e.id == Some(rejected_id))
+            })
+            .await,
+            "ControllerRejected must carry the id of the dropped submission"
+        );
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn remove_of_queued_submission_purges_it_before_start() {
+    let (handle, collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("occupant-q")).with_slot("s"),
+            ))
+            .await
+            .expect("first submit ok");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                handle.is_alive("occupant-q").await
+            })
+            .await
+        );
+
+        let victim_id = handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("queued-victim")).with_slot("s"),
+            ))
+            .await
+            .expect("second submit ok");
+
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                collector
+                    .find_all(EventKind::ControllerSubmitted)
+                    .iter()
+                    .any(|e| e.id == Some(victim_id))
+            })
+            .await,
+            "queued submission must be confirmed before removal"
+        );
+
+        handle.remove(victim_id).expect("remove accepted");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                collector
+                    .find_all(EventKind::ControllerRejected)
+                    .iter()
+                    .any(|e| {
+                        e.id == Some(victim_id) && e.reason.as_deref() == Some("removed_from_queue")
+                    })
+            })
+            .await,
+            "controller must confirm the queued spec was purged"
+        );
+
+        assert!(
+            handle
+                .cancel_by_label("occupant-q")
+                .await
+                .expect("cancel occupant")
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            collector
+                .by_label("queued-victim")
+                .iter()
+                .all(|e| e.kind != EventKind::TaskStarting),
+            "a removed queued submission must never start"
+        );
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn shutdown_does_not_start_queued_tasks() {
     let (handle, collector) = served_controller(ControllerConfig::default());
 
@@ -119,7 +265,7 @@ async fn idle_submit_admits_emits_submitted_then_running_transition() {
     let (handle, collector) = served_controller(ControllerConfig::default());
     with_timeout(10, async {
         let spec = TaskSpec::restartable(make_coop("runner-7")).with_slot("web");
-        handle.submit(ControllerSpec::queue(spec)).await.unwrap();
+        let id = handle.submit(ControllerSpec::queue(spec)).await.unwrap();
 
         assert!(
             poll_until(Duration::from_secs(3), || async {
@@ -139,18 +285,20 @@ async fn idle_submit_admits_emits_submitted_then_running_transition() {
                     .is_some_and(|r| r.contains("status=admitting"))
         }));
         for e in collector.by_label("web") {
-            if matches!(
-                e.kind,
-                EventKind::ControllerSubmitted | EventKind::ControllerSlotTransition
-            ) {
-                assert_eq!(e.id, None, "controller events must not carry a TaskId");
+            if e.kind == EventKind::ControllerSubmitted {
+                assert_eq!(
+                    e.id,
+                    Some(id),
+                    "ControllerSubmitted must carry the submission TaskId"
+                );
             }
         }
         assert!(
             collector
                 .by_label("runner-7")
                 .iter()
-                .any(|e| { e.kind == EventKind::TaskStarting && e.id.is_some() })
+                .any(|e| { e.kind == EventKind::TaskStarting && e.id == Some(id) }),
+            "the lifecycle must run under the id minted at submit()"
         );
 
         let _ = handle.shutdown().await;

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -35,6 +35,118 @@ fn logging_once(name: &str, log: Arc<Mutex<Vec<String>>>) -> TaskRef {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn submit_and_watch_resolves_completed_for_admitted_task() {
+    let (handle, _collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        let (id, waiter) = handle
+            .submit_and_watch(ControllerSpec::queue(
+                TaskSpec::once(make_ok_once("watched-ok")).with_slot("s"),
+            ))
+            .await
+            .expect("submit_and_watch ok");
+        assert_eq!(waiter.id(), id);
+
+        let outcome = waiter.wait().await.expect("waiter errored");
+        assert_eq!(
+            outcome,
+            TaskOutcome::Completed,
+            "an admitted task that succeeds must resolve Completed"
+        );
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn submit_and_watch_resolves_rejected_on_drop_if_running() {
+    let (handle, _collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("occupant-w")).with_slot("s"),
+            ))
+            .await
+            .expect("first submit ok");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                handle.is_alive("occupant-w").await
+            })
+            .await
+        );
+
+        let (_id, waiter) = handle
+            .submit_and_watch(ControllerSpec::drop_if_running(
+                TaskSpec::restartable(make_coop("dropped-w")).with_slot("s"),
+            ))
+            .await
+            .expect("submit_and_watch accepted into channel");
+
+        match waiter.wait().await.expect("waiter errored") {
+            TaskOutcome::Rejected { reason } => {
+                assert!(
+                    reason.contains("dropped"),
+                    "rejection reason must explain why: {reason}"
+                );
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn submit_and_watch_resolves_rejected_when_removed_from_queue() {
+    let (handle, collector) = served_controller(ControllerConfig::default());
+
+    with_timeout(10, async {
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("occupant-rm")).with_slot("s"),
+            ))
+            .await
+            .expect("first submit ok");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                handle.is_alive("occupant-rm").await
+            })
+            .await
+        );
+
+        let (victim_id, waiter) = handle
+            .submit_and_watch(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("queued-victim-w")).with_slot("s"),
+            ))
+            .await
+            .expect("queued submit_and_watch ok");
+        assert!(
+            poll_until(Duration::from_secs(2), || async {
+                collector
+                    .find_all(EventKind::ControllerSubmitted)
+                    .iter()
+                    .any(|e| e.id == Some(victim_id))
+            })
+            .await
+        );
+        handle.remove(victim_id).expect("remove accepted");
+
+        match waiter.wait().await.expect("waiter errored") {
+            TaskOutcome::Rejected { reason } => {
+                assert_eq!(&*reason, "removed_from_queue");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+
+        handle.shutdown().await.expect("shutdown ok");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn submit_returns_task_id_carried_by_events() {
     let (handle, collector) = served_controller(ControllerConfig::default());
 

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -205,7 +205,7 @@ async fn cooperative_cancellation_returning_ok_yields_task_stopped() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn cancellation_returning_canceled_error_still_task_stopped() {
+async fn cancellation_returning_canceled_error_yields_task_canceled() {
     let collector = EventCollector::new();
     let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
     let sup = Supervisor::builder(SupervisorConfig {
@@ -240,7 +240,14 @@ async fn cancellation_returning_canceled_error_still_task_stopped() {
         );
 
         let by_id = collector.by_id(id);
-        assert!(by_id.iter().any(|e| e.kind == EventKind::TaskStopped));
+        assert!(
+            by_id.iter().any(|e| e.kind == EventKind::TaskCanceled),
+            "graceful cancellation must surface as TaskCanceled"
+        );
+        assert!(
+            by_id.iter().all(|e| e.kind != EventKind::TaskStopped),
+            "TaskStopped is reserved for successful attempts"
+        );
         assert!(by_id.iter().all(|e| e.kind != EventKind::TaskFailed));
         assert!(by_id.iter().all(|e| e.kind != EventKind::ActorExhausted));
         assert!(by_id.iter().all(|e| e.kind != EventKind::ActorDead));

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -1,0 +1,391 @@
+//! Integration tests for `add_and_watch` / `TaskWaiter`.
+
+mod common;
+
+use std::time::Duration;
+
+use common::*;
+use taskvisor::prelude::*;
+
+const ADD_TIMEOUT: Duration = Duration::from_secs(1);
+
+fn supervisor() -> (std::sync::Arc<Supervisor>, SupervisorHandle) {
+    let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+    let handle = sup.serve();
+    (sup, handle)
+}
+
+#[tokio::test]
+async fn outcome_reason_is_byte_identical_to_the_event_reason() {
+    use std::sync::Arc;
+
+    let collector = EventCollector::new();
+    let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
+    let sup = Supervisor::new(SupervisorConfig::default(), subs);
+    let handle = sup.serve();
+
+    let spec = TaskSpec::restartable(make_fail("drifter", Some(9)))
+        .with_backoff(fast_backoff())
+        .with_max_retries(2);
+    let (id, waiter) = handle
+        .add_and_watch(spec, ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+
+    assert!(
+        poll_until(Duration::from_secs(2), || async {
+            collector
+                .by_id(id)
+                .iter()
+                .any(|e| e.kind == EventKind::ActorExhausted)
+        })
+        .await
+    );
+    let event = collector
+        .by_id(id)
+        .into_iter()
+        .find(|e| e.kind == EventKind::ActorExhausted)
+        .expect("ActorExhausted event for the run");
+
+    match outcome {
+        TaskOutcome::Failed { reason, exit_code } => {
+            assert_eq!(
+                &*reason,
+                event.reason.as_deref().expect("event carries a reason"),
+                "TaskOutcome reason must be byte-identical to the ActorExhausted reason"
+            );
+            assert_eq!(exit_code, event.exit_code, "exit_code must match too");
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn completed_outcome_for_successful_once_task() {
+    let (_sup, handle) = supervisor();
+
+    let (id, waiter) = handle
+        .add_and_watch(TaskSpec::once(make_ok_once("ok")), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+    assert_eq!(waiter.id(), id);
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+    assert_eq!(outcome, TaskOutcome::Completed);
+    assert!(outcome.is_success());
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn failed_outcome_carries_reason_and_exit_code() {
+    let (_sup, handle) = supervisor();
+
+    let spec = TaskSpec::restartable(make_fail("flaky", Some(7)))
+        .with_backoff(fast_backoff())
+        .with_max_retries(2);
+    let (_id, waiter) = handle
+        .add_and_watch(spec, ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    match with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored")
+    {
+        TaskOutcome::Failed { reason, exit_code } => {
+            assert!(
+                reason.contains("max_retries_exceeded"),
+                "reason must mention exhausted retries: {reason}"
+            );
+            assert_eq!(exit_code, Some(7), "exit code must survive to the outcome");
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn fatal_outcome_for_fatal_error() {
+    let (_sup, handle) = supervisor();
+
+    let (_id, waiter) = handle
+        .add_and_watch(
+            TaskSpec::restartable(make_fatal("doomed", Some(137))),
+            ADD_TIMEOUT,
+        )
+        .await
+        .expect("add_and_watch should succeed");
+
+    match with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored")
+    {
+        TaskOutcome::Fatal { reason, exit_code } => {
+            assert!(
+                reason.contains("unrecoverable"),
+                "reason must carry the fatal message: {reason}"
+            );
+            assert_eq!(exit_code, Some(137));
+        }
+        other => panic!("expected Fatal, got {other:?}"),
+    }
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn failed_outcome_after_task_panic_with_never_policy() {
+    let (_sup, handle) = supervisor();
+
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::once(make_panic("kaboom")), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    match with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored")
+    {
+        TaskOutcome::Failed { reason, .. } => {
+            assert!(
+                reason.contains("panic"),
+                "reason must mention the panic: {reason}"
+            );
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn spurious_canceled_return_resolves_canceled_outcome() {
+    let (_sup, handle) = supervisor();
+
+    let liar: TaskRef = TaskFn::arc("liar-watch", |_ctx: CancellationToken| async {
+        Err(TaskError::Canceled)
+    });
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::restartable(liar), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+    assert_eq!(
+        outcome,
+        TaskOutcome::Canceled,
+        "a task returning Canceled without cancellation must resolve as Canceled"
+    );
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_drain_force_aborts_stubborn_watched_task() {
+    let cfg = SupervisorConfig {
+        grace: Duration::from_millis(150),
+        ..Default::default()
+    };
+    let sup = Supervisor::new(cfg, vec![]);
+    let handle = sup.serve();
+
+    let stubborn: TaskRef = TaskFn::arc("stubborn-watch", |_ctx: CancellationToken| async {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Ok(())
+    });
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::once(stubborn), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let (shutdown_res, outcome) = tokio::join!(handle.shutdown(), with_timeout(5, waiter.wait()));
+    assert!(
+        shutdown_res.is_err(),
+        "stubborn task must trip GraceExceeded"
+    );
+    assert_eq!(
+        outcome.expect("waiter errored"),
+        TaskOutcome::ForceAborted,
+        "the shutdown drain's force-abort must resolve the waiter as ForceAborted"
+    );
+}
+
+#[tokio::test]
+async fn waiter_stays_pending_across_periodic_reruns() {
+    let (_sup, handle) = supervisor();
+
+    let spec =
+        TaskSpec::restartable(make_ok_once("periodic-watch")).with_restart(RestartPolicy::Always {
+            interval: Some(Duration::from_millis(20)),
+        });
+    let (id, waiter) = handle
+        .add_and_watch(spec, ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let pending = tokio::time::timeout(Duration::from_millis(200), waiter.wait()).await;
+    assert!(
+        pending.is_err(),
+        "waiter must stay pending across successful Always re-runs"
+    );
+
+    let _ = handle.cancel(id).await;
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn cancelled_outcome_when_task_is_cancelled() {
+    let (_sup, handle) = supervisor();
+
+    let (id, waiter) = handle
+        .add_and_watch(TaskSpec::restartable(make_coop("coop")), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let removed = handle.cancel(id).await.expect("cancel should not error");
+    assert!(removed, "existing task must report removed=true");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+    assert_eq!(outcome, TaskOutcome::Canceled);
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn force_aborted_outcome_for_noncooperative_task() {
+    let cfg = SupervisorConfig {
+        grace: Duration::from_millis(100),
+        ..Default::default()
+    };
+    let sup = Supervisor::new(cfg, vec![]);
+    let handle = sup.serve();
+
+    let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: CancellationToken| async move {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Ok(())
+    });
+    let (id, waiter) = handle
+        .add_and_watch(TaskSpec::once(stubborn), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    handle.remove(id).expect("remove should be accepted");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+    assert_eq!(outcome, TaskOutcome::ForceAborted);
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn duplicate_name_returns_already_exists_not_a_waiter() {
+    let (_sup, handle) = supervisor();
+
+    let first = handle
+        .add_and_watch(TaskSpec::restartable(make_coop("dup")), ADD_TIMEOUT)
+        .await;
+    assert!(first.is_ok(), "first add must succeed");
+
+    let second = handle
+        .add_and_watch(TaskSpec::restartable(make_coop("dup")), ADD_TIMEOUT)
+        .await;
+    assert!(
+        matches!(second, Err(RuntimeError::TaskAlreadyExists { .. })),
+        "duplicate add must surface TaskAlreadyExists, got {second:?}"
+    );
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_resolves_pending_waiters() {
+    let (_sup, handle) = supervisor();
+
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::restartable(make_coop("worker")), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    handle
+        .clone()
+        .shutdown()
+        .await
+        .expect("shutdown should be Ok");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+    assert_eq!(
+        outcome,
+        TaskOutcome::Canceled,
+        "cooperative task must resolve as Canceled on shutdown"
+    );
+}
+
+#[tokio::test]
+async fn dropping_waiter_does_not_affect_task() {
+    let (_sup, handle) = supervisor();
+
+    let (id, waiter) = handle
+        .add_and_watch(TaskSpec::restartable(make_coop("ignored")), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+    drop(waiter);
+
+    assert!(
+        poll_until(Duration::from_secs(2), || async {
+            handle.is_alive("ignored").await
+        })
+        .await,
+        "task must keep running after its waiter is dropped"
+    );
+
+    let removed = handle.cancel(id).await.expect("cancel should not error");
+    assert!(removed);
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn outcome_is_delivered_even_under_bus_lag() {
+    let cfg = SupervisorConfig {
+        bus_capacity: 2,
+        ..Default::default()
+    };
+    let sup = Supervisor::new(cfg, vec![]);
+    let handle = sup.serve();
+
+    let spec = TaskSpec::restartable(make_fail("noisy", None))
+        .with_backoff(fast_backoff())
+        .with_max_retries(5);
+    let (_id, waiter) = handle
+        .add_and_watch(spec, ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    match with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored")
+    {
+        TaskOutcome::Failed { .. } => {}
+        other => panic!("expected Failed despite bus lag, got {other:?}"),
+    }
+
+    let _ = handle.shutdown().await;
+}


### PR DESCRIPTION
## 📝 Description

- **`EventKind::TaskCanceled`** — graceful cancellation as a first-class lifecycle event.
- **Completion plane** — await a task's final result on a guaranteed channel (immune to bus lag):
  - `SupervisorHandle::add_and_watch(spec, timeout) -> (TaskId, TaskWaiter)` (direct path)
  - `SupervisorHandle::submit_and_watch(spec) -> (TaskId, TaskWaiter)` (controller path)
  - `TaskWaiter::wait() -> Result<TaskOutcome, RuntimeError>`
  - `TaskOutcome { Completed, Failed{reason,exit_code}, Fatal{reason,exit_code}, Canceled, ForceAborted, Panicked, Rejected{reason} }`
- **Admission events carry identity** — `ControllerSubmitted` / `ControllerRejected` set `Event.id` to the submission's pre-minted `TaskId`.
- **`TaskStopped` and `TaskCanceled` carry `attempt`.**
- **Queued-spec removal** — `remove(id)` / `cancel(id)` now also purge a submission still waiting in a slot queue (`ControllerRejected("removed_from_queue")`); a submission displaced by `Replace` resolves `superseded_by_replace`.
- **`TaskId::from_raw(u64)`** for wire round-trips (a fabricated id matches nothing).

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally