### PR TITLE
[controller][feat] add realtime snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## See it recover from failure
 
 A task that fails twice, then succeeds - taskvisor retries it with backoff and publishes an event for every step. 
-A subscriber prints them, so you *see* the supervision happen:
+A subscriber prints them, and you *see* the supervision happen:
 
 ```rust,no_run
 use std::sync::Arc;
@@ -447,10 +447,16 @@ let id = handle.submit(ControllerSpec::queue(spec)).await?;
 handle.submit(ControllerSpec::replace(spec)).await?;
 handle.submit(ControllerSpec::drop_if_running(spec)).await?;
 
-// ...or await the outcome directly. If the slot never admits it (busy, queue full,
-// superseded, removed, shutting down) the waiter resolves to TaskOutcome::Rejected.
+// ...or await the outcome directly. If the slot never admits it (busy, queue full, superseded, removed, shutting down) the waiter resolves to TaskOutcome::Rejected.
 let (id, waiter) = handle.submit_and_watch(ControllerSpec::queue(spec)).await?;
 let outcome = waiter.wait().await?;
+
+// Inspect the controller's live state directly - no parsing of bus events.
+// `controller_snapshot()` is the slot-path analogue of `list()`/`snapshot()`.
+if let Some(snap) = handle.controller_snapshot().await {
+    println!("{} running, {} queued", snap.running_count(), snap.total_queued());
+    let depth = snap.slot("deploy").map_or(0, |s| s.queue_depth);
+}
 
 handle.shutdown().await?;
 ```

--- a/benches/controller.rs
+++ b/benches/controller.rs
@@ -14,7 +14,7 @@
 //! | `multi_slot/N`         | N submissions fanned out across `SLOTS` distinct slots, drained.    |
 //!
 //! `queue` and `multi_slot` measure real completion via an event-driven drain (wait for the expected `TaskRemoved` count).
-//! `replace`/`drop_if_running` admit a timing-dependent number of runs, so they time only the admission decisions (teardown is excluded).
+//! `replace`/`drop_if_running` admit a timing-dependent number of runs; time only the admission decisions (teardown is excluded).
 //! `submit_hotpath` isolates the caller-side enqueue cost, and `multi_slot` exercises the per-slot `DashMap` sharding the single-slot benches never touch.
 //!
 //! ## Run

--- a/examples/admission.rs
+++ b/examples/admission.rs
@@ -22,6 +22,7 @@
 //! - `handle.submit_and_watch(ControllerSpec::...)`: submit and get `(TaskId, TaskWaiter)`.
 //! - An **admitted** `Queue` job resolving to `Completed`.
 //! - A **rejected** `DropIfRunning` job (slot busy) resolving to `Rejected { reason }`.
+//! - `handle.controller_snapshot()`: pull the live slot state (status, queue depth) without parsing events.
 //!
 //! ## Enabling the feature
 //!
@@ -67,7 +68,7 @@ fn job(name: &'static str, dur: Duration) -> TaskSpec {
             _ = ctx.cancelled() => Err(TaskError::Canceled),
         }
     });
-    // Same slot "deploy" for every submission, so they contend for one slot.
+    // Same slot "deploy" for every submission; they contend for one slot.
     TaskSpec::once(task).with_slot("deploy")
 }
 
@@ -91,6 +92,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Give it a moment to actually occupy the slot.
     tokio::time::sleep(Duration::from_millis(50)).await;
     println!("    deploy-v1 admitted, now running\n");
+
+    // Pull the controller's live state directly: no parsing of bus events.
+    if let Some(snap) = handle.controller_snapshot().await {
+        let deploy = snap.slot("deploy");
+        println!(
+            "    controller: {} running, {} queued; deploy status={:?} depth={}\n",
+            snap.running_count(),
+            snap.total_queued(),
+            deploy.map(|s| s.status),
+            deploy.map_or(0, |s| s.queue_depth),
+        );
+    }
 
     // 2) While deploy-v1 holds the slot, a DropIfRunning submission is refused.
     //     submit() would only fire a ControllerRejected event on the lossy bus;

