### PR TITLE
[supervisor][fix] Handle signal setup failures explicitly

### DIFF
--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -531,18 +531,26 @@ impl Supervisor {
     /// Waits for either shutdown signal or natural completion of all tasks.
     async fn drive_shutdown(&self) -> Result<(), RuntimeError> {
         let res = tokio::select! {
-            _ = crate::core::shutdown::wait_for_shutdown_signal() => {
-                self.bus.publish(Event::new(EventKind::ShutdownRequested));
-                self.drain_with_grace().await
-            }
-            _ = self.registry.wait_until_empty() => {
-                Ok(())
-            }
+            sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
+            _ = self.registry.wait_until_empty() => Ok(()),
         };
         self.runtime_token.cancel();
         self.join_subscriber_listener().await;
         self.subs.close().await;
         res
+    }
+
+    /// Handles the outcome of [`wait_for_shutdown_signal`](crate::core::shutdown::wait_for_shutdown_signal).
+    async fn on_shutdown_signal(&self, res: std::io::Result<()>) -> Result<(), RuntimeError> {
+        match res {
+            Ok(()) => {
+                self.bus.publish(Event::new(EventKind::ShutdownRequested));
+                self.drain_with_grace().await
+            }
+            Err(e) => Err(RuntimeError::SignalSetupFailed {
+                reason: Arc::from(e.to_string()),
+            }),
+        }
     }
 
     /// Cancels all tasks and waits up to `grace` for them to stop, force-aborting stragglers.
@@ -609,6 +617,48 @@ impl Supervisor {
 mod tests {
     use super::*;
     use crate::{TaskFn, TaskRef};
+
+    #[tokio::test]
+    async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
+        let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+        let mut rx = sup.bus.subscribe();
+
+        let err = std::io::Error::other("signal registration failed");
+        let out = sup.on_shutdown_signal(Err(err)).await;
+
+        assert!(
+            matches!(out, Err(RuntimeError::SignalSetupFailed { .. })),
+            "a signal-setup error must surface as SignalSetupFailed, got {out:?}"
+        );
+
+        let mut saw_shutdown = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, EventKind::ShutdownRequested) {
+                saw_shutdown = true;
+            }
+        }
+        assert!(
+            !saw_shutdown,
+            "a signal-setup error must NOT masquerade as a shutdown request"
+        );
+    }
+
+    #[tokio::test]
+    async fn real_signal_publishes_shutdown_requested() {
+        let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+        let mut rx = sup.bus.subscribe();
+
+        let out = sup.on_shutdown_signal(Ok(())).await;
+        assert!(out.is_ok(), "a real signal drains gracefully: {out:?}");
+
+        let mut saw_shutdown = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, EventKind::ShutdownRequested) {
+                saw_shutdown = true;
+            }
+        }
+        assert!(saw_shutdown, "a real signal must publish ShutdownRequested");
+    }
 
     #[tokio::test]
     async fn shutdown_force_terminates_noncooperative_task_within_grace() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,12 @@ pub enum RuntimeError {
         /// How long we waited.
         timeout: Duration,
     },
+    /// OS signal-listener registration failed; signal-based shutdown is unavailable.
+    #[error("failed to install shutdown signal handlers: {reason}")]
+    SignalSetupFailed {
+        /// The underlying I/O error from signal registration, rendered as text.
+        reason: Arc<str>,
+    },
     /// The supervisor runtime is shutting down; the command channel is closed.
     #[error("supervisor is shutting down")]
     ShuttingDown,
@@ -66,6 +72,7 @@ impl RuntimeError {
             RuntimeError::TaskAlreadyExists { .. } => "runtime_task_already_exists",
             RuntimeError::TaskRemoveTimeout { .. } => "runtime_task_remove_timeout",
             RuntimeError::TaskAddTimeout { .. } => "runtime_task_add_timeout",
+            RuntimeError::SignalSetupFailed { .. } => "runtime_signal_setup_failed",
             RuntimeError::ShuttingDown => "runtime_shutting_down",
         }
     }


### PR DESCRIPTION
## 📝 Description
`Supervisor::run` no longer treats signal-listener registration errors as real shutdown signals. 
Such failures now return `RuntimeError::SignalSetupFailed` without publishing `ShutdownRequested`.

## 🔄 Related Issues
Resolves #94

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally
