### PR TITLE
[error] Preserve error sources across task outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         async move {
             let n = attempts.fetch_add(1, Ordering::Relaxed) + 1;
             if n < 3 {
-                Err(TaskError::Fail { reason: format!("boom #{n}"), exit_code: None })
+                Err(TaskError::fail(format!("boom #{n}")))
             } else {
                 Ok(()) // 3rd attempt succeeds
             }
@@ -261,14 +261,14 @@ Each subscriber gets its own bounded queue - a slow subscriber never blocks othe
 
 Return these from your task to control what happens next:
 
-| Return                                        | Retryable | What happens                                                               |
-|-----------------------------------------------|-----------|----------------------------------------------------------------------------|
-| `Ok(())`                                      | -         | Task completed. `RestartPolicy` decides next step.                         |
-| `Err(TaskError::Fail { reason, exit_code })`  | Yes       | Retryable failure. Backoff, then retry.                                    |
-| `Err(TaskError::Timeout { .. })`              | Yes       | Set automatically when per-task timeout is exceeded.                       |
-| `Err(TaskError::Fatal { reason, exit_code })` | No        | Permanent failure. Actor stops, publishes `ActorDead`.                     |
-| `Err(TaskError::Canceled)`                    | No        | Graceful shutdown. Not an error.                                           |
-| `panic!` in the task body                     | Yes       | Caught and converted to `TaskError::Fail`; backoff, then retry per policy. |
+| Return                           | Retryable | What happens                                                                |
+|----------------------------------|-----------|-----------------------------------------------------------------------------|
+| `Ok(())`                         | -         | Task completed. `RestartPolicy` decides next step.                          |
+| `panic!` in the task body        | Yes       | Caught and converted to `TaskError::Fail`; backoff, then retry per policy.  |
+| `Err(TaskError::fail(reason))`   | Yes       | Retryable failure. Backoff, then retry. Wrap a cause with `fail_from(err)`. |
+| `Err(TaskError::Timeout { .. })` | Yes       | Set automatically when per-task timeout is exceeded.                        |
+| `Err(TaskError::fatal(reason))`  | No        | Permanent failure. Actor stops, publishes `ActorDead`. See `fatal_from`.    |
+| `Err(TaskError::Canceled)`       | No        | Graceful shutdown. Not an error.                                            |
 
 `exit_code` is `Option<i32>`: use when the error comes from a process-like runtime, pass `None` for logical errors. 
 Subscribers receive it as `Event::exit_code` on `TaskFailed` / `ActorDead` / `ActorExhausted`.

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -114,10 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if n <= 3 {
                 println!("[flaky-job] attempt #{n}: fail");
-                Err(TaskError::Fail {
-                    reason: format!("attempt #{n}"),
-                    exit_code: None,
-                })
+                Err(TaskError::fail(format!("attempt #{n}")))
             } else {
                 println!("[flaky-job] attempt #{n}: success!");
                 Ok(())

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -74,10 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             if n < 3 {
-                Err(TaskError::Fail {
-                    reason: format!("attempt #{n} not ready yet"),
-                    exit_code: None,
-                })
+                Err(TaskError::fail(format!("attempt #{n} not ready yet")))
             } else {
                 println!("[resilient] success on attempt #{n}!");
                 Ok(())

--- a/examples/outcomes.rs
+++ b/examples/outcomes.rs
@@ -88,10 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         async move {
             let n = attempts.fetch_add(1, Ordering::Relaxed) + 1;
             println!("  sync attempt #{n} failing...");
-            Err(TaskError::Fail {
-                reason: "upstream 503".into(),
-                exit_code: Some(75),
-            })
+            Err(TaskError::fail("upstream 503").with_exit_code(75))
         }
     });
     let spec = TaskSpec::restartable(flaky)
@@ -107,7 +104,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .wait()
         .await?
     {
-        TaskOutcome::Failed { reason, exit_code } => {
+        TaskOutcome::Failed {
+            reason, exit_code, ..
+        } => {
             println!("  sync -> Failed: {reason} (exit_code={exit_code:?})\n");
         }
         other => println!("  sync -> {other:?}\n"),

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -70,6 +70,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     TaskError,
     core::runner::run_once,
+    error::SharedError,
     events::{Bus, Event, EventKind},
     identity::TaskId,
     policies::{BackoffPolicy, RestartPolicy},
@@ -80,7 +81,7 @@ use crate::{
 ///
 /// Used to determine what event to publish, whether to clean up the task from registry, and which [`TaskOutcome`](crate::TaskOutcome)
 /// to deliver to a watcher (see [`Registry::report_join`](super::registry::Registry)).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) enum ActorExitReason {
     /// Final attempt succeeded and the restart policy forbids another run.
     ///
@@ -100,6 +101,8 @@ pub(crate) enum ActorExitReason {
         reason: Arc<str>,
         /// Numeric exit code from a process-like runtime, if any.
         exit_code: Option<i32>,
+        /// Underlying cause from the final [`TaskError`], carried to the completion plane.
+        source: Option<SharedError>,
     },
 
     /// Actor was canceled due shutdown signal, explicit removal, or the task itself reporting `TaskError::Canceled`.
@@ -114,6 +117,8 @@ pub(crate) enum ActorExitReason {
         reason: Arc<str>,
         /// Numeric exit code from a process-like runtime, if any.
         exit_code: Option<i32>,
+        /// Underlying cause from the [`TaskError::Fatal`], carried to the completion plane.
+        source: Option<SharedError>,
     },
 }
 
@@ -274,6 +279,7 @@ impl TaskActor {
                 Err(e) if e.is_fatal() => {
                     let reason: Arc<str> = Arc::from(e.to_string());
                     let exit_code = e.exit_code();
+                    let source: Option<SharedError> = e.into_source().map(Arc::from);
 
                     let mut ev = Event::new(EventKind::ActorDead)
                         .with_task(task_name.clone())
@@ -284,7 +290,11 @@ impl TaskActor {
                         ev = ev.with_exit_code(code);
                     }
                     self.bus.publish(ev);
-                    return ActorExitReason::Fatal { reason, exit_code };
+                    return ActorExitReason::Fatal {
+                        reason,
+                        exit_code,
+                        source,
+                    };
                 }
                 Err(TaskError::Canceled) => {
                     if runtime_token.is_cancelled() {
@@ -318,6 +328,7 @@ impl TaskActor {
                             Arc::from(e.to_string())
                         };
                         let exit_code = e.exit_code();
+                        let source: Option<SharedError> = e.into_source().map(Arc::from);
 
                         let mut ev = Event::new(EventKind::ActorExhausted)
                             .with_task(task_name.clone())
@@ -328,7 +339,11 @@ impl TaskActor {
                             ev = ev.with_exit_code(code);
                         }
                         self.bus.publish(ev);
-                        return ActorExitReason::Exhausted { reason, exit_code };
+                        return ActorExitReason::Exhausted {
+                            reason,
+                            exit_code,
+                            source,
+                        };
                     }
 
                     let delay = self.params.backoff.next(backoff_attempt);
@@ -420,12 +435,7 @@ mod tests {
             "fail"
         }
         fn spawn(&self, _ctx: TaskContext) -> BoxFut {
-            Box::pin(async {
-                Err(TaskError::Fail {
-                    reason: "boom".into(),
-                    exit_code: None,
-                })
-            })
+            Box::pin(async { Err(TaskError::fail("boom")) })
         }
     }
 
@@ -435,12 +445,7 @@ mod tests {
             "fatal"
         }
         fn spawn(&self, _ctx: TaskContext) -> BoxFut {
-            Box::pin(async {
-                Err(TaskError::Fatal {
-                    reason: "fatal".into(),
-                    exit_code: None,
-                })
-            })
+            Box::pin(async { Err(TaskError::fatal("fatal")) })
         }
     }
 
@@ -461,12 +466,7 @@ mod tests {
         fn spawn(&self, _ctx: TaskContext) -> BoxFut {
             let prev = self.remaining.fetch_sub(1, Ordering::SeqCst);
             if prev > 0 {
-                Box::pin(async {
-                    Err(TaskError::Fail {
-                        reason: "transient".into(),
-                        exit_code: None,
-                    })
-                })
+                Box::pin(async { Err(TaskError::fail("transient")) })
             } else {
                 Box::pin(async { Ok(()) })
             }
@@ -477,14 +477,14 @@ mod tests {
     async fn never_ok_returns_completed() {
         let a = actor(Arc::new(OkTask), RestartPolicy::Never, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::Completed);
+        assert!(matches!(reason, ActorExitReason::Completed));
     }
 
     #[tokio::test]
     async fn on_failure_ok_returns_completed() {
         let a = actor(Arc::new(OkTask), RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::Completed);
+        assert!(matches!(reason, ActorExitReason::Completed));
     }
 
     #[tokio::test]
@@ -492,7 +492,9 @@ mod tests {
         let a = actor(Arc::new(FatalTask), RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
         match reason {
-            ActorExitReason::Fatal { reason, exit_code } => {
+            ActorExitReason::Fatal {
+                reason, exit_code, ..
+            } => {
                 assert!(
                     reason.contains("fatal"),
                     "reason must carry the error: {reason}"
@@ -528,7 +530,7 @@ mod tests {
             0,
         );
         let reason = a.run(token).await;
-        assert_eq!(reason, ActorExitReason::Canceled);
+        assert!(matches!(reason, ActorExitReason::Canceled));
     }
 
     #[tokio::test]
@@ -536,6 +538,6 @@ mod tests {
         let task = Arc::new(CountedTask::new(2));
         let a = actor(task, RestartPolicy::OnFailure, 0);
         let reason = a.run(CancellationToken::new()).await;
-        assert_eq!(reason, ActorExitReason::Completed);
+        assert!(matches!(reason, ActorExitReason::Completed));
     }
 }

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot;
 
-use crate::error::RuntimeError;
+use crate::error::{RuntimeError, SharedError};
 use crate::identity::TaskId;
 
 /// Final result of a supervised task run.
@@ -74,29 +74,35 @@ use crate::identity::TaskId;
 /// - [`RestartPolicy`](crate::RestartPolicy) / [`BackoffPolicy`](crate::BackoffPolicy) - decide how many attempts happen first
 /// - [`EventKind`](crate::EventKind) - per-attempt observability on the event bus
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum TaskOutcome {
     /// Final attempt succeeded and the restart policy did not require another run.
     Completed,
 
     /// Final attempt failed and no further retries were allowed (non-retryable error, `RestartPolicy::Never`, or `max_retries` exhausted).
+    #[non_exhaustive]
     Failed {
         /// Final failure message (byte-identical to the `ActorExhausted` event reason).
         reason: Arc<str>,
         /// Numeric exit code from a process-like runtime; `None` for logical errors.
         exit_code: Option<i32>,
+        /// Underlying cause, preserved end-to-end from [`TaskError`](crate::TaskError) (see [`source`](Self::source)).
+        source: Option<SharedError>,
     },
 
     /// Task returned [`TaskError::Fatal`](crate::TaskError::Fatal); no retries were attempted.
+    #[non_exhaustive]
     Fatal {
         /// Fatal error message (byte-identical to the `ActorDead` event reason).
         reason: Arc<str>,
         /// Numeric exit code from a process-like runtime; `None` for logical errors.
         exit_code: Option<i32>,
+        /// Underlying cause, preserved end-to-end from [`TaskError`](crate::TaskError) (see [`source`](Self::source)).
+        source: Option<SharedError>,
     },
 
-    /// Task was canceled: shutdown, explicit [`remove`](crate::SupervisorHandle::remove)/
-    /// [`cancel`](crate::SupervisorHandle::cancel), or the task itself returned [`TaskError::Canceled`](crate::TaskError::Canceled).
+    /// Task was canceled:
+    /// shutdown, explicit [`remove`](crate::SupervisorHandle::remove)/[`cancel`](crate::SupervisorHandle::cancel), or the task itself returned [`TaskError::Canceled`](crate::TaskError::Canceled).
     Canceled,
 
     /// Task ignored cooperative cancellation and was force-aborted after the grace period.
@@ -121,6 +127,23 @@ impl TaskOutcome {
     #[must_use]
     pub fn is_success(&self) -> bool {
         matches!(self, TaskOutcome::Completed)
+    }
+
+    /// Returns the underlying error that caused a [`Failed`](Self::Failed)/[`Fatal`](Self::Fatal)
+    /// outcome, if a cause was attached (e.g. via [`TaskError::fail_from`](crate::TaskError::fail_from)).
+    ///
+    /// Enables `downcast_ref` and `anyhow`/`eyre` chaining on the guaranteed completion plane.
+    #[must_use]
+    pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TaskOutcome::Failed { source, .. } | TaskOutcome::Fatal { source, .. } => {
+                source.as_ref().map(|e| {
+                    let e: &(dyn std::error::Error + 'static) = e.as_ref();
+                    e
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Stable machine-readable label (for metrics/logging).
@@ -202,10 +225,12 @@ mod tests {
             TaskOutcome::Failed {
                 reason: Arc::from("x"),
                 exit_code: None,
+                source: None,
             },
             TaskOutcome::Fatal {
                 reason: Arc::from("x"),
                 exit_code: Some(1),
+                source: None,
             },
             TaskOutcome::Canceled,
             TaskOutcome::ForceAborted,
@@ -223,12 +248,47 @@ mod tests {
         assert!(!TaskOutcome::Panicked.is_success());
     }
 
+    #[test]
+    fn failed_outcome_exposes_downcastable_source() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let outcome = TaskOutcome::Failed {
+            reason: Arc::from("denied"),
+            exit_code: None,
+            source: Some(Arc::new(io)),
+        };
+
+        let src = outcome
+            .source()
+            .expect("a Failed outcome with a cause must expose its source");
+        assert_eq!(
+            src.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn sourceless_outcomes_report_no_source() {
+        assert!(TaskOutcome::Completed.source().is_none());
+        assert!(
+            TaskOutcome::Failed {
+                reason: Arc::from("plain"),
+                exit_code: Some(1),
+                source: None,
+            }
+            .source()
+            .is_none()
+        );
+    }
+
     #[tokio::test]
     async fn waiter_resolves_with_sent_outcome() {
         let (tx, rx) = oneshot::channel();
         let waiter = TaskWaiter::new(TaskId::next(), rx);
         tx.send(TaskOutcome::Completed).unwrap();
-        assert_eq!(waiter.wait().await.unwrap(), TaskOutcome::Completed);
+        assert!(matches!(
+            waiter.wait().await.unwrap(),
+            TaskOutcome::Completed
+        ));
     }
 
     #[tokio::test]

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -494,12 +494,24 @@ impl Registry {
         match res {
             Ok(ActorExitReason::Completed) => TaskOutcome::Completed,
             Ok(ActorExitReason::Canceled) => TaskOutcome::Canceled,
-            Ok(ActorExitReason::Exhausted { reason, exit_code }) => {
-                TaskOutcome::Failed { reason, exit_code }
-            }
-            Ok(ActorExitReason::Fatal { reason, exit_code }) => {
-                TaskOutcome::Fatal { reason, exit_code }
-            }
+            Ok(ActorExitReason::Exhausted {
+                reason,
+                exit_code,
+                source,
+            }) => TaskOutcome::Failed {
+                reason,
+                exit_code,
+                source,
+            },
+            Ok(ActorExitReason::Fatal {
+                reason,
+                exit_code,
+                source,
+            }) => TaskOutcome::Fatal {
+                reason,
+                exit_code,
+                source,
+            },
             Err(e) if e.is_panic() => TaskOutcome::Panicked,
             Err(_aborted) => TaskOutcome::ForceAborted,
         }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -73,10 +73,7 @@ fn panic_to_error(payload: &(dyn std::any::Any + Send)) -> TaskError {
         .copied()
         .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
         .unwrap_or("non-string panic payload");
-    TaskError::Fail {
-        reason: format!("task panicked: {msg}"),
-        exit_code: None,
-    }
+    TaskError::fail(format!("task panicked: {msg}"))
 }
 
 /// Executes a single attempt of `task`, publishing lifecycle events to `bus`.
@@ -254,12 +251,7 @@ mod tests {
         }
 
         fn spawn(&self, _ctx: TaskContext) -> BoxFut {
-            Box::pin(async {
-                Err(TaskError::Fail {
-                    reason: "boom".into(),
-                    exit_code: None,
-                })
-            })
+            Box::pin(async { Err(TaskError::fail("boom")) })
         }
     }
 

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -547,9 +547,7 @@ impl Supervisor {
                 self.bus.publish(Event::new(EventKind::ShutdownRequested));
                 self.drain_with_grace().await
             }
-            Err(e) => Err(RuntimeError::SignalSetupFailed {
-                reason: Arc::from(e.to_string()),
-            }),
+            Err(e) => Err(RuntimeError::SignalSetupFailed { source: e }),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,14 @@ use thiserror::Error;
 
 use crate::identity::TaskId;
 
+/// Boxed, type-erased source error carried by [`TaskError`] failure variants.
+///
+/// Failures cross task/thread boundaries and chain into `anyhow`/`eyre` via [`std::error::Error::source`].
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Shared, type-erased source error carried on the completion plane ([`TaskOutcome`](crate::TaskOutcome)).
+pub type SharedError = Arc<dyn std::error::Error + Send + Sync + 'static>;
+
 /// # Errors produced by the taskvisor runtime.
 ///
 /// These represent failures in the orchestration system itself.
@@ -53,10 +61,11 @@ pub enum RuntimeError {
         timeout: Duration,
     },
     /// OS signal-listener registration failed; signal-based shutdown is unavailable.
-    #[error("failed to install shutdown signal handlers: {reason}")]
+    #[error("failed to install shutdown signal handlers: {source}")]
     SignalSetupFailed {
-        /// The underlying I/O error from signal registration, rendered as text.
-        reason: Arc<str>,
+        /// The underlying I/O error from signal registration (preserves [`ErrorKind`](std::io::ErrorKind)).
+        #[source]
+        source: std::io::Error,
     },
     /// The supervisor runtime is shutting down; the command channel is closed.
     #[error("supervisor is shutting down")]
@@ -96,22 +105,30 @@ pub enum TaskError {
 
     /// Non-recoverable fatal error (should not be retried).
     #[error("fatal error (no retry): {reason}")]
+    #[non_exhaustive]
     Fatal {
         /// Human-readable failure reason (rendered by `Display`).
         reason: String,
         /// Numeric exit code when the error came from a process-like runtime;
         /// `None` for logical errors with no process behind them.
         exit_code: Option<i32>,
+        /// Underlying error, preserved for [`source`](std::error::Error::source) chains.
+        #[source]
+        source: Option<BoxError>,
     },
 
     /// Task execution failed but may succeed if retried.
     #[error("execution failed: {reason}")]
+    #[non_exhaustive]
     Fail {
         /// Human-readable failure reason (rendered by `Display`).
         reason: String,
         /// Numeric exit code when the error came from a process-like runtime;
         /// `None` for logical errors with no process behind them.
         exit_code: Option<i32>,
+        /// Underlying error, preserved for [`source`](std::error::Error::source) chains.
+        #[source]
+        source: Option<BoxError>,
     },
 
     /// Task was canceled due to shut down or parent cancellation.
@@ -120,6 +137,76 @@ pub enum TaskError {
 }
 
 impl TaskError {
+    /// A retryable failure with a human-readable reason and no underlying error.
+    pub fn fail(reason: impl Into<String>) -> Self {
+        TaskError::Fail {
+            reason: reason.into(),
+            exit_code: None,
+            source: None,
+        }
+    }
+
+    /// A permanent (non-retryable) failure with a human-readable reason and no underlying error.
+    pub fn fatal(reason: impl Into<String>) -> Self {
+        TaskError::Fatal {
+            reason: reason.into(),
+            exit_code: None,
+            source: None,
+        }
+    }
+
+    /// A retryable failure wrapping an underlying error.
+    pub fn fail_from<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        TaskError::Fail {
+            reason: source.to_string(),
+            exit_code: None,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// A permanent failure wrapping an underlying error (see [`fail_from`](Self::fail_from)).
+    pub fn fatal_from<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        TaskError::Fatal {
+            reason: source.to_string(),
+            exit_code: None,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Builder: attach a process-style exit code to a [`Fail`](Self::Fail)/[`Fatal`](Self::Fatal) error.
+    #[must_use]
+    pub fn with_exit_code(mut self, code: impl Into<Option<i32>>) -> Self {
+        let code = code.into();
+        if let TaskError::Fail { exit_code, .. } | TaskError::Fatal { exit_code, .. } = &mut self {
+            *exit_code = code;
+        }
+        self
+    }
+
+    /// Builder: attach an underlying source error to a [`Fail`](Self::Fail)/[`Fatal`](Self::Fatal) error.
+    #[must_use]
+    pub fn with_source(mut self, source: impl Into<BoxError>) -> Self {
+        if let TaskError::Fail { source: s, .. } | TaskError::Fatal { source: s, .. } = &mut self {
+            *s = Some(source.into());
+        }
+        self
+    }
+
+    /// Consumes the error and returns its underlying source, if any.
+    #[must_use]
+    pub fn into_source(self) -> Option<BoxError> {
+        match self {
+            TaskError::Fail { source, .. } | TaskError::Fatal { source, .. } => source,
+            _ => None,
+        }
+    }
+
     /// Returns a short stable label.
     #[must_use]
     pub fn as_label(&self) -> &'static str {
@@ -160,10 +247,7 @@ mod tests {
 
     #[test]
     fn exit_code_is_some_for_fail_with_code() {
-        let e = TaskError::Fail {
-            reason: "x".into(),
-            exit_code: Some(5),
-        };
+        let e = TaskError::fail("x").with_exit_code(5);
         assert_eq!(e.exit_code(), Some(5));
         assert!(e.is_retryable());
         assert!(!e.is_fatal());
@@ -171,10 +255,7 @@ mod tests {
 
     #[test]
     fn exit_code_is_some_for_fatal_with_code() {
-        let e = TaskError::Fatal {
-            reason: "x".into(),
-            exit_code: Some(137),
-        };
+        let e = TaskError::fatal("x").with_exit_code(137);
         assert_eq!(e.exit_code(), Some(137));
         assert!(!e.is_retryable());
         assert!(e.is_fatal());
@@ -182,10 +263,7 @@ mod tests {
 
     #[test]
     fn exit_code_is_none_for_logical_fail() {
-        let e = TaskError::Fail {
-            reason: "logical".into(),
-            exit_code: None,
-        };
+        let e = TaskError::fail("logical");
         assert_eq!(e.exit_code(), None);
     }
 
@@ -204,10 +282,78 @@ mod tests {
 
     #[test]
     fn display_still_renders_reason_only() {
-        let e = TaskError::Fail {
-            reason: "boom".into(),
-            exit_code: Some(1),
-        };
+        let e = TaskError::fail("boom").with_exit_code(1);
         assert_eq!(e.to_string(), "execution failed: boom");
+    }
+
+    #[test]
+    fn fail_constructor_is_retryable_and_sourceless() {
+        let e = TaskError::fail("logical");
+        assert_eq!(e.to_string(), "execution failed: logical");
+        assert!(e.is_retryable());
+        assert_eq!(e.exit_code(), None);
+        assert!(std::error::Error::source(&e).is_none());
+    }
+
+    #[test]
+    fn fail_from_preserves_source_chain_and_io_kind() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let e = TaskError::fail_from(io);
+
+        assert!(e.to_string().contains("denied"));
+        let src = std::error::Error::source(&e).expect("source must be present");
+        let io_ref = src
+            .downcast_ref::<std::io::Error>()
+            .expect("source must downcast to the original io::Error");
+        assert_eq!(io_ref.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn with_exit_code_and_with_source_builders_compose() {
+        let io = std::io::Error::other("boom");
+        let e = TaskError::fail("upload failed")
+            .with_exit_code(13)
+            .with_source(io);
+
+        assert_eq!(e.exit_code(), Some(13));
+        assert_eq!(e.to_string(), "execution failed: upload failed");
+        assert!(std::error::Error::source(&e).is_some());
+    }
+
+    #[test]
+    fn with_exit_code_accepts_bare_and_option() {
+        assert_eq!(TaskError::fail("x").with_exit_code(7).exit_code(), Some(7));
+        let dynamic: Option<i32> = None;
+        assert_eq!(
+            TaskError::fail("y").with_exit_code(dynamic).exit_code(),
+            None
+        );
+    }
+
+    #[test]
+    fn fatal_from_is_fatal_and_carries_source() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let e = TaskError::fatal_from(io);
+
+        assert!(e.is_fatal());
+        assert!(!e.is_retryable());
+        let src = std::error::Error::source(&e).expect("source present");
+        assert_eq!(
+            src.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn signal_setup_failed_exposes_io_source() {
+        let io = std::io::Error::new(std::io::ErrorKind::AddrInUse, "in use");
+        let e = RuntimeError::SignalSetupFailed { source: io };
+
+        assert!(e.to_string().contains("in use"));
+        let src = std::error::Error::source(&e).expect("source present");
+        assert_eq!(
+            src.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::AddrInUse
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ mod events;
 pub use events::{BackoffSource, Event, EventKind};
 
 mod error;
-pub use error::{RuntimeError, TaskError};
+pub use error::{BoxError, RuntimeError, SharedError, TaskError};
 
 mod subscribers;
 pub use subscribers::Subscribe;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -134,19 +134,13 @@ pub fn make_ok_once(name: &str) -> TaskRef {
 
 pub fn make_fail(name: &str, exit_code: Option<i32>) -> TaskRef {
     TaskFn::arc(name, move |_ctx: TaskContext| async move {
-        Err(TaskError::Fail {
-            reason: "boom".to_string(),
-            exit_code,
-        })
+        Err(TaskError::fail("boom").with_exit_code(exit_code))
     })
 }
 
 pub fn make_fatal(name: &str, exit_code: Option<i32>) -> TaskRef {
     TaskFn::arc(name, move |_ctx: TaskContext| async move {
-        Err(TaskError::Fatal {
-            reason: "unrecoverable".to_string(),
-            exit_code,
-        })
+        Err(TaskError::fatal("unrecoverable").with_exit_code(exit_code))
     })
 }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -48,10 +48,9 @@ async fn submit_and_watch_resolves_completed_for_admitted_task() {
         assert_eq!(waiter.id(), id);
 
         let outcome = waiter.wait().await.expect("waiter errored");
-        assert_eq!(
-            outcome,
-            TaskOutcome::Completed,
-            "an admitted task that succeeds must resolve Completed"
+        assert!(
+            matches!(outcome, TaskOutcome::Completed),
+            "an admitted task that succeeds must resolve Completed, got {outcome:?}"
         );
 
         handle.shutdown().await.expect("shutdown ok");

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -65,10 +65,7 @@ async fn never_oneshot_failure_emits_taskfailed_then_exhausted_no_backoff() {
     let sup = Supervisor::new(SupervisorConfig::default(), subs);
 
     let task = TaskFn::arc("fail-once", |_ctx: TaskContext| async move {
-        Err(TaskError::Fail {
-            reason: "boom".to_string(),
-            exit_code: None,
-        })
+        Err(TaskError::fail("boom".to_string()))
     });
     with_timeout(10, sup.run(vec![TaskSpec::once(task)]))
         .await
@@ -108,10 +105,7 @@ async fn on_failure_flaky_retries_then_succeeds_failure_source_backoff() {
         async move {
             let prev = r.fetch_sub(1, Ordering::SeqCst);
             if prev > 0 {
-                Err(TaskError::Fail {
-                    reason: "transient-err".to_string(),
-                    exit_code: None,
-                })
+                Err(TaskError::fail("transient-err".to_string()))
             } else {
                 Ok(())
             }
@@ -266,10 +260,7 @@ async fn unlimited_retries_eventual_success_no_max_retries_reason() {
         async move {
             let c = nc.fetch_add(1, Ordering::SeqCst);
             if c < 3 {
-                Err(TaskError::Fail {
-                    reason: "still-failing".to_string(),
-                    exit_code: None,
-                })
+                Err(TaskError::fail("still-failing".to_string()))
             } else {
                 Ok(())
             }
@@ -408,10 +399,7 @@ async fn success_driven_restart_does_not_consume_failure_retry_budget() {
         async move {
             let c = nc.fetch_add(1, Ordering::SeqCst);
             if c == 0 {
-                Err(TaskError::Fail {
-                    reason: "first-fails".to_string(),
-                    exit_code: None,
-                })
+                Err(TaskError::fail("first-fails".to_string()))
             } else {
                 Ok(())
             }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -52,7 +52,9 @@ async fn outcome_reason_is_byte_identical_to_the_event_reason() {
         .expect("ActorExhausted event for the run");
 
     match outcome {
-        TaskOutcome::Failed { reason, exit_code } => {
+        TaskOutcome::Failed {
+            reason, exit_code, ..
+        } => {
             assert_eq!(
                 &*reason,
                 event.reason.as_deref().expect("event carries a reason"),
@@ -79,7 +81,7 @@ async fn completed_outcome_for_successful_once_task() {
     let outcome = with_timeout(5, waiter.wait())
         .await
         .expect("waiter errored");
-    assert_eq!(outcome, TaskOutcome::Completed);
+    assert!(matches!(outcome, TaskOutcome::Completed));
     assert!(outcome.is_success());
 
     let _ = handle.shutdown().await;
@@ -101,7 +103,9 @@ async fn failed_outcome_carries_reason_and_exit_code() {
         .await
         .expect("waiter errored")
     {
-        TaskOutcome::Failed { reason, exit_code } => {
+        TaskOutcome::Failed {
+            reason, exit_code, ..
+        } => {
             assert!(
                 reason.contains("max_retries_exceeded"),
                 "reason must mention exhausted retries: {reason}"
@@ -130,7 +134,9 @@ async fn fatal_outcome_for_fatal_error() {
         .await
         .expect("waiter errored")
     {
-        TaskOutcome::Fatal { reason, exit_code } => {
+        TaskOutcome::Fatal {
+            reason, exit_code, ..
+        } => {
             assert!(
                 reason.contains("unrecoverable"),
                 "reason must carry the fatal message: {reason}"
@@ -183,10 +189,9 @@ async fn spurious_canceled_return_resolves_canceled_outcome() {
     let outcome = with_timeout(5, waiter.wait())
         .await
         .expect("waiter errored");
-    assert_eq!(
-        outcome,
-        TaskOutcome::Canceled,
-        "a task returning Canceled without cancellation must resolve as Canceled"
+    assert!(
+        matches!(outcome, TaskOutcome::Canceled),
+        "a task returning Canceled without cancellation must resolve as Canceled, got {outcome:?}"
     );
 
     let _ = handle.shutdown().await;
@@ -215,9 +220,8 @@ async fn shutdown_drain_force_aborts_stubborn_watched_task() {
         shutdown_res.is_err(),
         "stubborn task must trip GraceExceeded"
     );
-    assert_eq!(
-        outcome.expect("waiter errored"),
-        TaskOutcome::ForceAborted,
+    assert!(
+        matches!(outcome.expect("waiter errored"), TaskOutcome::ForceAborted),
         "the shutdown drain's force-abort must resolve the waiter as ForceAborted"
     );
 }
@@ -260,7 +264,7 @@ async fn cancelled_outcome_when_task_is_cancelled() {
     let outcome = with_timeout(5, waiter.wait())
         .await
         .expect("waiter errored");
-    assert_eq!(outcome, TaskOutcome::Canceled);
+    assert!(matches!(outcome, TaskOutcome::Canceled));
 
     let _ = handle.shutdown().await;
 }
@@ -288,7 +292,7 @@ async fn force_aborted_outcome_for_noncooperative_task() {
     let outcome = with_timeout(5, waiter.wait())
         .await
         .expect("waiter errored");
-    assert_eq!(outcome, TaskOutcome::ForceAborted);
+    assert!(matches!(outcome, TaskOutcome::ForceAborted));
 
     let _ = handle.shutdown().await;
 }
@@ -331,10 +335,9 @@ async fn shutdown_resolves_pending_waiters() {
     let outcome = with_timeout(5, waiter.wait())
         .await
         .expect("waiter errored");
-    assert_eq!(
-        outcome,
-        TaskOutcome::Canceled,
-        "cooperative task must resolve as Canceled on shutdown"
+    assert!(
+        matches!(outcome, TaskOutcome::Canceled),
+        "cooperative task must resolve as Canceled on shutdown, got {outcome:?}"
     );
 }
 
@@ -386,6 +389,37 @@ async fn outcome_is_delivered_even_under_bus_lag() {
         TaskOutcome::Failed { .. } => {}
         other => panic!("expected Failed despite bus lag, got {other:?}"),
     }
+
+    let _ = handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn task_error_source_survives_end_to_end_to_the_outcome() {
+    let (_sup, handle) = supervisor();
+
+    let task: TaskRef = TaskFn::arc("io-fail", |_ctx: TaskContext| async {
+        Err(TaskError::fail_from(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "denied",
+        )))
+    });
+
+    let (_id, waiter) = handle
+        .add_and_watch(TaskSpec::once(task), ADD_TIMEOUT)
+        .await
+        .expect("add_and_watch should succeed");
+
+    let outcome = with_timeout(5, waiter.wait())
+        .await
+        .expect("waiter errored");
+
+    let source = outcome
+        .source()
+        .expect("the task error's source must survive to the completion plane");
+    let io = source
+        .downcast_ref::<std::io::Error>()
+        .expect("source must downcast back to the original io::Error");
+    assert_eq!(io.kind(), std::io::ErrorKind::PermissionDenied);
 
     let _ = handle.shutdown().await;
 }


### PR DESCRIPTION
## 📝 Description
Preserves underlying error sources for TaskError and carries them through to TaskOutcome, while keeping lifecycle events string-based. 

Also stores signal setup failures as real `std::io::Error` sources instead of flattening them to text.

## 🔄 Related Issues
Resolves #93

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally

## Breaking
- `TaskError::Fail` and `TaskError::Fatal` now have a source field. 
   Use `TaskError::fail(...)`, `TaskError::fatal(...)`, `fail_from(...)`, or `fatal_from(...)` instead of struct literals.
- `TaskOutcome` no longer implements `PartialEq / Eq`.