--- a/src/controller/core.rs
+++ b/src/controller/core.rs
@@ -43,6 +43,7 @@ use super::{
     error::ControllerError,
     slot::{SlotState, SlotStatus},
     spec::ControllerSpec,
+    view::{ControllerSnapshot, SlotStatusKind, SlotView},
 };
 
 struct Submission {
@@ -179,6 +180,39 @@ impl Controller {
         ControllerHandle {
             tx: self.tx.clone(),
         }
+    }
+
+    /// Builds a point-in-time [`ControllerSnapshot`] of all tracked slots.
+    pub(crate) async fn snapshot(&self) -> ControllerSnapshot {
+        let keys: Vec<Arc<str>> = self.slots.iter().map(|e| Arc::clone(e.key())).collect();
+
+        let mut slots = Vec::with_capacity(keys.len());
+        for key in keys {
+            let Some(slot_arc) = self.slots.get(&*key).map(|e| e.clone()) else {
+                continue;
+            };
+            let slot = slot_arc.lock().await;
+            let (status, status_for) = match slot.status {
+                SlotStatus::Idle => (SlotStatusKind::Idle, Duration::ZERO),
+                SlotStatus::Admitting { since } => (SlotStatusKind::Admitting, since.elapsed()),
+                SlotStatus::Running { started_at } => {
+                    (SlotStatusKind::Running, started_at.elapsed())
+                }
+                SlotStatus::Terminating { cancelled_at } => {
+                    (SlotStatusKind::Terminating, cancelled_at.elapsed())
+                }
+            };
+            slots.push(SlotView {
+                slot: Arc::clone(&key),
+                status,
+                running: slot.running_id,
+                queue_depth: slot.queue.len(),
+                status_for,
+            });
+        }
+
+        slots.sort_by(|a, b| a.slot.cmp(&b.slot));
+        ControllerSnapshot { slots }
     }
 
     /// Starts the controller loop (spawns in background).
@@ -339,9 +373,6 @@ impl Controller {
     }
 
     /// Applies the admission policy for a new submission.
-    ///
-    /// The body is a match on `(slot status, admission policy)`;
-    /// this table is the same grid, so it should stay in lockstep with the arms below:
     ///
     /// ```text
     /// │              │ Queue                   │ Replace                                │ DropIfRunning │
@@ -603,7 +634,7 @@ impl Controller {
         }
     }
 
-    /// `TaskAddFailed`: admission was rejected (e.g. duplicate name) free the slot and start the next queued task, so a slot can never wedge in `Admitting`.
+    /// `TaskAddFailed`: admission was rejected (e.g. duplicate name) free the slot and start the next queued task.
     async fn on_task_add_failed(&self, event: &Event) {
         self.free_and_advance(event).await;
     }
@@ -730,8 +761,6 @@ impl Controller {
     }
 
     /// Replaces the queue head with the new submission (latest-wins) or pushes it.
