### PR TITLE
[tasks][api] Decouple public API from tokio-util via TaskContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ exclude = [
 [features]
 default = []
 logging = []
+tokio-util-interop = []
 controller = ["dashmap"]
 
 [package.metadata.docs.rs]
-features = ["logging", "controller"]
+features = ["logging", "controller", "tokio-util-interop"]
 
 [dependencies]
 tokio      = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ use taskvisor::prelude::*;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sup = Supervisor::builder(SupervisorConfig::default()).build();
 
-    let ping: TaskRef = TaskFn::arc("ping", |ctx: CancellationToken| async move {
+    let ping: TaskRef = TaskFn::arc("ping", |ctx: TaskContext| async move {
         tokio::select! {
             _ = ctx.cancelled() => return Err(TaskError::Canceled),
             _ = tokio::time::sleep(Duration::from_millis(100)) => {}
@@ -137,7 +137,7 @@ impl Subscribe for Printer {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let attempts = Arc::new(AtomicU32::new(0));
-    let flaky: TaskRef = TaskFn::arc("flaky", move |_ctx: CancellationToken| {
+    let flaky: TaskRef = TaskFn::arc("flaky", move |_ctx: TaskContext| {
         let attempts = Arc::clone(&attempts);
         async move {
             let n = attempts.fetch_add(1, Ordering::Relaxed) + 1;
@@ -207,7 +207,7 @@ handle.shutdown().await?;
 
 **Task & TaskFn** - A `Task` is any `Send + Sync + 'static` type that implements
 ```rust,ignore
-fn spawn(&self, ctx: CancellationToken) -> BoxTaskFuture
+fn spawn(&self, ctx: TaskContext) -> BoxTaskFuture
 ``` 
 `TaskFn` wraps a closure into a `Task` so you don't need a struct. `TaskRef` is just `Arc<dyn Task>`.
 
@@ -275,7 +275,7 @@ Subscribers receive it as `Event::exit_code` on `TaskFailed` / `ActorDead` / `Ac
 
 ### Cancellation
 
-Tasks **must** observe cancellation via the `CancellationToken` passed to `spawn`:
+Tasks **must** observe cancellation via the `TaskContext` passed to `spawn`:
 
 ```rust,ignore
 // Pattern 1: select! (recommended for long-running tasks)

--- a/benches/controller.rs
+++ b/benches/controller.rs
@@ -28,9 +28,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use taskvisor::TaskContext;
 use tokio::runtime::Runtime;
 use tokio::sync::Notify;
-use tokio_util::sync::CancellationToken;
 
 use taskvisor::{
     BackoffPolicy, ControllerConfig, ControllerSpec, Event, EventKind, RestartPolicy, Subscribe,
@@ -114,12 +114,12 @@ fn bench_config() -> SupervisorConfig {
 }
 
 fn instant_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+    let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 
 fn short_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, |ctx: TaskContext| async move {
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_millis(5)) => Ok(()),
             _ = ctx.cancelled() => Ok(()),

--- a/benches/dynamic.rs
+++ b/benches/dynamic.rs
@@ -20,8 +20,8 @@
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use taskvisor::TaskContext;
 use tokio::runtime::Runtime;
-use tokio_util::sync::CancellationToken;
 
 use taskvisor::{
     BackoffPolicy, RestartPolicy, Supervisor, SupervisorConfig, TaskFn, TaskRef, TaskSpec,
@@ -58,7 +58,7 @@ fn bench_config() -> SupervisorConfig {
 }
 
 fn worker_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, |ctx: TaskContext| async move {
         ctx.cancelled().await;
         Ok(())
     });
@@ -66,7 +66,7 @@ fn worker_task(name: &str) -> TaskSpec {
 }
 
 fn instant_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+    let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 

--- a/benches/fanout.rs
+++ b/benches/fanout.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use taskvisor::TaskContext;
 use tokio::runtime::Runtime;
-use tokio_util::sync::CancellationToken;
 
 use taskvisor::{
     BackoffPolicy, Event, RestartPolicy, Subscribe, Supervisor, SupervisorConfig, TaskFn, TaskRef,
@@ -82,7 +82,7 @@ fn bench_config() -> SupervisorConfig {
 }
 
 fn instant_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+    let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 

--- a/benches/lifecycle.rs
+++ b/benches/lifecycle.rs
@@ -23,8 +23,8 @@
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use taskvisor::TaskContext;
 use tokio::runtime::Runtime;
-use tokio_util::sync::CancellationToken;
 
 use taskvisor::{
     BackoffPolicy, RestartPolicy, Supervisor, SupervisorConfig, TaskFn, TaskRef, TaskSpec,
@@ -61,12 +61,12 @@ fn bench_config() -> SupervisorConfig {
 }
 
 fn instant_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+    let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 
 fn work_task(name: &str, iterations: u64) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, move |_ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, move |_ctx: TaskContext| async move {
         let mut x = 0u64;
         for i in 0..iterations {
             x = x.wrapping_add(i);

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -20,8 +20,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use taskvisor::TaskContext;
 use tokio::runtime::Runtime;
-use tokio_util::sync::CancellationToken;
 
 use taskvisor::{
     BackoffPolicy, Event, RestartPolicy, Subscribe, Supervisor, SupervisorConfig, TaskFn, TaskRef,
@@ -83,12 +83,12 @@ fn bench_config() -> SupervisorConfig {
 }
 
 fn instant_task(name: &str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+    let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 
 fn work_task(name: &str, iterations: u64) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, move |_ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, move |_ctx: TaskContext| async move {
         let mut x = 0u64;
         for i in 0..iterations {
             x = x.wrapping_add(i);

--- a/examples/admission.rs
+++ b/examples/admission.rs
@@ -61,7 +61,7 @@ use taskvisor::prelude::*;
 
 /// A job that runs for `dur`, observing cancellation.
 fn job(name: &'static str, dur: Duration) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, move |ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, move |ctx: TaskContext| async move {
         tokio::select! {
             _ = tokio::time::sleep(dur) => Ok(()),
             _ = ctx.cancelled() => Err(TaskError::Canceled),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,8 +9,7 @@
 //! - `TaskSpec::once(task)` creates a one-shot spec (`RestartPolicy::Never`).
 //! - `Supervisor::run(specs)` blocks until all tasks finish or Ctrl+C is pressed.
 //!
-//! The `CancellationToken` parameter is unused here because the task completes instantly.
-//!
+//! The `TaskContext` parameter is unused here because the task completes instantly.
 //! For long-running tasks that **must react to shut down**, see `worker.rs`.
 //!
 //! ## Runtime flavor
@@ -36,7 +35,7 @@ use taskvisor::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let task: TaskRef = TaskFn::arc("hello", |_ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc("hello", |_ctx: TaskContext| async move {
         println!("Hello from taskvisor!");
         Ok(())
     });

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -73,7 +73,7 @@ use std::time::Duration;
 use taskvisor::prelude::*;
 
 fn make_worker(name: &'static str) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, move |ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, move |ctx: TaskContext| async move {
         let mut tick = 0u32;
         loop {
             tokio::select! {

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // A "flaky" task that fails 3 times then succeeds.
     let counter = Arc::new(AtomicU32::new(0));
-    let flaky: TaskRef = TaskFn::arc("flaky-job", move |_ctx: CancellationToken| {
+    let flaky: TaskRef = TaskFn::arc("flaky-job", move |_ctx: TaskContext| {
         let counter = Arc::clone(&counter);
         async move {
             let n = counter.fetch_add(1, Ordering::Relaxed) + 1;

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -57,7 +57,7 @@ use taskvisor::prelude::*;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // One-shot: runs once and exits
-    let one_shot: TaskRef = TaskFn::arc("one-shot", |_ctx: CancellationToken| async move {
+    let one_shot: TaskRef = TaskFn::arc("one-shot", |_ctx: TaskContext| async move {
         println!("[one-shot] doing work...");
         tokio::time::sleep(Duration::from_millis(200)).await;
         println!("[one-shot] done.");
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Resilient: fails first 2 attempts, succeeds on 3rd
     let attempt = Arc::new(AtomicU32::new(0));
-    let resilient: TaskRef = TaskFn::arc("resilient", move |_ctx: CancellationToken| {
+    let resilient: TaskRef = TaskFn::arc("resilient", move |_ctx: TaskContext| {
         let attempt = Arc::clone(&attempt);
         async move {
             let n = attempt.fetch_add(1, Ordering::Relaxed) + 1;
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Always-on: repeats every 500ms until Ctrl+C
     let cycle = Arc::new(AtomicU32::new(0));
-    let always_on: TaskRef = TaskFn::arc("always-on", move |_ctx: CancellationToken| {
+    let always_on: TaskRef = TaskFn::arc("always-on", move |_ctx: TaskContext| {
         let cycle = Arc::clone(&cycle);
         async move {
             let n = cycle.fetch_add(1, Ordering::Relaxed) + 1;

--- a/examples/outcomes.rs
+++ b/examples/outcomes.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 1) A one-shot job that succeeds -> Completed.
     println!("=== Completed ===");
-    let job: TaskRef = TaskFn::arc("import", |_ctx: CancellationToken| async {
+    let job: TaskRef = TaskFn::arc("import", |_ctx: TaskContext| async {
         tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(())
     });
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //    Note the outcome's reason/exit_code are identical to the ActorExhausted event.
     println!("=== Failed (retries exhausted) ===");
     let attempts = Arc::new(AtomicU32::new(0));
-    let flaky: TaskRef = TaskFn::arc("sync", move |_ctx: CancellationToken| {
+    let flaky: TaskRef = TaskFn::arc("sync", move |_ctx: TaskContext| {
         let attempts = Arc::clone(&attempts);
         async move {
             let n = attempts.fetch_add(1, Ordering::Relaxed) + 1;
@@ -115,7 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3) A long-running worker we cancel -> Canceled.
     println!("=== Canceled ===");
-    let worker: TaskRef = TaskFn::arc("worker", |ctx: CancellationToken| async move {
+    let worker: TaskRef = TaskFn::arc("worker", |ctx: TaskContext| async move {
         ctx.cancelled().await;
         Ok(())
     });

--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -9,7 +9,7 @@
 //!   *With `interval: None`, restarts happen immediately.*
 //! - The task itself is short-lived (print and exit).
 //!   The supervisor handles the scheduling loop: your task doesn't need its own `loop {}`.
-//! - `CancellationToken` is unused here because the task completes instantly.
+//! - The `TaskContext` is unused here because the task completes instantly.
 //!
 //! ## How it differs from a loop inside the task
 //!
@@ -46,7 +46,7 @@ use taskvisor::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let heartbeat: TaskRef = TaskFn::arc("heartbeat", |_ctx: CancellationToken| async move {
+    let heartbeat: TaskRef = TaskFn::arc("heartbeat", |_ctx: TaskContext| async move {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();

--- a/examples/pipeline.rs
+++ b/examples/pipeline.rs
@@ -57,7 +57,7 @@ use std::time::Duration;
 use taskvisor::prelude::*;
 
 fn job(name: &'static str, duration: Duration) -> TaskSpec {
-    let task: TaskRef = TaskFn::arc(name, move |ctx: CancellationToken| async move {
+    let task: TaskRef = TaskFn::arc(name, move |ctx: TaskContext| async move {
         println!("  [{name}] started");
         let start = tokio::time::Instant::now();
 

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -6,7 +6,7 @@
 //! ## What this shows
 //!
 //! - **Cooperative cancellation** via `tokio::select!` + `ctx.cancelled()`.
-//!   Every long-running task **MUST** observe its `CancellationToken`.
+//!   Every long-running task **MUST** observe cancellation via its `TaskContext`.
 //!   Without it, the task would keep running inside `sleep()` and ignore the shutdown signal until the grace period expires.
 //! - `TaskSpec::restartable(task)` uses `RestartPolicy::OnFailure` by default:
 //!   the worker restarts only if it returns `Err`, not on `Ok`.
@@ -14,7 +14,7 @@
 //! ## Why `ctx.cancelled()` matters
 //!
 //! Tokio **does not kill futures**: it cancels them cooperatively.
-//! When the supervisor shuts down, it cancels the task's `CancellationToken`.
+//! When the supervisor shuts down, it cancels the task's `TaskContext`.
 //! If your task is awaiting `sleep(10s)`, it won't notice until the sleep finishes.
 //! `tokio::select!` with `ctx.cancelled()` lets the task react immediately.
 //!
@@ -58,7 +58,7 @@ use taskvisor::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let worker: TaskRef = TaskFn::arc("ticker", |ctx: CancellationToken| async move {
+    let worker: TaskRef = TaskFn::arc("ticker", |ctx: TaskContext| async move {
         let mut tick = 0u64;
         loop {
             tokio::select! {

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -757,11 +757,11 @@ impl Controller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TaskContext;
     use crate::{BackoffPolicy, RestartPolicy, TaskFn, TaskRef, TaskSpec};
-    use tokio_util::sync::CancellationToken;
 
     fn make_spec(name: &str) -> TaskSpec {
-        let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
         TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
     }
 
@@ -906,7 +906,7 @@ mod tests {
         let bus = Bus::new(64);
         let ctrl = make_controller(ControllerConfig::default(), bus);
 
-        let task: TaskRef = TaskFn::arc("buffered", |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc("buffered", |_ctx: TaskContext| async { Ok(()) });
         let (_id, waiter) = ctrl
             .handle()
             .submit_and_watch(ControllerSpec::queue(TaskSpec::once(task).with_slot("s")))
@@ -935,7 +935,7 @@ mod tests {
         let mut rx = ctrl.rx.write().await.take().expect("rx present");
         ctrl.finalize_pending_on_shutdown(&mut rx);
 
-        let task: TaskRef = TaskFn::arc("late", |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc("late", |_ctx: TaskContext| async { Ok(()) });
         let result = ctrl
             .handle()
             .submit_and_watch(ControllerSpec::queue(TaskSpec::once(task).with_slot("s")))
@@ -973,7 +973,7 @@ mod tests {
             .build();
         let handle = sup.serve();
 
-        let task: TaskRef = TaskFn::arc("clamped", |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc("clamped", |_ctx: TaskContext| async { Ok(()) });
         handle
             .submit(ControllerSpec::queue(TaskSpec::once(task)))
             .await
@@ -991,7 +991,7 @@ mod tests {
     async fn sup_with_live_task() -> (Arc<Supervisor>, crate::core::SupervisorHandle, TaskId) {
         let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
         let handle = sup.serve();
-        let task: TaskRef = TaskFn::arc("occupant", |ctx: CancellationToken| async move {
+        let task: TaskRef = TaskFn::arc("occupant", |ctx: TaskContext| async move {
             ctx.cancelled().await;
             Ok(())
         });
@@ -1067,7 +1067,7 @@ mod tests {
         let (sup, handle, id) = sup_with_live_task().await;
         let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
 
-        let queued: TaskRef = TaskFn::arc("queued", |ctx: CancellationToken| async move {
+        let queued: TaskRef = TaskFn::arc("queued", |ctx: TaskContext| async move {
             ctx.cancelled().await;
             Ok(())
         });
@@ -1110,7 +1110,7 @@ mod tests {
         let handle = sup.serve();
 
         let mk = |name: &'static str| -> ControllerSpec {
-            let task: TaskRef = TaskFn::arc(name, |ctx: CancellationToken| async move {
+            let task: TaskRef = TaskFn::arc(name, |ctx: TaskContext| async move {
                 ctx.cancelled().await;
                 Ok(())
             });

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -128,10 +128,10 @@ mod tests {
     }
 
     fn make_spec(name: &str) -> TaskSpec {
+        use crate::TaskContext;
         use crate::{BackoffPolicy, RestartPolicy, TaskFn, TaskRef};
-        use tokio_util::sync::CancellationToken;
 
-        let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
         TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
     }
 }

--- a/src/controller/spec.rs
+++ b/src/controller/spec.rs
@@ -75,11 +75,11 @@ impl ControllerSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TaskContext;
     use crate::{BackoffPolicy, RestartPolicy, TaskFn, TaskRef};
-    use tokio_util::sync::CancellationToken;
 
     fn make_spec(name: &str) -> TaskSpec {
-        let task: TaskRef = TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) });
+        let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
         TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
     }
 

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -5,7 +5,7 @@
 //! - delays per [`BackoffPolicy`],
 //! - optional per-attempt timeout,
 //!
-//! *Cooperative cancellation via `CancellationToken`.*
+//! *Cooperative cancellation via the task's `TaskContext`.*
 //!
 //! ## Event flow
 //!
@@ -369,6 +369,7 @@ impl TaskActor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TaskContext;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -408,7 +409,7 @@ mod tests {
         fn name(&self) -> &str {
             "ok"
         }
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async { Ok(()) })
         }
     }
@@ -418,7 +419,7 @@ mod tests {
         fn name(&self) -> &str {
             "fail"
         }
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async {
                 Err(TaskError::Fail {
                     reason: "boom".into(),
@@ -433,7 +434,7 @@ mod tests {
         fn name(&self) -> &str {
             "fatal"
         }
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async {
                 Err(TaskError::Fatal {
                     reason: "fatal".into(),
@@ -457,7 +458,7 @@ mod tests {
         fn name(&self) -> &str {
             "counted"
         }
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             let prev = self.remaining.fetch_sub(1, Ordering::SeqCst);
             if prev > 0 {
                 Box::pin(async {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -47,7 +47,7 @@ pub struct SupervisorConfig {
     /// Maximum time to wait for graceful shutdown before force-terminating.
     ///
     /// When a shutdown signal is received:
-    /// - Tasks are cancelled via `CancellationToken`
+    /// - Tasks are cancelled via their `TaskContext`
     /// - Supervisor waits up to `grace` for tasks to exit
     /// - If timeout exceeds, returns `RuntimeError::GraceExceeded`
     pub grace: Duration,

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -35,7 +35,7 @@ use super::supervisor::Supervisor;
 ///     let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
 ///     let handle = sup.serve();
 ///
-///     let task = TaskFn::arc("worker", |ctx: CancellationToken| async move {
+///     let task = TaskFn::arc("worker", |ctx: TaskContext| async move {
 ///         while !ctx.is_cancelled() {
 ///             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 ///         }
@@ -117,7 +117,7 @@ impl SupervisorHandle {
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
     /// # let handle = sup.serve();
-    /// let job: TaskRef = TaskFn::arc("job", |_ctx: CancellationToken| async { Ok(()) });
+    /// let job: TaskRef = TaskFn::arc("job", |_ctx: TaskContext| async { Ok(()) });
     /// let (_id, waiter) = handle
     ///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
     ///     .await?;

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -150,7 +150,7 @@ impl TaskOutcome {
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
 /// # let handle = sup.serve();
-/// let job: TaskRef = TaskFn::arc("job", |_ctx: CancellationToken| async { Ok(()) });
+/// let job: TaskRef = TaskFn::arc("job", |_ctx: TaskContext| async { Ok(()) });
 /// let (id, waiter) = handle
 ///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
 ///     .await?;

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -48,7 +48,7 @@ use crate::{
     error::TaskError,
     events::{Bus, Event, EventKind},
     identity::TaskId,
-    tasks::{BoxTaskFuture, Task},
+    tasks::{BoxTaskFuture, Task, TaskContext},
 };
 
 /// Future adapter that traps panics raised by the task body.
@@ -121,8 +121,9 @@ pub async fn run_once<T: Task + ?Sized>(
     bus: &Bus,
 ) -> Result<(), TaskError> {
     let child = parent.child_token();
+    let ctx = TaskContext::from_token(child.clone());
 
-    let fut = match std::panic::catch_unwind(AssertUnwindSafe(|| task.spawn(child.clone()))) {
+    let fut = match std::panic::catch_unwind(AssertUnwindSafe(move || task.spawn(ctx))) {
         Ok(fut) => CatchPanic(fut),
         Err(payload) => {
             let e = panic_to_error(payload.as_ref());
@@ -225,7 +226,7 @@ mod tests {
             "slow-task"
         }
 
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async {
                 tokio::time::sleep(Duration::from_secs(3600)).await;
                 Ok(())
@@ -240,7 +241,7 @@ mod tests {
             "ok-task"
         }
 
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async { Ok(()) })
         }
     }
@@ -252,7 +253,7 @@ mod tests {
             "fail-task"
         }
 
-        fn spawn(&self, _ctx: CancellationToken) -> BoxFut {
+        fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             Box::pin(async {
                 Err(TaskError::Fail {
                     reason: "boom".into(),

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -70,7 +70,7 @@
 //! ## Example
 //! ```rust,no_run
 //! use std::time::Duration;
-//! use tokio_util::sync::CancellationToken;
+//! use taskvisor::TaskContext;
 //!
 //! use taskvisor::{SupervisorConfig, Supervisor, TaskSpec, TaskFn, RestartPolicy, BackoffPolicy};
 //!
@@ -79,7 +79,7 @@
 //!     let cfg = SupervisorConfig::default();
 //!     let sup = Supervisor::new(cfg, Vec::new());
 //!
-//!     let task = TaskFn::arc("ticker", |ctx: CancellationToken| async move {
+//!     let task = TaskFn::arc("ticker", |ctx: TaskContext| async move {
 //!         while !ctx.is_cancelled() {
 //!             tokio::time::sleep(Duration::from_millis(250)).await;
 //!         }
@@ -616,7 +616,7 @@ impl Supervisor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{TaskFn, TaskRef};
+    use crate::{TaskContext, TaskFn, TaskRef};
 
     #[tokio::test]
     async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
@@ -669,7 +669,7 @@ mod tests {
         let sup = Supervisor::new(cfg, vec![]);
         let handle = sup.serve();
 
-        let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: CancellationToken| async move {
+        let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: TaskContext| async move {
             tokio::time::sleep(Duration::from_secs(30)).await;
             Ok(())
         });
@@ -702,7 +702,7 @@ mod tests {
         let sup = Supervisor::new(cfg, vec![]);
         let handle = sup.serve();
 
-        let good: TaskRef = TaskFn::arc("good", |ctx: CancellationToken| async move {
+        let good: TaskRef = TaskFn::arc("good", |ctx: TaskContext| async move {
             ctx.cancelled().await;
             Ok(())
         });
@@ -726,7 +726,7 @@ mod tests {
         let handle = sup.serve();
 
         let make = || -> TaskRef {
-            TaskFn::arc("dup", |ctx: CancellationToken| async move {
+            TaskFn::arc("dup", |ctx: TaskContext| async move {
                 ctx.cancelled().await;
                 Ok(())
             })
@@ -756,7 +756,7 @@ mod tests {
         let sup = Supervisor::new(cfg, vec![]);
         let handle = sup.serve();
 
-        let t: TaskRef = TaskFn::arc("laggy", |ctx: CancellationToken| async move {
+        let t: TaskRef = TaskFn::arc("laggy", |ctx: TaskContext| async move {
             ctx.cancelled().await;
             Ok(())
         });
@@ -808,7 +808,7 @@ mod tests {
         let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
         let handle = sup.serve();
 
-        let t: TaskRef = TaskFn::arc("c", |ctx: CancellationToken| async move {
+        let t: TaskRef = TaskFn::arc("c", |ctx: TaskContext| async move {
             ctx.cancelled().await;
             Ok(())
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //!     let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
 //!
 //!     // Define a simple task that runs once and exits
-//!     let hello: TaskRef = TaskFn::arc("hello", |ctx: CancellationToken| async move {
+//!     let hello: TaskRef = TaskFn::arc("hello", |ctx: TaskContext| async move {
 //!         if ctx.is_cancelled() { return Ok(()); }
 //!         println!("Hello from task!");
 //!         Ok(())
@@ -147,7 +147,7 @@ pub use core::{
 };
 
 mod tasks;
-pub use tasks::{BoxTaskFuture, Task, TaskFn, TaskRef, TaskSpec};
+pub use tasks::{BoxTaskFuture, Task, TaskContext, TaskFn, TaskRef, TaskSpec};
 
 mod policies;
 pub use policies::{BackoffPolicy, JitterPolicy, RestartPolicy};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,7 +12,7 @@ pub use crate::core::{
 };
 
 // Tasks
-pub use crate::tasks::{BoxTaskFuture, Task, TaskFn, TaskRef, TaskSpec};
+pub use crate::tasks::{BoxTaskFuture, Task, TaskContext, TaskFn, TaskRef, TaskSpec};
 
 // Policies
 pub use crate::policies::{BackoffPolicy, JitterPolicy, RestartPolicy};
@@ -29,5 +29,7 @@ pub use crate::error::{RuntimeError, TaskError};
 // Runtime task identity
 pub use crate::identity::TaskId;
 
-// Re-export CancellationToken.
+// Raw cancellation token — only when interop is explicitly opted into.
+// By default the prelude stays free of `tokio-util` types (see `TaskContext`).
+#[cfg(feature = "tokio-util-interop")]
 pub use tokio_util::sync::CancellationToken;

--- a/src/tasks/context.rs
+++ b/src/tasks/context.rs
@@ -1,0 +1,150 @@
+//! Task execution context handed to [`Task::spawn`](crate::Task::spawn).
+
+use tokio_util::sync::CancellationToken;
+
+/// Execution context passed to a [`Task`](crate::Task) on every attempt.
+///
+/// Carries the per-attempt cancellation signal and is the only argument to [`Task::spawn`](crate::Task::spawn).
+///
+/// ## Cancellation
+///
+/// The context is cancelled by the supervisor during shutdown or when the task is removed at runtime.
+/// - Long-running tasks should await [`cancelled`](Self::cancelled) (or poll [`is_cancelled`](Self::is_cancelled));
+///   tasks that ignore it block graceful shutdown until the grace period expires.
+/// - Short-lived, one-shot tasks that finish quickly may ignore it.
+#[derive(Clone, Debug)]
+pub struct TaskContext {
+    cancel: CancellationToken,
+}
+
+impl TaskContext {
+    /// Wraps a raw cancellation token (crate-internal; the runtime owns token creation).
+    pub(crate) fn from_token(cancel: CancellationToken) -> Self {
+        Self { cancel }
+    }
+
+    /// Resolves once the context is cancelled.
+    ///
+    /// Safe to call repeatedly and to use as a branch in `tokio::select!`.
+    pub async fn cancelled(&self) {
+        self.cancel.cancelled().await;
+    }
+
+    /// Returns `true` if the context has already been cancelled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Derives a child context: cancelled when this context is cancelled, but cancelling the child does **not** affect this context.
+    #[must_use]
+    pub fn child(&self) -> TaskContext {
+        TaskContext {
+            cancel: self.cancel.child_token(),
+        }
+    }
+
+    /// Returns a clone of the underlying [`tokio_util`] cancellation token.
+    ///
+    /// Escape hatch for interop with third-party `tokio-util`-aware APIs. The
+    /// returned token shares cancellation state with this context.
+    ///
+    /// Requires the `tokio-util-interop` feature.
+    /// **Enabling it makes `tokio-util` a public dependency of your crate** (its semver leaks into yours);
+    /// prefer [`cancelled`](Self::cancelled)/[`child`](Self::child) where possible.
+    #[cfg(feature = "tokio-util-interop")]
+    #[must_use]
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskContext;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn is_cancelled_reflects_underlying_token() {
+        let token = CancellationToken::new();
+        let ctx = TaskContext::from_token(token.clone());
+
+        assert!(!ctx.is_cancelled(), "fresh context must not be cancelled");
+        token.cancel();
+        assert!(
+            ctx.is_cancelled(),
+            "context must observe the underlying token's cancellation"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolves_once_token_is_cancelled() {
+        let token = CancellationToken::new();
+        let ctx = TaskContext::from_token(token.clone());
+        token.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), ctx.cancelled())
+            .await
+            .expect("cancelled() must resolve promptly after the token is cancelled");
+    }
+
+    #[test]
+    fn clone_shares_cancellation_state() {
+        let token = CancellationToken::new();
+        let ctx = TaskContext::from_token(token.clone());
+        let clone = ctx.clone();
+
+        token.cancel();
+        assert!(
+            clone.is_cancelled(),
+            "a cloned context must share cancellation state with the original"
+        );
+    }
+
+    #[test]
+    fn child_is_cancelled_when_parent_cancels() {
+        let token = CancellationToken::new();
+        let ctx = TaskContext::from_token(token.clone());
+        let child = ctx.child();
+
+        assert!(!child.is_cancelled(), "fresh child must not be cancelled");
+        token.cancel();
+        assert!(
+            child.is_cancelled(),
+            "cancelling the parent must propagate to a child context"
+        );
+    }
+
+    #[cfg(feature = "tokio-util-interop")]
+    #[test]
+    fn cancellation_token_shares_state_with_context() {
+        let token = CancellationToken::new();
+        let ctx = TaskContext::from_token(token.clone());
+        let raw = ctx.cancellation_token();
+
+        assert!(!raw.is_cancelled());
+        token.cancel();
+        assert!(
+            raw.is_cancelled(),
+            "the raw token must share cancellation state with the context"
+        );
+    }
+
+    #[cfg(feature = "tokio-util-interop")]
+    #[test]
+    fn child_cancellation_does_not_affect_parent() {
+        let ctx = TaskContext::from_token(CancellationToken::new());
+        let child = ctx.child();
+
+        child.cancellation_token().cancel();
+        assert!(
+            child.is_cancelled(),
+            "child must observe its own cancellation"
+        );
+        assert!(
+            !ctx.is_cancelled(),
+            "cancelling a child must not cancel the parent (child() must use a child token, not a clone)"
+        );
+    }
+}

--- a/src/tasks/impl/func.rs
+++ b/src/tasks/impl/func.rs
@@ -1,25 +1,24 @@
 //! Closure-based [`Task`] implementation.
 
 use std::{future::Future, sync::Arc};
-use tokio_util::sync::CancellationToken;
 
 use crate::{
     error::TaskError,
+    tasks::TaskContext,
     tasks::task::{BoxTaskFuture, Task},
 };
 
 /// Closure-based [`Task`] implementation.
 ///
-/// - Wraps `F: Fn(CancellationToken) -> Future`
+/// - Wraps `F: Fn(TaskContext) -> Future`
 /// - Each [`spawn`](Task::spawn) invokes the closure to produce a fresh, independent future.
 ///
 /// ## Stateless task
 ///
 /// ```rust
-/// use tokio_util::sync::CancellationToken;
-/// use taskvisor::{TaskFn, TaskRef, TaskError};
+/// use taskvisor::{TaskContext, TaskFn, TaskRef, TaskError};
 ///
-/// let worker: TaskRef = TaskFn::arc("worker", |_ctx: CancellationToken| async move {
+/// let worker: TaskRef = TaskFn::arc("worker", |_ctx: TaskContext| async move {
 ///     // do some work and complete
 ///     Ok(())
 /// });
@@ -30,14 +29,13 @@ use crate::{
 /// ```rust
 /// use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
 /// use std::time::Duration;
-/// use tokio_util::sync::CancellationToken;
 ///
-/// use taskvisor::{TaskFn, TaskRef, TaskError};
+/// use taskvisor::{TaskContext, TaskFn, TaskRef, TaskError};
 ///
 /// let counter = Arc::new(AtomicU64::new(0));
 /// let task: TaskRef = TaskFn::arc("counter", {
 ///     let counter = counter.clone();
-///     move |ctx: CancellationToken| {
+///     move |ctx: TaskContext| {
 ///         // clone per-attempt; the underlying value persists across restarts.
 ///         let counter = counter.clone();
 ///         async move {
@@ -81,14 +79,14 @@ impl<F> TaskFn<F> {
 
 impl<Fnc, Fut> Task for TaskFn<Fnc>
 where
-    Fnc: Fn(CancellationToken) -> Fut + Send + Sync + 'static,
+    Fnc: Fn(TaskContext) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<(), TaskError>> + Send + 'static,
 {
     fn name(&self) -> &str {
         &self.name
     }
 
-    fn spawn(&self, ctx: CancellationToken) -> BoxTaskFuture {
+    fn spawn(&self, ctx: TaskContext) -> BoxTaskFuture {
         let fut = (self.f)(ctx);
         Box::pin(fut)
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -40,9 +40,9 @@
 //!
 //! ```rust
 //! use taskvisor::{TaskFn, TaskRef, TaskSpec, TaskError};
-//! use tokio_util::sync::CancellationToken;
+//! use taskvisor::TaskContext;
 //!
-//! let task: TaskRef = TaskFn::arc("worker", |ctx: CancellationToken| async move {
+//! let task: TaskRef = TaskFn::arc("worker", |ctx: TaskContext| async move {
 //!     // ... do work, observe ctx.cancelled() ...
 //!     Ok::<(), TaskError>(())
 //! });
@@ -51,6 +51,9 @@
 //! // TaskSpec::restartable(task);          // restart on failure
 //! // TaskSpec::with_defaults(task, &cfg);  // inherit from config
 //! ```
+
+mod context;
+pub use context::TaskContext;
 
 mod task;
 pub use task::{BoxTaskFuture, Task, TaskRef};

--- a/src/tasks/spec.rs
+++ b/src/tasks/spec.rs
@@ -17,11 +17,11 @@ use crate::{
 ///
 /// ## Creating a spec
 /// ```rust
-/// use tokio_util::sync::CancellationToken;
+/// use taskvisor::TaskContext;
 /// use taskvisor::{TaskSpec, TaskFn, SupervisorConfig, RestartPolicy, BackoffPolicy, TaskRef, TaskError};
 /// use std::time::Duration;
 ///
-/// let task: TaskRef = TaskFn::arc("demo", |_ctx: CancellationToken| async move {
+/// let task: TaskRef = TaskFn::arc("demo", |_ctx: TaskContext| async move {
 ///     Ok::<(), TaskError>(())
 /// });
 ///
@@ -208,11 +208,10 @@ impl TaskSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TaskFn;
-    use tokio_util::sync::CancellationToken;
+    use crate::{TaskContext, TaskFn};
 
     fn task(name: &str) -> TaskRef {
-        TaskFn::arc(name, |_ctx: CancellationToken| async { Ok(()) })
+        TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) })
     }
 
     #[test]

--- a/src/tasks/task.rs
+++ b/src/tasks/task.rs
@@ -1,9 +1,9 @@
 //! Core [`Task`] trait, [`TaskRef`] handle, and [`BoxTaskFuture`] alias.
 
 use std::{future::Future, pin::Pin, sync::Arc};
-use tokio_util::sync::CancellationToken;
 
 use crate::error::TaskError;
+use crate::tasks::TaskContext;
 
 /// Boxed, pinned, `Send` future: the return type of [`Task::spawn`].
 pub type BoxTaskFuture = Pin<Box<dyn Future<Output = Result<(), TaskError>> + Send + 'static>>;
@@ -29,9 +29,8 @@ pub type TaskRef = Arc<dyn Task>;
 ///
 /// ## Cancellation
 ///
-/// The [`CancellationToken`] `ctx` is cancelled by the supervisor during shutdown or when the task is removed at runtime.
-/// - Long-running tasks should poll `ctx.cancelled()`: tasks that ignore the token will
-///   block graceful shutdown until the grace period expires.
+/// The [`TaskContext`] `ctx` is cancelled by the supervisor during shutdown or when the task is removed at runtime.
+/// - Long-running tasks should await `ctx.cancelled()` (or poll `ctx.is_cancelled()`): tasks that ignore it will block graceful shutdown until the grace period expires.
 /// - Short-lived, one-shot tasks that complete quickly may omit this check.
 ///
 /// A task that loops forever and only exits via `ctx.cancelled()` should return `Err(TaskError::Canceled)`;
@@ -50,5 +49,5 @@ pub trait Task: Send + Sync + 'static {
     /// Creates a new future that runs the task until completion or cancellation.
     ///
     /// Called once per attempt. Takes `&self` - each call must return an independent future with no side effects from previous runs.
-    fn spawn(&self, ctx: CancellationToken) -> BoxTaskFuture;
+    fn spawn(&self, ctx: TaskContext) -> BoxTaskFuture;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio_util::sync::CancellationToken;
+use taskvisor::TaskContext;
 
 use taskvisor::{
     BackoffPolicy, Event, EventKind, JitterPolicy, Subscribe, TaskError, TaskFn, TaskId, TaskRef,
@@ -122,18 +122,18 @@ pub async fn with_timeout<F: Future>(secs: u64, fut: F) -> F::Output {
 }
 
 pub fn make_coop(name: &str) -> TaskRef {
-    TaskFn::arc(name, |ctx: CancellationToken| async move {
+    TaskFn::arc(name, |ctx: TaskContext| async move {
         ctx.cancelled().await;
         Ok(())
     })
 }
 
 pub fn make_ok_once(name: &str) -> TaskRef {
-    TaskFn::arc(name, |_ctx: CancellationToken| async move { Ok(()) })
+    TaskFn::arc(name, |_ctx: TaskContext| async move { Ok(()) })
 }
 
 pub fn make_fail(name: &str, exit_code: Option<i32>) -> TaskRef {
-    TaskFn::arc(name, move |_ctx: CancellationToken| async move {
+    TaskFn::arc(name, move |_ctx: TaskContext| async move {
         Err(TaskError::Fail {
             reason: "boom".to_string(),
             exit_code,
@@ -142,7 +142,7 @@ pub fn make_fail(name: &str, exit_code: Option<i32>) -> TaskRef {
 }
 
 pub fn make_fatal(name: &str, exit_code: Option<i32>) -> TaskRef {
-    TaskFn::arc(name, move |_ctx: CancellationToken| async move {
+    TaskFn::arc(name, move |_ctx: TaskContext| async move {
         Err(TaskError::Fatal {
             reason: "unrecoverable".to_string(),
             exit_code,
@@ -151,7 +151,7 @@ pub fn make_fatal(name: &str, exit_code: Option<i32>) -> TaskRef {
 }
 
 pub fn make_panic(name: &str) -> TaskRef {
-    TaskFn::arc(name, |_ctx: CancellationToken| async move {
+    TaskFn::arc(name, |_ctx: TaskContext| async move {
         panic!("kaboom");
     })
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -24,7 +24,7 @@ fn served_controller(cfg: ControllerConfig) -> (SupervisorHandle, Arc<EventColle
 
 fn logging_once(name: &str, log: Arc<Mutex<Vec<String>>>) -> TaskRef {
     let n = name.to_string();
-    TaskFn::arc(name, move |_ctx: CancellationToken| {
+    TaskFn::arc(name, move |_ctx: TaskContext| {
         let log = log.clone();
         let n = n.clone();
         async move {

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -105,7 +105,7 @@ async fn panicking_task_restarts_per_policy_then_succeeds() {
 
     let attempts = Arc::new(AtomicU32::new(0));
     let attempts2 = Arc::clone(&attempts);
-    let flaky: TaskRef = TaskFn::arc("flaky-panic", move |_ctx: CancellationToken| {
+    let flaky: TaskRef = TaskFn::arc("flaky-panic", move |_ctx: TaskContext| {
         let attempts = Arc::clone(&attempts2);
         async move {
             if attempts.fetch_add(1, Ordering::SeqCst) < 2 {
@@ -145,7 +145,7 @@ async fn task_returning_canceled_without_cancellation_is_reaped() {
 
     // The task lies: returns Canceled while its token was never cancelled.
     // Worst case is Always, which would otherwise restart on any other return.
-    let liar: TaskRef = TaskFn::arc("liar", |_ctx: CancellationToken| async move {
+    let liar: TaskRef = TaskFn::arc("liar", |_ctx: TaskContext| async move {
         Err(TaskError::Canceled)
     });
     let spec = TaskSpec::restartable(liar).with_restart(RestartPolicy::Always { interval: None });
@@ -216,7 +216,7 @@ async fn cancellation_returning_canceled_error_yields_task_canceled() {
     .build();
     let handle = sup.serve();
 
-    let task = TaskFn::arc("cancel-err", |ctx: CancellationToken| async move {
+    let task = TaskFn::arc("cancel-err", |ctx: TaskContext| async move {
         ctx.cancelled().await;
         Err(TaskError::Canceled)
     });

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -359,7 +359,7 @@ async fn cancel_with_timeout_true_for_cooperative_task() {
 async fn cancel_with_timeout_errors_on_stuck_task() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
-        let task = TaskFn::arc("stubborn", |_ctx: CancellationToken| async move {
+        let task = TaskFn::arc("stubborn", |_ctx: TaskContext| async move {
             tokio::time::sleep(Duration::from_secs(30)).await;
             Ok(())
         });
@@ -401,7 +401,7 @@ async fn individually_removed_stuck_task_is_force_aborted_after_grace() {
     let handle = sup.serve();
 
     with_timeout(10, async {
-        let task = TaskFn::arc("stuck-runner", |_ctx: CancellationToken| async move {
+        let task = TaskFn::arc("stuck-runner", |_ctx: TaskContext| async move {
             tokio::time::sleep(Duration::from_secs(30)).await;
             Ok(())
         });

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -64,7 +64,7 @@ async fn never_oneshot_failure_emits_taskfailed_then_exhausted_no_backoff() {
     let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
     let sup = Supervisor::new(SupervisorConfig::default(), subs);
 
-    let task = TaskFn::arc("fail-once", |_ctx: CancellationToken| async move {
+    let task = TaskFn::arc("fail-once", |_ctx: TaskContext| async move {
         Err(TaskError::Fail {
             reason: "boom".to_string(),
             exit_code: None,
@@ -103,7 +103,7 @@ async fn on_failure_flaky_retries_then_succeeds_failure_source_backoff() {
 
     let remaining = Arc::new(AtomicU32::new(2));
     let r = remaining.clone();
-    let task = TaskFn::arc("flaky", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("flaky", move |_ctx: TaskContext| {
         let r = r.clone();
         async move {
             let prev = r.fetch_sub(1, Ordering::SeqCst);
@@ -261,7 +261,7 @@ async fn unlimited_retries_eventual_success_no_max_retries_reason() {
 
     let n = Arc::new(AtomicU32::new(0));
     let nc = n.clone();
-    let task = TaskFn::arc("eventual", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("eventual", move |_ctx: TaskContext| {
         let nc = nc.clone();
         async move {
             let c = nc.fetch_add(1, Ordering::SeqCst);
@@ -311,7 +311,7 @@ async fn always_interval_none_restarts_repeatedly_no_backoff_scheduled() {
 
     let counter = Arc::new(AtomicU32::new(0));
     let cc = counter.clone();
-    let task = TaskFn::arc("rerun", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("rerun", move |_ctx: TaskContext| {
         let cc = cc.clone();
         async move {
             cc.fetch_add(1, Ordering::SeqCst);
@@ -353,7 +353,7 @@ async fn always_interval_some_emits_success_source_backoff_between_runs() {
 
     let counter = Arc::new(AtomicU32::new(0));
     let cc = counter.clone();
-    let task = TaskFn::arc("periodic", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("periodic", move |_ctx: TaskContext| {
         let cc = cc.clone();
         async move {
             cc.fetch_add(1, Ordering::SeqCst);
@@ -403,7 +403,7 @@ async fn success_driven_restart_does_not_consume_failure_retry_budget() {
 
     let n = Arc::new(AtomicU32::new(0));
     let nc = n.clone();
-    let task = TaskFn::arc("recover", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("recover", move |_ctx: TaskContext| {
         let nc = nc.clone();
         async move {
             let c = nc.fetch_add(1, Ordering::SeqCst);

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -10,7 +10,7 @@ use taskvisor::prelude::*;
 
 /// Task that ignores cancellation and sleeps far longer than any test grace.
 fn make_stubborn(name: &str) -> TaskRef {
-    TaskFn::arc(name, |_ctx: CancellationToken| async move {
+    TaskFn::arc(name, |_ctx: TaskContext| async move {
         tokio::time::sleep(Duration::from_secs(30)).await;
         Ok(())
     })
@@ -206,7 +206,7 @@ async fn run_blocks_while_gated_task_alive_then_unblocks_on_completion() {
     let gate = Arc::new(tokio::sync::Notify::new());
 
     let g = gate.clone();
-    let task = TaskFn::arc("gated", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("gated", move |_ctx: TaskContext| {
         let g = g.clone();
         async move {
             g.notified().await;

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -16,7 +16,7 @@ async fn per_attempt_timeout_emits_timeout_hit_before_task_failed_then_retries()
     let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
     let sup = Supervisor::new(SupervisorConfig::default(), subs);
 
-    let task = TaskFn::arc("slow", |_ctx: CancellationToken| async move {
+    let task = TaskFn::arc("slow", |_ctx: TaskContext| async move {
         tokio::time::sleep(Duration::from_secs(3600)).await;
         Ok(())
     });
@@ -72,7 +72,7 @@ async fn timeout_then_success_unlimited_retries_exhausts_on_success() {
 
     let n = Arc::new(AtomicU32::new(0));
     let nc = n.clone();
-    let task = TaskFn::arc("slow-then-ok", move |_ctx: CancellationToken| {
+    let task = TaskFn::arc("slow-then-ok", move |_ctx: TaskContext| {
         let nc = nc.clone();
         async move {
             let c = nc.fetch_add(1, Ordering::SeqCst);
@@ -127,7 +127,7 @@ async fn zero_timeout_means_no_timeout_task_runs_to_completion() {
     let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
     let sup = Supervisor::new(SupervisorConfig::default(), subs);
 
-    let task = TaskFn::arc("zero-to", |_ctx: CancellationToken| async move {
+    let task = TaskFn::arc("zero-to", |_ctx: TaskContext| async move {
         tokio::time::sleep(Duration::from_millis(30)).await;
         Ok(())
     });

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -172,7 +172,7 @@ async fn failed_outcome_after_task_panic_with_never_policy() {
 async fn spurious_canceled_return_resolves_canceled_outcome() {
     let (_sup, handle) = supervisor();
 
-    let liar: TaskRef = TaskFn::arc("liar-watch", |_ctx: CancellationToken| async {
+    let liar: TaskRef = TaskFn::arc("liar-watch", |_ctx: TaskContext| async {
         Err(TaskError::Canceled)
     });
     let (_id, waiter) = handle
@@ -201,7 +201,7 @@ async fn shutdown_drain_force_aborts_stubborn_watched_task() {
     let sup = Supervisor::new(cfg, vec![]);
     let handle = sup.serve();
 
-    let stubborn: TaskRef = TaskFn::arc("stubborn-watch", |_ctx: CancellationToken| async {
+    let stubborn: TaskRef = TaskFn::arc("stubborn-watch", |_ctx: TaskContext| async {
         tokio::time::sleep(Duration::from_secs(60)).await;
         Ok(())
     });
@@ -274,7 +274,7 @@ async fn force_aborted_outcome_for_noncooperative_task() {
     let sup = Supervisor::new(cfg, vec![]);
     let handle = sup.serve();
 
-    let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: CancellationToken| async move {
+    let stubborn: TaskRef = TaskFn::arc("stubborn", |_ctx: TaskContext| async move {
         tokio::time::sleep(Duration::from_secs(60)).await;
         Ok(())
     });


### PR DESCRIPTION
## 📝 Description

Replaces the raw tokio_util::sync::CancellationToken in Task::spawn and TaskFn closures with an owned TaskContext.
Exposes the raw only via cancellation_token() behind the opt-in `tokio-util-interop` feature.

## 🔄 Related Issues
Resolves #95 

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally

## Breaking
- `Task::spawn(&self, ctx: TaskContext)`; `TaskFn` closures: `|ctx: TaskContext|`
- prelude re-exports `CancellationToken` only with `tokio-util-interop`