-    ///
-    /// A displaced queued submission is rejected with `superseded_by_replace`, carrying its id, so submitters can observe that it will never run.
     fn replace_head_or_push(
         &self,
         slot: &mut SlotState,
@@ -1129,6 +1158,43 @@ mod tests {
             superseded,
             "Replace must supersede run-1 with run-2 in the shared slot, not run both"
         );
+
+        let _ = handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_reports_status_running_and_queue_depth() {
+        use crate::controller::SlotStatusKind;
+
+        let (sup, handle, id) = sup_with_live_task().await;
+        let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
+
+        let queued: TaskRef = TaskFn::arc("queued", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back((TaskId::next(), TaskSpec::restartable(queued)));
+        ctrl.slots.insert(
+            Arc::from("s"),
+            Arc::new(Mutex::new(SlotState {
+                status: SlotStatus::Running {
+                    started_at: Instant::now(),
+                },
+                running_id: Some(id),
+                queue,
+            })),
+        );
+
+        let snap = ctrl.snapshot().await;
+        assert_eq!(snap.len(), 1, "one slot tracked");
+        assert_eq!(snap.running_count(), 1);
+        assert_eq!(snap.total_queued(), 1);
+
+        let view = snap.slot("s").expect("slot 's' must be present");
+        assert_eq!(view.status, SlotStatusKind::Running);
+        assert_eq!(view.queue_depth, 1);
+        assert_eq!(view.running, Some(id));
 
         let _ = handle.shutdown().await;
     }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -116,6 +116,9 @@
 //! - Slots advance to next task **only** after `TaskRemoved`.
 //! - `Replace` is **latest-wins** (head replace); `Queue` is FIFO.
 
+mod view;
+pub use view::{ControllerSnapshot, SlotStatusKind, SlotView};
+
 mod admission;
 pub use admission::AdmissionPolicy;
 

--- a/src/controller/view.rs
+++ b/src/controller/view.rs
@@ -1,0 +1,84 @@
+//! Read-only views of controller slot state.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::identity::TaskId;
+
+/// Status discriminant of a controller slot.
+///
+/// An `Instant`-free public mirror of the controller's internal slot status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SlotStatusKind {
+    /// No task running; ready to accept submissions.
+    Idle,
+    /// A task was admitted and the slot awaits its `TaskAdded` confirmation.
+    Admitting,
+    /// A task is currently running in the slot.
+    Running,
+    /// The occupying task is being cancelled (awaiting `TaskRemoved`).
+    Terminating,
+}
+
+/// Point-in-time view of a single controller slot.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SlotView {
+    /// Slot key (`TaskSpec::slot`, defaulting to the task name).
+    pub slot: Arc<str>,
+    /// Current status.
+    pub status: SlotStatusKind,
+    /// Identity of the task currently occupying the slot, if any.
+    pub running: Option<TaskId>,
+    /// Number of submissions waiting in this slot's queue.
+    pub queue_depth: usize,
+    /// How long the slot has been in its current status (`0` for `Idle`).
+    pub status_for: Duration,
+}
+
+/// Point-in-time snapshot of the controller's slots.
+///
+/// **Not globally atomic**: slots are sampled one at a time, exactly like [`SupervisorHandle::list`](crate::SupervisorHandle::list).
+/// Treat the figures as gauges.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ControllerSnapshot {
+    /// All currently tracked slots, sorted by slot key.
+    pub slots: Vec<SlotView>,
+}
+
+impl ControllerSnapshot {
+    /// Number of slots currently `Running`.
+    #[must_use]
+    pub fn running_count(&self) -> usize {
+        self.slots
+            .iter()
+            .filter(|s| s.status == SlotStatusKind::Running)
+            .count()
+    }
+
+    /// Total submissions queued across all slots.
+    #[must_use]
+    pub fn total_queued(&self) -> usize {
+        self.slots.iter().map(|s| s.queue_depth).sum()
+    }
+
+    /// View of a specific slot, if currently tracked.
+    #[must_use]
+    pub fn slot(&self, name: &str) -> Option<&SlotView> {
+        self.slots.iter().find(|s| &*s.slot == name)
+    }
+
+    /// Number of tracked slots.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Whether no slots are tracked.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -313,4 +313,27 @@ impl SupervisorHandle {
         let (id, rx) = self.inner.submit_and_watch(spec).await?;
         Ok((id, TaskWaiter::new(id, rx)))
     }
+
+    /// Returns a point-in-time [`ControllerSnapshot`](crate::ControllerSnapshot) of the controller's slots.
+    ///
+    /// ## Example
+    /// ```rust,no_run
+    /// # use taskvisor::prelude::*;
+    /// # #[tokio::main] async fn main() {
+    /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
+    /// # let handle = sup.serve();
+    /// if let Some(snap) = handle.controller_snapshot().await {
+    ///     println!("{} running, {} queued", snap.running_count(), snap.total_queued());
+    ///     if let Some(web) = snap.slot("web") {
+    ///         println!("web: {:?}, depth {}", web.status, web.queue_depth);
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// Requires the `controller` feature flag.
+    #[cfg(feature = "controller")]
+    pub async fn controller_snapshot(&self) -> Option<crate::controller::ControllerSnapshot> {
+        self.inner.controller_snapshot().await
+    }
 }

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -33,7 +33,7 @@
 //! - The outcome is delivered via `oneshot` (guaranteed, not subject to bus `Lagged` loss).
 //! - The channel is created **atomically with registration**: there is no window in which the task can finish before the waiter exists.
 //! - **Exactly-once by construction**: the sender has a single owner (the registry `Handle`, or the controller `watchers` map before admission);
-//!   ownership transfers to exactly one resolution site, so the waiter is resolved once and never leaks.
+//!   ownership transfers to exactly one resolution site, and the waiter is resolved once and never leaks.
 //! - Dropping a [`TaskWaiter`] is always safe: the matching `send` becomes a no-op.
 //! - The outcome reflects the **final** attempt only; per-attempt results are observable via [`Subscribe`](crate::Subscribe) events.
 //! - `Rejected` is observed only on the controller path: a submission that never ran - never admitted (slot busy, queue full, superseded, removed while queued, shutting down) or rejected at registration (duplicate task name) - resolves there.
@@ -164,7 +164,7 @@ impl TaskOutcome {
 /// Awaitable handle resolving to the [`TaskOutcome`] of a single task run.
 ///
 /// Created by [`SupervisorHandle::add_and_watch`](crate::SupervisorHandle::add_and_watch).
-/// Consumed by [`wait`](Self::wait) (a task terminates exactly once, so the outcome is delivered exactly once).
+/// Consumed by [`wait`](Self::wait) (a task terminates exactly once; the outcome is delivered exactly once).
 ///
 /// ## Example
 /// ```rust,no_run

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -39,7 +39,7 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::time;
 use tokio_util::sync::CancellationToken;
@@ -117,6 +117,7 @@ pub async fn run_once<T: Task + ?Sized>(
     id: TaskId,
     bus: &Bus,
 ) -> Result<(), TaskError> {
+    let started = Instant::now();
     let child = parent.child_token();
     let ctx = TaskContext::from_token(child.clone());
 
@@ -124,7 +125,7 @@ pub async fn run_once<T: Task + ?Sized>(
         Ok(fut) => CatchPanic(fut),
         Err(payload) => {
             let e = panic_to_error(payload.as_ref());
-            publish_failed(bus, id, task.name(), attempt, &e);
+            publish_failed(bus, id, task.name(), attempt, &e, started.elapsed());
             return Err(e);
         }
     };
@@ -134,7 +135,7 @@ pub async fn run_once<T: Task + ?Sized>(
             Ok(r) => r,
             Err(_elapsed) => {
                 child.cancel();
-                publish_timeout(bus, id, task.name(), dur, attempt);
+                publish_timeout(bus, id, task.name(), dur, attempt, started.elapsed());
                 Err(TaskError::Timeout { timeout: dur })
             }
         }
@@ -144,50 +145,56 @@ pub async fn run_once<T: Task + ?Sized>(
 
     match res {
         Ok(()) => {
-            publish_stopped(bus, id, task.name(), attempt);
+            publish_stopped(bus, id, task.name(), attempt, started.elapsed());
             Ok(())
         }
         Err(TaskError::Canceled) => {
-            publish_canceled(bus, id, task.name(), attempt);
+            publish_canceled(bus, id, task.name(), attempt, started.elapsed());
             Err(TaskError::Canceled)
         }
         Err(e) => {
-            publish_failed(bus, id, task.name(), attempt, &e);
+            publish_failed(bus, id, task.name(), attempt, &e, started.elapsed());
             Err(e)
         }
     }
 }
 
-/// Publishes `TaskStopped` event.
-///
-/// successful attempt.
-fn publish_stopped(bus: &Bus, id: TaskId, name: &str, attempt: u32) {
+/// Publishes `TaskStopped` event for a successful attempt, carrying its duration.
+fn publish_stopped(bus: &Bus, id: TaskId, name: &str, attempt: u32, duration: Duration) {
     bus.publish(
         Event::new(EventKind::TaskStopped)
             .with_task(name)
             .with_id(id)
-            .with_attempt(attempt),
+            .with_attempt(attempt)
+            .with_duration(duration),
     );
 }
 
-/// Publishes `TaskCanceled` event.
-///
-/// graceful cancellation of an attempt.
-fn publish_canceled(bus: &Bus, id: TaskId, name: &str, attempt: u32) {
+/// Publishes `TaskCanceled` event for a gracefully cancelled attempt, carrying its duration.
+fn publish_canceled(bus: &Bus, id: TaskId, name: &str, attempt: u32, duration: Duration) {
     bus.publish(
         Event::new(EventKind::TaskCanceled)
             .with_task(name)
             .with_id(id)
-            .with_attempt(attempt),
+            .with_attempt(attempt)
+            .with_duration(duration),
     );
 }
 
-/// Publishes `TaskFailed` event with error details.
-fn publish_failed(bus: &Bus, id: TaskId, name: &str, attempt: u32, err: &TaskError) {
+/// Publishes `TaskFailed` event with error details and the attempt's duration.
+fn publish_failed(
+    bus: &Bus,
+    id: TaskId,
+    name: &str,
+    attempt: u32,
+    err: &TaskError,
+    duration: Duration,
+) {
     let mut ev = Event::new(EventKind::TaskFailed)
         .with_task(name)
         .with_id(id)
         .with_attempt(attempt)
+        .with_duration(duration)
         .with_reason(err.to_string());
     if let Some(code) = err.exit_code() {
         ev = ev.with_exit_code(code);
@@ -196,15 +203,21 @@ fn publish_failed(bus: &Bus, id: TaskId, name: &str, attempt: u32, err: &TaskErr
 }
 
 /// Publishes `TimeoutHit` event.
-///
-/// always followed by `TaskFailed`.
-fn publish_timeout(bus: &Bus, id: TaskId, name: &str, dur: Duration, attempt: u32) {
+fn publish_timeout(
+    bus: &Bus,
+    id: TaskId,
+    name: &str,
+    dur: Duration,
+    attempt: u32,
+    duration: Duration,
+) {
     bus.publish(
         Event::new(EventKind::TimeoutHit)
             .with_task(name)
             .with_id(id)
             .with_timeout(dur)
-            .with_attempt(attempt),
+            .with_attempt(attempt)
+            .with_duration(duration),
     );
 }
 
@@ -294,6 +307,42 @@ mod tests {
             stopped_attempt,
             Some(3),
             "TaskStopped must carry the attempt number"
+        );
+    }
+
+    #[tokio::test]
+    async fn stopped_event_carries_measured_attempt_duration() {
+        struct SleepOk;
+        impl Task for SleepOk {
+            fn name(&self) -> &str {
+                "sleep-ok"
+            }
+            fn spawn(&self, _ctx: TaskContext) -> BoxFut {
+                Box::pin(async {
+                    tokio::time::sleep(Duration::from_millis(30)).await;
+                    Ok(())
+                })
+            }
+        }
+
+        let bus = Bus::new(16);
+        let mut rx = bus.subscribe();
+        let parent = CancellationToken::new();
+
+        run_once(&SleepOk, &parent, None, 1, TaskId::next(), &bus)
+            .await
+            .expect("task succeeds");
+
+        let mut duration_ms = None;
+        while let Ok(ev) = rx.try_recv() {
+            if ev.kind == EventKind::TaskStopped {
+                duration_ms = ev.duration_ms;
+            }
+        }
+        let measured = duration_ms.expect("TaskStopped must carry the attempt duration");
+        assert!(
+            measured >= 20,
+            "attempt duration must reflect the ~30ms of work, got {measured}ms"
         );
     }
 

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -470,6 +470,17 @@ impl Supervisor {
         }
     }
 
+    /// Returns a point-in-time snapshot of the controller's slots, or `None` if no controller is configured.
+    #[cfg(feature = "controller")]
+    pub(crate) async fn controller_snapshot(
+        &self,
+    ) -> Option<crate::controller::ControllerSnapshot> {
+        match self.controller.get() {
+            Some(ctrl) => Some(ctrl.snapshot().await),
+            None => None,
+        }
+    }
+
     /// Listens to the internal event bus and distributes each received [`Event`] to all active subscribers.
     ///
     /// The listener also updates the [`AliveTracker`] before distributing them, to keep the latest per-task state in sync.

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -281,6 +281,8 @@ pub struct Event {
     pub timeout_ms: Option<u32>,
     /// Backoff delay before next attempt in milliseconds (compact).
     pub delay_ms: Option<u32>,
+    /// Wall-clock duration of the attempt in milliseconds (compact).
+    pub duration_ms: Option<u32>,
     /// Human-readable reason (errors, overflow details, etc.).
     pub reason: Option<Arc<str>>,
     /// Attempt count (starting from 1).
@@ -312,6 +314,7 @@ impl Event {
             backoff_source: None,
             timeout_ms: None,
             delay_ms: None,
+            duration_ms: None,
             attempt: None,
             reason: None,
             task: None,
@@ -359,6 +362,15 @@ impl Event {
     pub fn with_delay(mut self, d: Duration) -> Self {
         let ms = d.as_millis().min(u128::from(u32::MAX)) as u32;
         self.delay_ms = Some(ms);
+        self
+    }
+
+    /// Attaches the attempt's wall-clock duration (stored as milliseconds).
+    #[inline]
+    #[must_use]
+    pub fn with_duration(mut self, d: Duration) -> Self {
+        let ms = d.as_millis().min(u128::from(u32::MAX)) as u32;
+        self.duration_ms = Some(ms);
         self
     }
 
@@ -460,6 +472,9 @@ impl std::fmt::Debug for Event {
         if let Some(delay_ms) = self.delay_ms {
             d.field("delay_ms", &delay_ms);
         }
+        if let Some(duration_ms) = self.duration_ms {
+            d.field("duration_ms", &duration_ms);
+        }
         if let Some(ref src) = self.backoff_source {
             d.field("backoff_source", src);
         }
@@ -490,6 +505,21 @@ mod tests {
         let huge = Duration::from_millis(u64::from(u32::MAX) + 1000);
         let ev = Event::new(EventKind::BackoffScheduled).with_delay(huge);
         assert_eq!(ev.delay_ms, Some(u32::MAX));
+    }
+
+    #[test]
+    fn with_duration_sets_and_clamps() {
+        let ev = Event::new(EventKind::TaskStopped).with_duration(Duration::from_millis(42));
+        assert_eq!(ev.duration_ms, Some(42));
+
+        let huge = Duration::from_millis(u64::from(u32::MAX) + 1000);
+        let clamped = Event::new(EventKind::TaskStopped).with_duration(huge);
+        assert_eq!(clamped.duration_ms, Some(u32::MAX));
+    }
+
+    #[test]
+    fn new_event_has_no_duration() {
+        assert_eq!(Event::new(EventKind::TaskStopped).duration_ms, None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,10 @@ pub use subscribers::Subscribe;
 #[cfg(feature = "controller")]
 mod controller;
 #[cfg(feature = "controller")]
-pub use controller::{AdmissionPolicy, ControllerConfig, ControllerError, ControllerSpec};
+pub use controller::{
+    AdmissionPolicy, ControllerConfig, ControllerError, ControllerSnapshot, ControllerSpec,
+    SlotStatusKind, SlotView,
+};
 
 #[cfg(feature = "logging")]
 pub use subscribers::LogWriter;

--- a/src/policies/jitter.rs
+++ b/src/policies/jitter.rs
@@ -58,7 +58,7 @@ impl Default for JitterPolicy {
 impl JitterPolicy {
     /// Applies jitter to the given delay.
     ///
-    /// `Decorrelated` has no previous-delay context here, so it falls back to **full jitter** (random in `[0, delay]`) rather than silently returning the input.
+    /// `Decorrelated` has no previous-delay context here, it falls back to **full jitter** (random in `[0, delay]`) rather than silently returning the input.
     /// For the true decorrelated recurrence use [`apply_decorrelated`](Self::apply_decorrelated).
     #[must_use]
     pub fn apply(&self, delay: Duration) -> Duration {

--- a/src/subscribers/subscriber_set.rs
+++ b/src/subscribers/subscriber_set.rs
@@ -106,10 +106,9 @@ impl SubscriberSet {
             let handle = tokio::spawn(async move {
                 while let Some(ev) = rx.recv().await {
                     // SAFETY (unwind):
-                    // Each subscriber runs in its own worker task with its own mpsc channel:
-                    // a panic cannot corrupt another subscriber's state.
+                    // Each subscriber runs in its own worker task with its own mpsc channel: a panic cannot corrupt another subscriber's state.
                     //
-                    // `on_event` is synchronous, so a single `catch_unwind` call suffices.
+                    // `on_event` is synchronous: a single `catch_unwind` call suffices.
                     //
                     // If the panicking subscriber holds an Arc<Mutex<T>>, that mutex will be poisoned, which is the expected Rust behavior.
                     // The worker continues processing the next event after reporting the panic via SubscriberPanicked.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use common::*;
 use taskvisor::prelude::*;
-use taskvisor::{ControllerConfig, ControllerError, ControllerSpec};
+use taskvisor::{ControllerConfig, ControllerError, ControllerSpec, SlotStatusKind};
 
 fn served_controller(cfg: ControllerConfig) -> (SupervisorHandle, Arc<EventCollector>) {
     let collector = EventCollector::new();
@@ -321,8 +321,6 @@ async fn shutdown_does_not_start_queued_tasks() {
     })
     .await;
 
-    // Draining the occupant publishes TaskRemoved; the controller must NOT react
-    // by starting the queued task mid-shutdown (it would be force-aborted with no grace).
     assert!(
         collector.by_label("queued").is_empty()
             || collector
@@ -714,6 +712,52 @@ async fn try_submit_full_when_queue_capacity_saturated() {
             "saturated intake channel must yield ControllerError::Full"
         );
         let _ = handle.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn controller_snapshot_reports_running_slot_and_queue_depth() {
+    let (handle, _collector) = served_controller(ControllerConfig {
+        queue_capacity: 16,
+        max_slot_queue: 4,
+    });
+
+    with_timeout(10, async {
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("occupant-snap")).with_slot("s"),
+            ))
+            .await
+            .expect("submit occupant ok");
+        handle
+            .submit(ControllerSpec::queue(
+                TaskSpec::restartable(make_coop("queued-snap")).with_slot("s"),
+            ))
+            .await
+            .expect("submit queued ok");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut observed = false;
+        while tokio::time::Instant::now() < deadline {
+            if let Some(snap) = handle.controller_snapshot().await
+                && let Some(view) = snap.slot("s")
+                && view.status == SlotStatusKind::Running
+                && view.queue_depth == 1
+                && snap.running_count() == 1
+                && snap.total_queued() == 1
+            {
+                observed = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            observed,
+            "controller_snapshot must report slot 's' Running with queue_depth 1"
+        );
+
+        handle.shutdown().await.expect("shutdown ok");
     })
     .await;
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -22,8 +22,6 @@ async fn drained(collector: &EventCollector, at_least_removed: usize) {
 
 #[test]
 fn supervisor_builder_is_nameable_from_public_api() {
-    // The builder must be a public, nameable type: users store it in variables,
-    // write helper functions returning it, and docs.rs must render its page.
     let builder: taskvisor::SupervisorBuilder = Supervisor::builder(SupervisorConfig::default());
     let _ = builder;
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -470,3 +470,26 @@ async fn static_run_multiple_oneshots_all_complete_run_returns_ok() {
         );
     }
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn terminal_events_carry_attempt_duration() {
+    let collector = EventCollector::new();
+    let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];
+    let sup = Supervisor::new(SupervisorConfig::default(), subs);
+
+    with_timeout(10, sup.run(vec![TaskSpec::once(make_ok_once("dur"))]))
+        .await
+        .expect("run returns Ok");
+
+    let saw_duration = poll_until(Duration::from_secs(2), || async {
+        collector
+            .find_all(EventKind::TaskStopped)
+            .iter()
+            .any(|e| e.duration_ms.is_some())
+    })
+    .await;
+    assert!(
+        saw_duration,
+        "TaskStopped delivered to a subscriber must carry duration_ms"
+    );
+}


### PR DESCRIPTION
## 📝 Description
Adds `controller_snapshot()` to `SupervisorHandle`;
Add event duration.

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally

## Examples
```rust
if let Some(snap) = handle.controller_snapshot().await {
    println!(
        "running={}, queued={}",
        snap.running_count(),
        snap.total_queued()
    );

    if let Some(slot) = snap.slot("deploy") {
        println!(
            "deploy: {:?}, depth={}",
            slot.status,
            slot.queue_depth
        );
    }
}
```
