### PR TITLE
[refactor] Split the monolithic Supervisor into a SupervisorCore runtime and facade

### DIFF
--- a/src/controller/core/introspect.rs
+++ b/src/controller/core/introspect.rs
@@ -1,0 +1,46 @@
+//! Pull-introspection: point-in-time snapshot of the controller's slots.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::controller::slot::SlotStatus;
+use crate::controller::view::{ControllerSnapshot, SlotStatusKind, SlotView};
+
+use super::Controller;
+
+impl Controller {
+    /// Builds a point-in-time [`ControllerSnapshot`] of all tracked slots.
+    ///
+    /// Slots are sampled one at a time (keys collected first, then each slot locked).
+    pub(crate) async fn snapshot(&self) -> ControllerSnapshot {
+        let keys: Vec<Arc<str>> = self.slots.iter().map(|e| Arc::clone(e.key())).collect();
+
+        let mut slots = Vec::with_capacity(keys.len());
+        for key in keys {
+            let Some(slot_arc) = self.slots.get(&*key).map(|e| e.clone()) else {
+                continue;
+            };
+            let slot = slot_arc.lock().await;
+            let (status, status_for) = match slot.status {
+                SlotStatus::Idle => (SlotStatusKind::Idle, Duration::ZERO),
+                SlotStatus::Admitting { since } => (SlotStatusKind::Admitting, since.elapsed()),
+                SlotStatus::Running { started_at } => {
+                    (SlotStatusKind::Running, started_at.elapsed())
+                }
+                SlotStatus::Terminating { cancelled_at } => {
+                    (SlotStatusKind::Terminating, cancelled_at.elapsed())
+                }
+            };
+            slots.push(SlotView {
+                slot: Arc::clone(&key),
+                status,
+                running: slot.running_id,
+                queue_depth: slot.queue.len(),
+                status_for,
+            });
+        }
+
+        slots.sort_by(|a, b| a.slot.cmp(&b.slot));
+        ControllerSnapshot { slots }
+    }
+}

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -5,9 +5,9 @@
 //! ## State machine (per slot)
 //!
 //! ```text
-//! Idle ──submit──► Running ──TaskRemoved──► Idle (or start next from queue)
-//!                     ├──Replace──► Terminating ──TaskRemoved──► Running (queued next)
-//!                     └──DropIfRunning──► rejected
+//! Idle ── submit ──► Running ── TaskRemoved ──► Idle (or start next from queue)
+//!                     ├──Replace ──► Terminating/TaskRemoved ──► Running (queued next)
+//!                     └──DropIfRunning ──► rejected
 //! ```
 //!
 //! ## Architecture
@@ -21,7 +21,7 @@
 
 use std::{
     sync::{Arc, Weak},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use dashmap::DashMap;
@@ -43,8 +43,11 @@ use super::{
     error::ControllerError,
     slot::{SlotState, SlotStatus},
     spec::ControllerSpec,
-    view::{ControllerSnapshot, SlotStatusKind, SlotView},
 };
+
+mod introspect;
+mod shutdown;
+mod recovery;
 
 struct Submission {
     id: TaskId,
@@ -182,39 +185,6 @@ impl Controller {
         }
     }
 
-    /// Builds a point-in-time [`ControllerSnapshot`] of all tracked slots.
-    pub(crate) async fn snapshot(&self) -> ControllerSnapshot {
-        let keys: Vec<Arc<str>> = self.slots.iter().map(|e| Arc::clone(e.key())).collect();
-
-        let mut slots = Vec::with_capacity(keys.len());
-        for key in keys {
-            let Some(slot_arc) = self.slots.get(&*key).map(|e| e.clone()) else {
-                continue;
-            };
-            let slot = slot_arc.lock().await;
-            let (status, status_for) = match slot.status {
-                SlotStatus::Idle => (SlotStatusKind::Idle, Duration::ZERO),
-                SlotStatus::Admitting { since } => (SlotStatusKind::Admitting, since.elapsed()),
-                SlotStatus::Running { started_at } => {
-                    (SlotStatusKind::Running, started_at.elapsed())
-                }
-                SlotStatus::Terminating { cancelled_at } => {
-                    (SlotStatusKind::Terminating, cancelled_at.elapsed())
-                }
-            };
-            slots.push(SlotView {
-                slot: Arc::clone(&key),
-                status,
-                running: slot.running_id,
-                queue_depth: slot.queue.len(),
-                status_for,
-            });
-        }
-
-        slots.sort_by(|a, b| a.slot.cmp(&b.slot));
-        ControllerSnapshot { slots }
-    }
-
     /// Starts the controller loop (spawns in background).
     pub fn run(self: Arc<Self>, token: CancellationToken) {
         let bus = self.bus.clone();
@@ -266,110 +236,6 @@ impl Controller {
         }
         self.finalize_pending_on_shutdown(&mut rx);
         Ok(())
-    }
-
-    /// Resolves every still-pending watched submission as `Rejected` during shutdown.
-    fn finalize_pending_on_shutdown(&self, rx: &mut mpsc::Receiver<Submission>) {
-        rx.close();
-
-        let pending: Vec<TaskId> = self.watchers.iter().map(|e| *e.key()).collect();
-        for id in pending {
-            self.finalize_rejected(id, "controller_shutting_down");
-        }
-        while let Ok(sub) = rx.try_recv() {
-            self.bus.publish(
-                Event::new(EventKind::ControllerRejected)
-                    .with_task(sub.spec.slot_name().to_owned())
-                    .with_id(sub.id)
-                    .with_reason("controller_shutting_down"),
-            );
-            if let Some(done) = sub.done {
-                let _ = done.send(TaskOutcome::Rejected {
-                    reason: Arc::from("controller_shutting_down"),
-                });
-            }
-        }
-    }
-
-    /// Recovers slots wedged by a bus lag (a missed `TaskAdded`/`TaskRemoved`).
-    async fn recover_stale_slots(&self) {
-        const RECOVERY_DEADLINE: Duration = Duration::from_secs(5);
-
-        let Some(sup) = self.supervisor.upgrade() else {
-            return;
-        };
-
-        let slot_keys: Vec<Arc<str>> = self
-            .slots
-            .iter()
-            .map(|entry| Arc::clone(entry.key()))
-            .collect();
-
-        for slot_name in slot_keys {
-            let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
-                continue;
-            };
-            let mut slot = slot_arc.lock().await;
-
-            if matches!(slot.status, SlotStatus::Idle) {
-                continue;
-            }
-            match slot.status {
-                SlotStatus::Admitting { since } if since.elapsed() < RECOVERY_DEADLINE => continue,
-                SlotStatus::Terminating { cancelled_at }
-                    if cancelled_at.elapsed() < RECOVERY_DEADLINE =>
-                {
-                    continue;
-                }
-                _ => {}
-            }
-
-            let alive = match slot.running_id {
-                Some(rid) => sup.contains_id(rid).await,
-                None => false,
-            };
-            if alive {
-                match slot.status {
-                    SlotStatus::Admitting { .. } => {
-                        slot.status = SlotStatus::Running {
-                            started_at: Instant::now(),
-                        };
-                        self.bus.publish(
-                            Event::new(EventKind::ControllerSlotTransition)
-                                .with_task(Arc::clone(&slot_name))
-                                .with_reason("admitting→running (lag recovery)"),
-                        );
-                    }
-                    SlotStatus::Terminating { .. } => {
-                        if let Some(rid) = slot.running_id
-                            && let Err(e) = sup.remove(rid)
-                        {
-                            self.bus.publish(
-                                Event::new(EventKind::ControllerRejected)
-                                    .with_task(Arc::clone(&slot_name))
-                                    .with_reason(format!("recovery_remove_failed: {e}")),
-                            );
-                        }
-                    }
-                    _ => {}
-                }
-                continue;
-            }
-
-            if let Some(id) = slot.running_id.take() {
-                self.running.remove(&id);
-            }
-            slot.status = SlotStatus::Idle;
-
-            if !self.is_shutting_down() {
-                self.start_next_from_queue(&sup, &mut slot, &slot_name);
-            }
-
-            if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
-                drop(slot);
-                self.slots.remove(&*slot_name);
-            }
-        }
     }
 
     /// Applies the admission policy for a new submission.
@@ -437,8 +303,7 @@ impl Controller {
                                 .with_reason(reason.clone()),
                         );
                         self.finalize_rejected(id, &reason);
-                        drop(slot);
-                        self.slots.remove(&*slot_name);
+                        self.gc_if_idle(&slot_name, slot);
                     }
                 }
             }
@@ -581,10 +446,7 @@ impl Controller {
                     .with_reason("removed_from_queue"),
             );
             self.finalize_rejected(id, "removed_from_queue");
-            if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
-                drop(slot);
-                self.slots.remove(&*slot_name);
-            }
+            self.gc_if_idle(&slot_name, slot);
             return;
         }
     }
@@ -672,10 +534,7 @@ impl Controller {
             self.start_next_from_queue(&sup, &mut slot, &slot_name);
         }
 
-        if matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty() {
-            drop(slot);
-            self.slots.remove(&*slot_name);
-        }
+        self.gc_if_idle(&slot_name, slot);
     }
 
     /// Admits `task_spec` into the slot under its **pre-minted** identity,
@@ -743,6 +602,18 @@ impl Controller {
             .clone()
     }
 
+    /// Garbage-collects a slot: releases the guard, then drops the slot from the map iff it is `Idle` with an empty queue.
+    ///
+    /// A slot is tracked only while it is busy or has queued work.
+    #[inline]
+    fn gc_if_idle(&self, slot_name: &Arc<str>, slot: tokio::sync::MutexGuard<'_, SlotState>) {
+        let collect = matches!(slot.status, SlotStatus::Idle) && slot.queue.is_empty();
+        drop(slot);
+        if collect {
+            self.slots.remove(&**slot_name);
+        }
+    }
+
     #[inline]
     fn reject_if_full(&self, slot_name: &str, id: TaskId, slot_len: usize) -> bool {
         if slot_len >= self.config.max_slot_queue {
@@ -788,6 +659,7 @@ mod tests {
     use super::*;
     use crate::TaskContext;
     use crate::{BackoffPolicy, RestartPolicy, TaskFn, TaskRef, TaskSpec};
+    use std::time::Duration;
 
     fn make_spec(name: &str) -> TaskSpec {
         let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -31,8 +31,8 @@ use tokio_util::sync::CancellationToken;
 use tokio::sync::broadcast;
 
 use crate::{
-    RuntimeError, Supervisor, TaskSpec,
-    core::{OutcomeTx, TaskOutcome},
+    RuntimeError, TaskSpec,
+    core::{OutcomeTx, SupervisorCore, TaskOutcome},
     events::{Bus, Event, EventKind},
     identity::TaskId,
 };
@@ -130,7 +130,7 @@ impl ControllerHandle {
 /// - [`SlotState`](super::slot::SlotState) - per-slot status and pending queue
 pub(crate) struct Controller {
     config: ControllerConfig,
-    supervisor: Weak<Supervisor>,
+    supervisor: Weak<SupervisorCore>,
     bus: Bus,
 
     slots: DashMap<Arc<str>, Arc<Mutex<SlotState>>>,
@@ -145,7 +145,7 @@ pub(crate) struct Controller {
 
 impl Controller {
     /// Creates a new controller (must call [`run`](Self::run) to start it).
-    pub fn new(config: ControllerConfig, supervisor: &Arc<Supervisor>, bus: Bus) -> Arc<Self> {
+    pub fn new(config: ControllerConfig, supervisor: &Arc<SupervisorCore>, bus: Bus) -> Arc<Self> {
         let (tx, rx) = mpsc::channel(config.queue_capacity.max(1));
 
         Arc::new(Self {
@@ -542,7 +542,7 @@ impl Controller {
     /// The slot becomes `Running` on `TaskAdded`.
     fn start_in_slot(
         &self,
-        sup: &Arc<Supervisor>,
+        sup: &Arc<SupervisorCore>,
         slot: &mut SlotState,
         slot_name: &Arc<str>,
         id: TaskId,
@@ -562,7 +562,7 @@ impl Controller {
     /// Leaves the slot `Admitting` (one started) or `Idle` (queue empty / all failed).
     fn start_next_from_queue(
         &self,
-        sup: &Arc<Supervisor>,
+        sup: &Arc<SupervisorCore>,
         slot: &mut SlotState,
         slot_name: &Arc<str>,
     ) {
@@ -657,6 +657,7 @@ impl Controller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Supervisor;
     use crate::TaskContext;
     use crate::{BackoffPolicy, RestartPolicy, TaskFn, TaskRef, TaskSpec};
     use std::time::Duration;
@@ -906,7 +907,7 @@ mod tests {
     #[tokio::test]
     async fn recover_promotes_admitting_slot_with_alive_task() {
         let (sup, handle, id) = sup_with_live_task().await;
-        let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), Bus::new(64));
 
         ctrl.slots.insert(
             Arc::from("s"),
@@ -935,7 +936,7 @@ mod tests {
     #[tokio::test]
     async fn recover_reissues_removal_for_terminating_slot_with_alive_task() {
         let (sup, handle, id) = sup_with_live_task().await;
-        let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), Bus::new(64));
 
         ctrl.slots.insert(
             Arc::from("s"),
@@ -952,7 +953,7 @@ mod tests {
         ctrl.recover_stale_slots().await;
 
         let removed = poll_until(Duration::from_secs(2), || async {
-            !sup.contains_id(id).await
+            !sup.core().contains_id(id).await
         })
         .await;
         assert!(
@@ -966,7 +967,7 @@ mod tests {
     #[tokio::test]
     async fn no_queue_advancement_after_shutdown_requested() {
         let (sup, handle, id) = sup_with_live_task().await;
-        let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), Bus::new(64));
 
         let queued: TaskRef = TaskFn::arc("queued", |ctx: TaskContext| async move {
             ctx.cancelled().await;
@@ -996,7 +997,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(
-            sup.id_for_label("queued").await.is_none(),
+            sup.core().id_for_label("queued").await.is_none(),
             "controller must not start queued tasks once shutdown has been requested"
         );
 
@@ -1039,7 +1040,7 @@ mod tests {
         use crate::controller::SlotStatusKind;
 
         let (sup, handle, id) = sup_with_live_task().await;
-        let ctrl = Controller::new(ControllerConfig::default(), &sup, Bus::new(64));
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), Bus::new(64));
 
         let queued: TaskRef = TaskFn::arc("queued", |ctx: TaskContext| async move {
             ctx.cancelled().await;

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -46,8 +46,8 @@ use super::{
 };
 
 mod introspect;
-mod shutdown;
 mod recovery;
+mod shutdown;
 
 struct Submission {
     id: TaskId,

--- a/src/controller/core/recovery.rs
+++ b/src/controller/core/recovery.rs
@@ -1,0 +1,89 @@
+//! Bus-lag recovery: reconcile slots wedged by a missed `TaskAdded`/`TaskRemoved`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::controller::slot::SlotStatus;
+use crate::events::{Event, EventKind};
+
+use super::Controller;
+
+impl Controller {
+    /// Recovers slots wedged by a bus lag (a missed `TaskAdded`/`TaskRemoved`).
+    pub(super) async fn recover_stale_slots(&self) {
+        const RECOVERY_DEADLINE: Duration = Duration::from_secs(5);
+
+        let Some(sup) = self.supervisor.upgrade() else {
+            return;
+        };
+
+        let slot_keys: Vec<Arc<str>> = self
+            .slots
+            .iter()
+            .map(|entry| Arc::clone(entry.key()))
+            .collect();
+
+        for slot_name in slot_keys {
+            let Some(slot_arc) = self.slots.get(&*slot_name).map(|e| e.clone()) else {
+                continue;
+            };
+            let mut slot = slot_arc.lock().await;
+
+            if matches!(slot.status, SlotStatus::Idle) {
+                continue;
+            }
+            match slot.status {
+                SlotStatus::Admitting { since } if since.elapsed() < RECOVERY_DEADLINE => continue,
+                SlotStatus::Terminating { cancelled_at }
+                    if cancelled_at.elapsed() < RECOVERY_DEADLINE =>
+                {
+                    continue;
+                }
+                _ => {}
+            }
+
+            let alive = match slot.running_id {
+                Some(rid) => sup.contains_id(rid).await,
+                None => false,
+            };
+            if alive {
+                match slot.status {
+                    SlotStatus::Admitting { .. } => {
+                        slot.status = SlotStatus::Running {
+                            started_at: Instant::now(),
+                        };
+                        self.bus.publish(
+                            Event::new(EventKind::ControllerSlotTransition)
+                                .with_task(Arc::clone(&slot_name))
+                                .with_reason("admitting→running (lag recovery)"),
+                        );
+                    }
+                    SlotStatus::Terminating { .. } => {
+                        if let Some(rid) = slot.running_id
+                            && let Err(e) = sup.remove(rid)
+                        {
+                            self.bus.publish(
+                                Event::new(EventKind::ControllerRejected)
+                                    .with_task(Arc::clone(&slot_name))
+                                    .with_reason(format!("recovery_remove_failed: {e}")),
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            if let Some(id) = slot.running_id.take() {
+                self.running.remove(&id);
+            }
+            slot.status = SlotStatus::Idle;
+
+            if !self.is_shutting_down() {
+                self.start_next_from_queue(&sup, &mut slot, &slot_name);
+            }
+
+            self.gc_if_idle(&slot_name, slot);
+        }
+    }
+}

--- a/src/controller/core/shutdown.rs
+++ b/src/controller/core/shutdown.rs
@@ -1,0 +1,36 @@
+//! Shutdown drain: resolve every still-pending submission once the loop has stopped.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::core::TaskOutcome;
+use crate::events::{Event, EventKind};
+use crate::identity::TaskId;
+
+use super::{Controller, Submission};
+
+impl Controller {
+    /// Resolves every still-pending watched submission as `Rejected` during shutdown.
+    pub(super) fn finalize_pending_on_shutdown(&self, rx: &mut mpsc::Receiver<Submission>) {
+        rx.close();
+
+        let pending: Vec<TaskId> = self.watchers.iter().map(|e| *e.key()).collect();
+        for id in pending {
+            self.finalize_rejected(id, "controller_shutting_down");
+        }
+        while let Ok(sub) = rx.try_recv() {
+            self.bus.publish(
+                Event::new(EventKind::ControllerRejected)
+                    .with_task(sub.spec.slot_name().to_owned())
+                    .with_id(sub.id)
+                    .with_reason("controller_shutting_down"),
+            );
+            if let Some(done) = sub.done {
+                let _ = done.send(TaskOutcome::Rejected {
+                    reason: Arc::from("controller_shutting_down"),
+                });
+            }
+        }
+    }
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Role in Taskvisor
 //!
-//! The controller accepts `ControllerSpec`, unwraps its `TaskSpec`, applies admission rules, and delegates `add/remove` to the Supervisor.
+//! The controller accepts `ControllerSpec`, unwraps its `TaskSpec`, applies admission rules, and delegates `add/remove` to the runtime (`SupervisorCore`, held via a `Weak`).
 //! It subscribes to the Bus and advances slots strictly on `TaskRemoved` to avoid registry races and double starts.
 //!
 //! ```text
@@ -34,7 +34,7 @@
 //!              add/remove
 //!                  ▼
 //!        ┌──────────────────┐
-//!        │    Supervisor    │
+//!        │  SupervisorCore  │  (runtime; controller holds Weak)
 //!        └─────────┬────────┘
 //!      publishes runtime events
 //!                  ▼
@@ -48,7 +48,7 @@
 //! **Flow summary**
 //! 1. Application calls `handle.submit(ControllerSpec)` (via `SupervisorHandle`).
 //! 2. Controller unwraps `TaskSpec` and applies `Admission` rules.
-//! 3. If accepted, controller calls `Supervisor::add_task(TaskSpec)` or requests remove.
+//! 3. If accepted, controller calls the runtime's add (`SupervisorCore::add_task_with_id_watched`) or requests remove.
 //! 4. On terminal `TaskRemoved` (via Bus), the slot becomes `Idle` and the next queued task (if any) is started.
 //!
 //! ## Per-slot model

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -59,8 +59,7 @@ impl SupervisorBuilder {
 
     /// Enables the controller with the given configuration.
     ///
-    /// The controller manages task slots with admission policies
-    /// (Queue, Replace, DropIfRunning).
+    /// The controller manages task slots with admission policies (Queue, Replace, DropIfRunning).
     ///
     /// Requires the `controller` feature flag.
     #[cfg(feature = "controller")]
@@ -108,16 +107,16 @@ impl SupervisorBuilder {
         );
 
         #[cfg(feature = "controller")]
-        let controller = self.controller_config.map(|ctrl_cfg| {
-            let controller = crate::controller::Controller::new(ctrl_cfg, &core, bus.clone());
-            controller.clone().run(runtime_token.clone());
-            controller
-        });
+        let controller = self
+            .controller_config
+            .map(|ctrl_cfg| crate::controller::Controller::new(ctrl_cfg, &core, bus.clone()));
 
         Supervisor::from_parts(
             core,
             #[cfg(feature = "controller")]
             controller,
+            #[cfg(feature = "controller")]
+            runtime_token,
         )
     }
 }

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -13,7 +13,9 @@
 use std::sync::Arc;
 use tokio::{sync, sync::mpsc};
 
-use super::{alive::AliveTracker, registry::Registry, supervisor::Supervisor};
+use super::{
+    alive::AliveTracker, registry::Registry, runtime::SupervisorCore, supervisor::Supervisor,
+};
 use crate::{
     core::SupervisorConfig,
     events::Bus,
@@ -95,7 +97,7 @@ impl SupervisorBuilder {
         );
         let alive = Arc::new(AliveTracker::new());
 
-        let sup = Arc::new(Supervisor::new_internal(
+        let core = SupervisorCore::new_internal(
             self.cfg,
             bus.clone(),
             subs,
@@ -103,15 +105,19 @@ impl SupervisorBuilder {
             registry,
             runtime_token.clone(),
             cmd_tx,
-        ));
+        );
 
         #[cfg(feature = "controller")]
-        if let Some(ctrl_cfg) = self.controller_config {
-            let controller = crate::controller::Controller::new(ctrl_cfg, &sup, bus.clone());
+        let controller = self.controller_config.map(|ctrl_cfg| {
+            let controller = crate::controller::Controller::new(ctrl_cfg, &core, bus.clone());
+            controller.clone().run(runtime_token.clone());
+            controller
+        });
 
-            let _ = sup.controller.set(Arc::clone(&controller));
-            controller.run(runtime_token.clone());
-        }
-        sup
+        Supervisor::from_parts(
+            core,
+            #[cfg(feature = "controller")]
+            controller,
+        )
     }
 }

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -1,28 +1,33 @@
 //! # Supervisor handle for dynamic task management.
 //!
-//! [`SupervisorHandle`] is returned by [`Supervisor::serve()`] and provides the full runtime management API.
+//! [`SupervisorHandle`] is returned by [`Supervisor::serve()`](crate::Supervisor::serve) and provides
+//! the full runtime management API. It holds the runtime ([`SupervisorCore`]) directly and, when the
+//! `controller` feature is enabled, the optional controller — delegating to each without going through
+//! the [`Supervisor`](crate::Supervisor) facade.
 //!
 //! This is the **only** way to manage tasks dynamically at runtime.
-//! [`Supervisor::run()`] is a self-contained entry point for static task sets.
+//! [`Supervisor::run()`](crate::Supervisor::run) is a self-contained entry point for static task sets.
+//!
+//! [`SupervisorCore`]: crate::core::SupervisorCore
 
 use std::{sync::Arc, time::Duration};
 use tokio::sync::broadcast;
 
+use crate::core::SupervisorCore;
 use crate::error::RuntimeError;
 use crate::events::EventKind;
 use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
 use super::outcome::TaskWaiter;
-use super::supervisor::Supervisor;
 
 /// Handle for managing a running supervisor.
 ///
-/// Obtained via [`Supervisor::serve()`]. Provides the full runtime management API.
+/// Obtained via [`Supervisor::serve()`](crate::Supervisor::serve). Provides the full runtime management API.
 ///
 /// # Also
 ///
-/// - [`Supervisor`](crate::Supervisor) - the runtime behind this handle
+/// - [`Supervisor`](crate::Supervisor) - the facade that produces this handle
 /// - [`SupervisorConfig`](crate::SupervisorConfig) - configuration knobs
 /// - [`TaskSpec`](crate::TaskSpec) - task configuration passed to [`add`](Self::add)
 ///
@@ -50,23 +55,38 @@ use super::supervisor::Supervisor;
 /// ```
 #[derive(Clone)]
 pub struct SupervisorHandle {
-    inner: Arc<Supervisor>,
+    core: Arc<SupervisorCore>,
+
+    #[cfg(feature = "controller")]
+    controller: Option<Arc<crate::controller::Controller>>,
 }
 
 impl std::fmt::Debug for SupervisorHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SupervisorHandle")
-            .field("supervisor", &self.inner)
-            .finish()
+            .field("core", &self.core)
+            .finish_non_exhaustive()
     }
 }
 
 impl SupervisorHandle {
-    /// Creates a new handle wrapping the given supervisor.
-    ///
-    /// The supervisor must already be started (via `serve()`).
-    pub(crate) fn new(supervisor: Arc<Supervisor>) -> Self {
-        Self { inner: supervisor }
+    /// Creates a new handle over the (already-started) runtime.
+    pub(crate) fn new(core: Arc<SupervisorCore>) -> Self {
+        Self {
+            core,
+            #[cfg(feature = "controller")]
+            controller: None,
+        }
+    }
+
+    /// Attaches the optional controller (builder/facade wiring).
+    #[cfg(feature = "controller")]
+    pub(crate) fn with_controller(
+        mut self,
+        controller: Option<Arc<crate::controller::Controller>>,
+    ) -> Self {
+        self.controller = controller;
+        self
     }
 
     /// Adds a new task to the supervisor at runtime.
@@ -74,7 +94,7 @@ impl SupervisorHandle {
     /// Fire-and-forget: mints the [`TaskId`], publishes `TaskAddRequested`, and returns immediately with the id.
     /// The task is spawned asynchronously by the registry listener.
     pub fn add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        self.inner.add_task(spec)
+        self.core.add_task(spec)
     }
 
     /// Adds a task and waits for registration confirmation.
@@ -94,8 +114,8 @@ impl SupervisorHandle {
         timeout: Duration,
     ) -> Result<TaskId, RuntimeError> {
         let target: Arc<str> = Arc::from(spec.task().name());
-        let mut rx = self.inner.subscribe_bus();
-        let id = self.inner.add_task(spec)?;
+        let mut rx = self.core.subscribe_bus();
+        let id = self.core.add_task(spec)?;
         self.wait_registered(&mut rx, id, target, timeout).await
     }
 
@@ -132,8 +152,8 @@ impl SupervisorHandle {
         timeout: Duration,
     ) -> Result<(TaskId, TaskWaiter), RuntimeError> {
         let target: Arc<str> = Arc::from(spec.task().name());
-        let mut rx = self.inner.subscribe_bus();
-        let (id, done_rx) = self.inner.add_task_watched(spec)?;
+        let mut rx = self.core.subscribe_bus();
+        let (id, done_rx) = self.core.add_task_watched(spec)?;
         self.wait_registered(&mut rx, id, target, timeout).await?;
         Ok((id, TaskWaiter::new(id, done_rx)))
     }
@@ -160,7 +180,7 @@ impl SupervisorHandle {
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if self.inner.contains_id(id).await {
+                        if self.core.contains_id(id).await {
                             return Ok(id);
                         }
                     }
@@ -169,7 +189,7 @@ impl SupervisorHandle {
                     }
                 }
             }
-            if self.inner.contains_id(id).await {
+            if self.core.contains_id(id).await {
                 Ok(id)
             } else {
                 Err(RuntimeError::TaskAddTimeout {
@@ -195,14 +215,14 @@ impl SupervisorHandle {
     /// The task is cancelled and cleaned up asynchronously by the registry;
     /// a task that ignores cancellation is force-aborted after the configured grace period.
     pub fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
-        self.inner.remove(id)
+        self.core.remove(id)
     }
 
     /// Removes the task currently holding `name` (label); `false` if no such task.
     pub async fn remove_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
-        match self.inner.id_for_label(name).await {
+        match self.core.id_for_label(name).await {
             Some(id) => {
-                self.inner.remove(id)?;
+                self.core.remove(id)?;
                 Ok(true)
             }
             None => Ok(false),
@@ -214,7 +234,7 @@ impl SupervisorHandle {
     /// Includes tasks in any state: starting, running, stopping.
     /// See [`snapshot`](Self::snapshot) for only currently executing tasks.
     pub async fn list(&self) -> Vec<(TaskId, Arc<str>)> {
-        self.inner.list_tasks().await
+        self.core.list_tasks().await
     }
 
     /// Returns a sorted list of currently alive task names (from the alive tracker).
@@ -222,19 +242,19 @@ impl SupervisorHandle {
     /// Only includes tasks whose last lifecycle event was [`TaskStarting`](crate::EventKind::TaskStarting).
     /// See [`list`](Self::list) for all registered tasks regardless of state.
     pub async fn snapshot(&self) -> Vec<Arc<str>> {
-        self.inner.snapshot().await
+        self.core.snapshot().await
     }
 
     /// Check whether a given task is currently alive.
     pub async fn is_alive(&self, name: &str) -> bool {
-        self.inner.is_alive(name).await
+        self.core.is_alive(name).await
     }
 
     /// Requests cooperative cancellation of a task and waits up to the configured grace period for it to actually stop (its `TaskRemoved` event).
     ///
     /// A task that ignores cancellation is **force-aborted after the grace period**;
     pub async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
-        self.inner.cancel(id).await
+        self.core.cancel(id).await
     }
 
     /// Cancel the task currently holding `name` (label), resolving to its identity.
@@ -242,8 +262,8 @@ impl SupervisorHandle {
     /// Returns `Ok(false)` if no task currently holds that label;
     /// otherwise behaves like [`cancel`](Self::cancel) (including the `TaskRemoveTimeout` case for a task that won't stop).
     pub async fn cancel_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
-        match self.inner.id_for_label(name).await {
-            Some(id) => self.inner.cancel(id).await,
+        match self.core.id_for_label(name).await {
+            Some(id) => self.core.cancel(id).await,
             None => Ok(false),
         }
     }
@@ -259,12 +279,14 @@ impl SupervisorHandle {
         id: TaskId,
         wait_for: Duration,
     ) -> Result<bool, RuntimeError> {
-        self.inner.cancel_with_timeout(id, wait_for).await
+        self.core.cancel_with_timeout(id, wait_for).await
     }
 
     /// Initiates graceful shutdown: cancels all tasks and waits for them to stop.
+    ///
+    /// The controller (if any) winds down via the shared runtime cancellation token.
     pub async fn shutdown(self) -> Result<(), RuntimeError> {
-        self.inner.shutdown().await
+        self.core.shutdown().await
     }
 
     /// Submits a task to the controller (if enabled), returning its pre-minted [`TaskId`].
@@ -278,7 +300,10 @@ impl SupervisorHandle {
         &self,
         spec: crate::controller::ControllerSpec,
     ) -> Result<TaskId, crate::controller::ControllerError> {
-        self.inner.submit(spec).await
+        match &self.controller {
+            Some(ctrl) => ctrl.handle().submit(spec).await,
+            None => Err(crate::controller::ControllerError::NotConfigured),
+        }
     }
 
     /// Tries to submit a task without blocking, returning its pre-minted [`TaskId`].
@@ -292,7 +317,10 @@ impl SupervisorHandle {
         &self,
         spec: crate::controller::ControllerSpec,
     ) -> Result<TaskId, crate::controller::ControllerError> {
-        self.inner.try_submit(spec)
+        match &self.controller {
+            Some(ctrl) => ctrl.handle().try_submit(spec),
+            None => Err(crate::controller::ControllerError::NotConfigured),
+        }
     }
 
     /// Submits a task to the controller and returns an awaitable [`TaskWaiter`] resolving to its final [`TaskOutcome`](crate::TaskOutcome)
@@ -310,11 +338,16 @@ impl SupervisorHandle {
         &self,
         spec: crate::controller::ControllerSpec,
     ) -> Result<(TaskId, TaskWaiter), crate::controller::ControllerError> {
-        let (id, rx) = self.inner.submit_and_watch(spec).await?;
-        Ok((id, TaskWaiter::new(id, rx)))
+        match &self.controller {
+            Some(ctrl) => {
+                let (id, rx) = ctrl.handle().submit_and_watch(spec).await?;
+                Ok((id, TaskWaiter::new(id, rx)))
+            }
+            None => Err(crate::controller::ControllerError::NotConfigured),
+        }
     }
 
-    /// Returns a point-in-time [`ControllerSnapshot`](crate::ControllerSnapshot) of the controller's slots.
+    /// Returns a point-in-time [`ControllerSnapshot`](crate::ControllerSnapshot) of the controller's slots, or `None` if no controller is configured.
     ///
     /// ## Example
     /// ```rust,no_run
@@ -334,6 +367,9 @@ impl SupervisorHandle {
     /// Requires the `controller` feature flag.
     #[cfg(feature = "controller")]
     pub async fn controller_snapshot(&self) -> Option<crate::controller::ControllerSnapshot> {
-        self.inner.controller_snapshot().await
+        match &self.controller {
+            Some(ctrl) => Some(ctrl.snapshot().await),
+            None => None,
+        }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -124,6 +124,9 @@ pub use outcome::{TaskOutcome, TaskWaiter};
 mod supervisor;
 pub use supervisor::Supervisor;
 
+mod runtime;
+pub(crate) use runtime::SupervisorCore;
+
 mod actor;
 mod alive;
 mod runner;

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -34,7 +34,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::Arc, time::Duration};
-use tokio::{sync::Notify, sync::broadcast, sync::mpsc, time::timeout};
+use tokio::{sync::broadcast, sync::mpsc, time::timeout};
 use tokio_util::sync::CancellationToken;
 
 use crate::core::{
@@ -59,7 +59,6 @@ pub(crate) struct SupervisorCore {
     subs: Arc<SubscriberSet>,
     alive: Arc<AliveTracker>,
     registry: Arc<Registry>,
-    ready: Arc<Notify>,
     runtime_token: CancellationToken,
     started: AtomicBool,
     cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
@@ -93,7 +92,6 @@ impl SupervisorCore {
             alive,
             registry,
             runtime_token,
-            ready: Arc::new(Notify::new()),
             started: AtomicBool::new(false),
             cmd_tx,
             subscriber_handle: std::sync::Mutex::new(None),
@@ -184,7 +182,6 @@ impl SupervisorCore {
         }
         self.subscriber_listener();
         self.registry.clone().spawn_listener();
-        self.ready.notify_waiters();
     }
 
     /// Runs task specifications until completion or shutdown signal.

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -1,0 +1,542 @@
+//! # SupervisorCore: the runtime guts behind the [`Supervisor`](super::supervisor::Supervisor) facade.
+//!
+//! `SupervisorCore` owns the runtime components and orchestrates task execution from spawn to graceful shutdown.
+//!
+//! ## Architecture
+//! ```text
+//! SupervisorCore::start()           // non-blocking setup
+//!     ├──► subscriber_listener()
+//!     │     ├──► updates AliveTracker
+//!     │     └──► distributes to SubscriberSet
+//!     └──► Registry.spawn_listener()
+//!           ├──► cmd_rx: Add(id, spec)  → spawn actor
+//!           ├──► cmd_rx: Remove(id)     → cancel task
+//!           ├──► bus_rx: ActorExhausted → cleanup
+//!           └──► bus_rx: ActorDead      → cleanup
+//!
+//! SupervisorCore::run(tasks)        // start() + block until shutdown
+//!     ├──► start()
+//!     ├──► subscribe to bus (before publishing!)
+//!     ├──► add initial tasks
+//!     ├──► wait for each task's add outcome (TaskAdded/TaskAddFailed)
+//!     └──► drive_shutdown()
+//!
+//! SupervisorCore::shutdown()        // explicit graceful stop
+//!     └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
+//! ```
+//!
+//! ## Rules
+//! - Each task has individual cancellation token (not shared with runtime_token)
+//! - Graceful shutdown cancels all tasks and waits for registry to drain
+//! - Registry auto-cleanup via ActorExhausted/ActorDead events
+//! - All operations are event-driven (idempotent)
+//! - Registry tracks all active tasks by `TaskId` (with a label index for name lookups)
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{sync::Arc, time::Duration};
+use tokio::{sync::Notify, sync::broadcast, sync::mpsc, time::timeout};
+use tokio_util::sync::CancellationToken;
+
+use crate::core::{
+    alive::AliveTracker,
+    registry::{Registry, RegistryCommand},
+};
+use crate::{
+    core::SupervisorConfig,
+    error::RuntimeError,
+    events::{Bus, Event, EventKind},
+    identity::TaskId,
+    subscribers::SubscriberSet,
+    tasks::TaskSpec,
+};
+
+/// Controller-agnostic runtime owned by the [`Supervisor`](super::supervisor::Supervisor) facade.
+///
+/// See the [module documentation](self) for the architecture.
+pub(crate) struct SupervisorCore {
+    cfg: SupervisorConfig,
+    pub(super) bus: Bus,
+    subs: Arc<SubscriberSet>,
+    alive: Arc<AliveTracker>,
+    registry: Arc<Registry>,
+    ready: Arc<Notify>,
+    runtime_token: CancellationToken,
+    started: AtomicBool,
+    cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
+    subscriber_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl std::fmt::Debug for SupervisorCore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SupervisorCore")
+            .field("cfg", &self.cfg)
+            .field("started", &self.started.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl SupervisorCore {
+    /// Internal constructor used by the builder; returns a ready-to-share `Arc`.
+    pub(crate) fn new_internal(
+        cfg: SupervisorConfig,
+        bus: Bus,
+        subs: Arc<SubscriberSet>,
+        alive: Arc<AliveTracker>,
+        registry: Arc<Registry>,
+        runtime_token: CancellationToken,
+        cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            cfg,
+            bus,
+            subs,
+            alive,
+            registry,
+            runtime_token,
+            ready: Arc::new(Notify::new()),
+            started: AtomicBool::new(false),
+            cmd_tx,
+            subscriber_handle: std::sync::Mutex::new(None),
+        })
+    }
+
+    /// Adds a new task to the runtime, returning its minted [`TaskId`].
+    pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        self.add_task_inner(TaskId::next(), spec, None)
+    }
+
+    /// Core primitive: add a task under a **pre-minted** identity with an optional outcome sender.
+    #[cfg(feature = "controller")]
+    pub(crate) fn add_task_with_id_watched(
+        &self,
+        id: TaskId,
+        spec: TaskSpec,
+        done: Option<crate::core::registry::OutcomeTx>,
+    ) -> Result<TaskId, RuntimeError> {
+        self.add_task_inner(id, spec, done)
+    }
+
+    /// Adds a new task and returns a `oneshot` receiver resolving to its final [`TaskOutcome`](crate::TaskOutcome).
+    pub(crate) fn add_task_watched(
+        &self,
+        spec: TaskSpec,
+    ) -> Result<(TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>), RuntimeError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let id = self.add_task_inner(TaskId::next(), spec, Some(tx))?;
+        Ok((id, rx))
+    }
+
+    /// Publishes `TaskAddRequested` and sends the `Add` command with an optional outcome watcher.
+    fn add_task_inner(
+        &self,
+        id: TaskId,
+        spec: TaskSpec,
+        done: Option<crate::core::registry::OutcomeTx>,
+    ) -> Result<TaskId, RuntimeError> {
+        self.bus.publish(
+            Event::new(EventKind::TaskAddRequested)
+                .with_task(spec.task().name())
+                .with_id(id),
+        );
+        self.cmd_tx
+            .send(RegistryCommand::Add(id, spec, done))
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        Ok(id)
+    }
+
+    /// Removes a task from the runtime, by its runtime identity.
+    pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
+        self.bus
+            .publish(Event::new(EventKind::TaskRemoveRequested).with_id(id));
+        self.cmd_tx
+            .send(RegistryCommand::Remove(id))
+            .map_err(|_| RuntimeError::ShuttingDown)
+    }
+
+    /// Returns currently active tasks as `(id, label)` pairs from the registry.
+    pub(crate) async fn list_tasks(&self) -> Vec<(TaskId, Arc<str>)> {
+        self.registry.list().await
+    }
+
+    /// Checks if a task with the given identity is registered.
+    pub(crate) async fn contains_id(&self, id: TaskId) -> bool {
+        self.registry.contains(id).await
+    }
+
+    /// Resolves a label to the identity currently holding it (if any).
+    pub(crate) async fn id_for_label(&self, name: &str) -> Option<TaskId> {
+        self.registry.id_for_label(name).await
+    }
+
+    /// Returns a new bus receiver for event subscription.
+    pub(crate) fn subscribe_bus(&self) -> broadcast::Receiver<Arc<Event>> {
+        self.bus.subscribe()
+    }
+
+    /// Starts the runtime event loop without blocking.
+    ///
+    /// Spawns:
+    /// - subscriber listener (distributes events to subscribers)
+    /// - registry listener (task lifecycle management)
+    pub(crate) fn start(&self) {
+        if self.started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.subscriber_listener();
+        self.registry.clone().spawn_listener();
+        self.ready.notify_waiters();
+    }
+
+    /// Runs task specifications until completion or shutdown signal.
+    pub(crate) async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
+        self.start();
+
+        if !tasks.is_empty() {
+            let mut rx = self.bus.subscribe();
+            let mut pending_ids = Vec::with_capacity(tasks.len());
+            for spec in tasks {
+                pending_ids.push(self.add_task(spec)?);
+            }
+            self.wait_tasks_registered(&mut rx, &pending_ids).await;
+        }
+        self.drive_shutdown().await
+    }
+
+    /// Waits until every initially-added task has been processed by the registry.
+    async fn wait_tasks_registered(
+        &self,
+        rx: &mut broadcast::Receiver<Arc<Event>>,
+        ids: &[TaskId],
+    ) {
+        let mut pending: Vec<TaskId> = ids.to_vec();
+
+        let confirm = async {
+            while !pending.is_empty() {
+                match rx.recv().await {
+                    Ok(ev)
+                        if matches!(ev.kind, EventKind::TaskAdded | EventKind::TaskAddFailed) =>
+                    {
+                        if let Some(id) = ev.id {
+                            pending.retain(|p| *p != id);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        let mut still = Vec::new();
+                        for id in std::mem::take(&mut pending) {
+                            if !self.registry.contains(id).await {
+                                still.push(id);
+                            }
+                        }
+                        pending = still;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        };
+        const CONFIRM_BACKSTOP: Duration = Duration::from_secs(5);
+        let _ = timeout(CONFIRM_BACKSTOP, confirm).await;
+    }
+
+    /// Initiates graceful shutdown: cancels all tasks and waits up to `grace` for them to stop.
+    pub(crate) async fn shutdown(&self) -> Result<(), RuntimeError> {
+        self.bus.publish(Event::new(EventKind::ShutdownRequested));
+        let res = self.drain_with_grace().await;
+        self.runtime_token.cancel();
+        self.join_subscriber_listener().await;
+        self.subs.close().await;
+        res
+    }
+
+    /// Returns sorted list of currently alive task names.
+    pub(crate) async fn snapshot(&self) -> Vec<Arc<str>> {
+        self.alive.snapshot().await
+    }
+
+    /// Check whether a given task is currently alive.
+    pub(crate) async fn is_alive(&self, name: &str) -> bool {
+        self.alive.is_alive(name).await
+    }
+
+    /// Cancel a task by identity and wait for confirmation (`TaskRemoved`).
+    pub(crate) async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        self.cancel_with_timeout(id, self.cfg.grace).await
+    }
+
+    /// Cancel with explicit timeout.
+    pub(crate) async fn cancel_with_timeout(
+        &self,
+        id: TaskId,
+        wait_for: Duration,
+    ) -> Result<bool, RuntimeError> {
+        let mut rx = self.bus.subscribe();
+        if !self.registry.contains(id).await {
+            return Ok(false);
+        }
+
+        self.bus.publish(
+            Event::new(EventKind::TaskRemoveRequested)
+                .with_id(id)
+                .with_reason("manual_cancel"),
+        );
+        self.cmd_tx
+            .send(RegistryCommand::Remove(id))
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        self.wait_task_removed(&mut rx, id, wait_for).await
+    }
+
+    /// Listens to the internal event bus and distributes each received [`Event`] to all active subscribers.
+    fn subscriber_listener(&self) {
+        let mut rx = self.bus.subscribe();
+        let set = Arc::clone(&self.subs);
+        let alive = Arc::clone(&self.alive);
+        let rt = self.runtime_token.clone();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+
+                    msg = rx.recv() => match msg {
+                        Ok(arc_ev) => {
+                            alive.update(&arc_ev).await;
+                            set.emit_arc(arc_ev);
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            let e = Event::new(EventKind::SubscriberOverflow)
+                                .with_task("subscriber_listener")
+                                .with_reason(format!("lagged({skipped})"));
+
+                            let arc_e = Arc::new(e);
+                            alive.update(&arc_e).await;
+                            set.emit_arc(arc_e);
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    },
+
+                    _ = rt.cancelled() => {
+                        while let Ok(arc_ev) = rx.try_recv() {
+                            alive.update(&arc_ev).await;
+                            set.emit_arc(arc_ev);
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+
+        *self.subscriber_handle.lock().unwrap() = Some(handle);
+    }
+
+    /// Awaits the subscriber listener.
+    async fn join_subscriber_listener(&self) {
+        let handle = self.subscriber_handle.lock().unwrap().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
+    }
+
+    /// Waits for either shutdown signal or natural completion of all tasks.
+    async fn drive_shutdown(&self) -> Result<(), RuntimeError> {
+        let res = tokio::select! {
+            sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
+            _ = self.registry.wait_until_empty() => Ok(()),
+        };
+        self.runtime_token.cancel();
+        self.join_subscriber_listener().await;
+        self.subs.close().await;
+        res
+    }
+
+    /// Handles the outcome of [`wait_for_shutdown_signal`](crate::core::shutdown::wait_for_shutdown_signal).
+    async fn on_shutdown_signal(&self, res: std::io::Result<()>) -> Result<(), RuntimeError> {
+        match res {
+            Ok(()) => {
+                self.bus.publish(Event::new(EventKind::ShutdownRequested));
+                self.drain_with_grace().await
+            }
+            Err(e) => Err(RuntimeError::SignalSetupFailed { source: e }),
+        }
+    }
+
+    /// Cancels all tasks and waits up to `grace` for them to stop, force-aborting stragglers.
+    async fn drain_with_grace(&self) -> Result<(), RuntimeError> {
+        let grace = self.cfg.grace;
+        let stuck = self.registry.cancel_all_within(grace).await;
+        if stuck.is_empty() {
+            self.bus
+                .publish(Event::new(EventKind::AllStoppedWithinGrace));
+            Ok(())
+        } else {
+            self.bus.publish(Event::new(EventKind::GraceExceeded));
+            Err(RuntimeError::GraceExceeded { grace, stuck })
+        }
+    }
+
+    /// Waits up to `wait_for` for a task to **actually terminate**, signalled by its `TaskRemoved` event.
+    async fn wait_task_removed(
+        &self,
+        rx: &mut broadcast::Receiver<Arc<Event>>,
+        id: TaskId,
+        wait_for: Duration,
+    ) -> Result<bool, RuntimeError> {
+        let wait_for_event = async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if matches!(ev.kind, EventKind::TaskRemoved) && ev.id == Some(id) => {
+                        return true;
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if self.registry.is_terminated(id).await {
+                            return true;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return self.registry.is_terminated(id).await;
+                    }
+                }
+            }
+        };
+
+        match timeout(wait_for, wait_for_event).await {
+            Ok(true) => Ok(true),
+            Ok(false) | Err(_) => {
+                if self.registry.is_terminated(id).await {
+                    Ok(true)
+                } else {
+                    Err(RuntimeError::TaskRemoveTimeout {
+                        id,
+                        timeout: wait_for,
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a started-on-demand `SupervisorCore` directly (mirrors the builder's core wiring).
+    fn core(cfg: SupervisorConfig) -> Arc<SupervisorCore> {
+        let bus = Bus::new(cfg.bus_capacity_clamped());
+        let subs = Arc::new(SubscriberSet::new(Vec::new(), bus.clone()));
+        let token = CancellationToken::new();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let registry = Registry::new(bus.clone(), token.clone(), None, cfg.grace, cmd_rx);
+        let alive = Arc::new(AliveTracker::new());
+        SupervisorCore::new_internal(cfg, bus, subs, alive, registry, token, cmd_tx)
+    }
+
+    #[tokio::test]
+    async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
+        let core = core(SupervisorConfig::default());
+        let mut rx = core.bus.subscribe();
+
+        let err = std::io::Error::other("signal registration failed");
+        let out = core.on_shutdown_signal(Err(err)).await;
+
+        assert!(
+            matches!(out, Err(RuntimeError::SignalSetupFailed { .. })),
+            "a signal-setup error must surface as SignalSetupFailed, got {out:?}"
+        );
+
+        let mut saw_shutdown = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, EventKind::ShutdownRequested) {
+                saw_shutdown = true;
+            }
+        }
+        assert!(
+            !saw_shutdown,
+            "a signal-setup error must NOT masquerade as a shutdown request"
+        );
+    }
+
+    #[tokio::test]
+    async fn real_signal_publishes_shutdown_requested() {
+        let core = core(SupervisorConfig::default());
+        let mut rx = core.bus.subscribe();
+
+        let out = core.on_shutdown_signal(Ok(())).await;
+        assert!(out.is_ok(), "a real signal drains gracefully: {out:?}");
+
+        let mut saw_shutdown = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, EventKind::ShutdownRequested) {
+                saw_shutdown = true;
+            }
+        }
+        assert!(saw_shutdown, "a real signal must publish ShutdownRequested");
+    }
+
+    #[tokio::test]
+    async fn wait_task_removed_survives_bus_lag() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            bus_capacity: 8,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        core.start();
+
+        let t: TaskRef = TaskFn::arc("laggy", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let id = core
+            .add_task(TaskSpec::restartable(t))
+            .expect("add accepted");
+
+        let registered = timeout(Duration::from_secs(2), async {
+            loop {
+                if core.contains_id(id).await {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        registered.expect("task must register");
+
+        let mut lagged_rx = core.subscribe_bus();
+        let mut observer = core.subscribe_bus();
+
+        core.remove(id).expect("remove should be accepted");
+
+        let observed = timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(ev) = observer.recv().await
+                    && ev.kind == EventKind::TaskRemoved
+                    && ev.id == Some(id)
+                {
+                    return;
+                }
+            }
+        })
+        .await;
+        observed.expect("TaskRemoved must be observed by a healthy receiver");
+
+        for _ in 0..32 {
+            core.bus
+                .publish(Event::new(EventKind::TaskStarting).with_task("noise"));
+        }
+
+        let res = timeout(
+            Duration::from_secs(1),
+            core.wait_task_removed(&mut lagged_rx, id, Duration::from_millis(300)),
+        )
+        .await
+        .expect("wait_task_removed must not hang");
+        assert!(
+            matches!(res, Ok(true)),
+            "a lagged receiver must fall back to runtime state instead of reporting \
+             a spurious TaskRemoveTimeout, got {res:?}"
+        );
+
+        let _ = core.shutdown().await;
+    }
+}

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -1,124 +1,21 @@
-//! # Supervisor: orchestrates task actors and graceful shutdown.
+//! # Supervisor: public facade over the runtime ([`SupervisorCore`]) and optional controller.
 //!
-//! The [`Supervisor`] owns the runtime components and orchestrates task execution lifecycle from spawn to graceful termination.
+//! [`Supervisor`] is a thin composition root:
+//! it owns an `Arc<SupervisorCore>` and, when the `controller` feature is enabled, an `Arc<Controller>`.
 //!
-//! - Spawn task actors via event-driven registry
-//! - Dynamically add/remove tasks at runtime via events
-//! - Perform graceful shutdown with configurable grace period
-//! - Enforce global concurrency limits via optional semaphore
-//! - Track alive tasks for stuck detection during shutdown
-//! - Distribute events to subscribers via [`SubscriberSet`]
-//! - Handle OS termination signals
+//! The controller depends only on [`SupervisorCore`] (via a `Weak`).
+//! The cycle that previously coupled the two is gone: see [`SupervisorCore`].
 //!
-//! ## Architecture
-//! ```text
-//! Supervisor::start()           // non-blocking setup
-//!     ├──► subscriber_listener()
-//!     │     ├──► updates AliveTracker
-//!     │     └──► distributes to SubscriberSet
-//!     └──► Registry.spawn_listener()
-//!           ├──► cmd_rx: Add(id, spec)  → spawn actor
-//!           ├──► cmd_rx: Remove(id)     → cancel task
-//!           ├──► bus_rx: ActorExhausted → cleanup
-//!           └──► bus_rx: ActorDead      → cleanup
+//! ## Two usage modes
+//! - **Static**: [`run`](Supervisor::run) a known set of tasks until completion or Ctrl+C.
+//! - **Dynamic**: [`serve`](Supervisor::serve) returns a [`SupervisorHandle`] to add/remove/cancel/submit at runtime.
 //!
-//! Supervisor::run(tasks)        // start() + block until shutdown
-//!     ├──► start()
-//!     ├──► subscribe to bus (before publishing!)
-//!     ├──► add initial tasks
-//!     ├──► wait for each task's add outcome (TaskAdded/TaskAddFailed)
-//!     └──► drive_shutdown()
-//!           ├──► wait for signal or empty registry
-//!           └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
-//!
-//! Supervisor::shutdown()        // explicit graceful stop
-//!     └──► drain_with_grace (cancel tasks, join within grace, force-abort stragglers)
-//! ```
-//!
-//! ## Runtime task management
-//! ```text
-//! add_task(spec)                           // mints TaskId, returns it to caller
-//!     ├──► Bus.publish(TaskAddRequested)   // observability (non-blocking)
-//!     ├──► cmd_tx.send(Add(id, spec))      // guaranteed delivery (mpsc)
-//!     └──► Registry.spawn_listener
-//!           ├──► spawn actor
-//!           ├──► registry.insert(handle)
-//!           └──► Bus.publish(TaskAdded)
-//!
-//! remove(id)
-//!     ├──► Bus.publish(TaskRemoveRequested) // observability (fire-and-forget)
-//!     ├──► cmd_tx.send(Remove(id))          // guaranteed delivery (mpsc)
-//!     └──► Registry.spawn_listener
-//!           ├──► registry.remove(id) + cancel token
-//!           ├──► await actor finish
-//!           └──► Bus.publish(TaskRemoved)
-//!
-//! Actor finishes
-//!     ├──► Bus.publish(ActorExhausted/ActorDead)
-//!     └──► Registry.event_listener
-//!           ├──► registry.remove(id)
-//!           └──► Bus.publish(TaskRemoved)
-//! ```
-//!
-//! ## Rules
-//! - Each task has individual cancellation token (not shared with runtime_token)
-//! - Graceful shutdown cancels all tasks and waits for registry to drain
-//! - Registry auto-cleanup via ActorExhausted/ActorDead events
-//! - All operations are event-driven (idempotent)
-//! - Registry tracks all active tasks by `TaskId` (with a label index for name lookups)
-//!
-//! ## Example
-//! ```rust,no_run
-//! use std::time::Duration;
-//! use taskvisor::TaskContext;
-//!
-//! use taskvisor::{SupervisorConfig, Supervisor, TaskSpec, TaskFn, RestartPolicy, BackoffPolicy};
-//!
-//! #[tokio::main(flavor = "current_thread")]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let cfg = SupervisorConfig::default();
-//!     let sup = Supervisor::new(cfg, Vec::new());
-//!
-//!     let task = TaskFn::arc("ticker", |ctx: TaskContext| async move {
-//!         while !ctx.is_cancelled() {
-//!             tokio::time::sleep(Duration::from_millis(250)).await;
-//!         }
-//!         Ok(())
-//!     });
-//!
-//!     let spec = TaskSpec::new(
-//!         task,
-//!         RestartPolicy::Never,
-//!         BackoffPolicy::default(),
-//!         Some(Duration::from_secs(2)),
-//!     );
-//!
-//!     sup.run(vec![spec]).await?;
-//!     Ok(())
-//! }
-//! ```
+//! [`SupervisorCore`]: crate::core::SupervisorCore
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::{sync::Arc, time::Duration};
-use tokio::{sync::Notify, sync::broadcast, sync::mpsc, time::timeout};
-use tokio_util::sync::CancellationToken;
+use std::sync::Arc;
 
-#[cfg(feature = "controller")]
-use tokio::sync::OnceCell;
-
-use crate::core::{
-    alive::AliveTracker,
-    builder::SupervisorBuilder,
-    registry::{Registry, RegistryCommand},
-};
-use crate::{
-    core::SupervisorConfig,
-    error::RuntimeError,
-    events::{Bus, Event, EventKind},
-    identity::TaskId,
-    subscribers::{Subscribe, SubscriberSet},
-    tasks::TaskSpec,
-};
+use crate::core::{SupervisorConfig, SupervisorCore, builder::SupervisorBuilder};
+use crate::{error::RuntimeError, subscribers::Subscribe, tasks::TaskSpec};
 
 /// Orchestrates task actors, event delivery, and graceful shutdown.
 ///
@@ -151,56 +48,31 @@ use crate::{
 ///
 /// [`SupervisorHandle`]: crate::SupervisorHandle
 pub struct Supervisor {
-    cfg: SupervisorConfig,
-    bus: Bus,
-    subs: Arc<SubscriberSet>,
-    alive: Arc<AliveTracker>,
-    registry: Arc<Registry>,
-    ready: Arc<Notify>,
-    runtime_token: CancellationToken,
-    started: AtomicBool,
-    cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
-    subscriber_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    pub(super) core: Arc<SupervisorCore>,
 
     #[cfg(feature = "controller")]
-    pub(super) controller: OnceCell<Arc<crate::controller::Controller>>,
+    pub(super) controller: Option<Arc<crate::controller::Controller>>,
 }
 
 impl std::fmt::Debug for Supervisor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Supervisor")
-            .field("cfg", &self.cfg)
-            .field("started", &self.started.load(Ordering::Relaxed))
+            .field("core", &self.core)
             .finish_non_exhaustive()
     }
 }
 
 impl Supervisor {
-    /// Internal constructor used by builder (not public API).
-    pub(crate) fn new_internal(
-        cfg: SupervisorConfig,
-        bus: Bus,
-        subs: Arc<SubscriberSet>,
-        alive: Arc<AliveTracker>,
-        registry: Arc<Registry>,
-        runtime_token: CancellationToken,
-        cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
-    ) -> Self {
-        Self {
-            cfg,
-            bus,
-            subs,
-            alive,
-            registry,
-            runtime_token,
-            ready: Arc::new(Notify::new()),
-            started: AtomicBool::new(false),
-            cmd_tx,
-            subscriber_handle: std::sync::Mutex::new(None),
-
+    /// Internal facade constructor used by the builder.
+    pub(super) fn from_parts(
+        core: Arc<SupervisorCore>,
+        #[cfg(feature = "controller")] controller: Option<Arc<crate::controller::Controller>>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            core,
             #[cfg(feature = "controller")]
-            controller: OnceCell::new(),
-        }
+            controller,
+        })
     }
 
     /// Creates a new supervisor with the given config and subscribers (maybe empty).
@@ -224,401 +96,25 @@ impl Supervisor {
     }
 
     /// Returns a [`SupervisorHandle`] for dynamic task management.
-    ///
-    /// Starts the event loop (listeners) and returns a handle through which you can add, remove, or cancel tasks and trigger shutdown.
-    ///
-    /// This is the **only** way to manage tasks dynamically. Use [`run()`] for static task sets.
-    ///
-    /// [`SupervisorHandle`]: crate::SupervisorHandle
-    /// [`run()`]: Self::run
     pub fn serve(self: &Arc<Self>) -> super::handle::SupervisorHandle {
-        self.start();
-        super::handle::SupervisorHandle::new(Arc::clone(self))
+        self.core.start();
+        let handle = super::handle::SupervisorHandle::new(Arc::clone(&self.core));
+        #[cfg(feature = "controller")]
+        let handle = handle.with_controller(self.controller.clone());
+        handle
     }
 
-    /// Adds a new task to the supervisor at runtime, returning its minted [`TaskId`].
-    pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        self.add_task_inner(TaskId::next(), spec, None)
-    }
-
-    /// Adds a task under a **pre-minted** identity with an optional outcome watcher.
-    #[cfg(feature = "controller")]
-    pub(crate) fn add_task_with_id_watched(
-        &self,
-        id: TaskId,
-        spec: TaskSpec,
-        done: Option<crate::core::registry::OutcomeTx>,
-    ) -> Result<TaskId, RuntimeError> {
-        self.add_task_inner(id, spec, done)
-    }
-
-    /// Adds a new task and returns a `oneshot` receiver resolving to its final [`TaskOutcome`](crate::TaskOutcome).
-    pub(crate) fn add_task_watched(
-        &self,
-        spec: TaskSpec,
-    ) -> Result<(TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>), RuntimeError> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let id = self.add_task_inner(TaskId::next(), spec, Some(tx))?;
-        Ok((id, rx))
-    }
-
-    /// Publishes `TaskAddRequested` and sends the `Add` command with an optional outcome watcher.
-    fn add_task_inner(
-        &self,
-        id: TaskId,
-        spec: TaskSpec,
-        done: Option<crate::core::registry::OutcomeTx>,
-    ) -> Result<TaskId, RuntimeError> {
-        self.bus.publish(
-            Event::new(EventKind::TaskAddRequested)
-                .with_task(spec.task().name())
-                .with_id(id),
-        );
-        self.cmd_tx
-            .send(RegistryCommand::Add(id, spec, done))
-            .map_err(|_| RuntimeError::ShuttingDown)?;
-        Ok(id)
-    }
-
-    /// Removes a task from the supervisor at runtime, by its runtime identity.
-    pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
-        self.bus
-            .publish(Event::new(EventKind::TaskRemoveRequested).with_id(id));
-        self.cmd_tx
-            .send(RegistryCommand::Remove(id))
-            .map_err(|_| RuntimeError::ShuttingDown)
-    }
-
-    /// Returns currently active tasks as `(id, label)` pairs from the registry.
-    pub(crate) async fn list_tasks(&self) -> Vec<(TaskId, Arc<str>)> {
-        self.registry.list().await
-    }
-
-    /// Checks if a task with the given identity is registered.
-    pub(crate) async fn contains_id(&self, id: TaskId) -> bool {
-        self.registry.contains(id).await
-    }
-
-    /// Resolves a label to the identity currently holding it (if any).
-    pub(crate) async fn id_for_label(&self, name: &str) -> Option<TaskId> {
-        self.registry.id_for_label(name).await
-    }
-
-    /// Returns a new bus receiver for event subscription.
-    pub(crate) fn subscribe_bus(&self) -> broadcast::Receiver<Arc<Event>> {
-        self.bus.subscribe()
-    }
-
-    /// Starts the supervisor event loop without blocking.
+    /// Runs task specifications until completion or shutdown signal (static mode).
     ///
-    /// Spawns:
-    /// - subscriber listener (distributes events to subscribers)
-    /// - registry listener (task lifecycle management)
-    pub(crate) fn start(&self) {
-        if self.started.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.subscriber_listener();
-        self.registry.clone().spawn_listener();
-        self.ready.notify_waiters();
-    }
-
-    /// Runs task specifications until completion or shutdown signal.
-    ///
-    /// Steps:
-    /// - Start event loop (via `start`)
-    /// - Subscribe to bus **before** publishing (guarantees no missed events)
-    /// - Publish TaskAddRequested for initial tasks
-    /// - Wait for each task's add outcome (`TaskAdded`/`TaskAddFailed`) before driving shutdown
-    /// - Wait for shutdown signal or all tasks to exit
+    /// Delegates to the runtime; the controller (if configured) is already running independently.
     pub async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
-        self.start();
-
-        if !tasks.is_empty() {
-            let mut rx = self.bus.subscribe();
-            let mut pending_ids = Vec::with_capacity(tasks.len());
-            for spec in tasks {
-                pending_ids.push(self.add_task(spec)?);
-            }
-            self.wait_tasks_registered(&mut rx, &pending_ids).await;
-        }
-        self.drive_shutdown().await
+        self.core.run(tasks).await
     }
 
-    /// Waits until every initially-added task has been processed by the registry.
-    async fn wait_tasks_registered(
-        &self,
-        rx: &mut broadcast::Receiver<Arc<Event>>,
-        ids: &[TaskId],
-    ) {
-        let mut pending: Vec<TaskId> = ids.to_vec();
-
-        let confirm = async {
-            while !pending.is_empty() {
-                match rx.recv().await {
-                    Ok(ev)
-                        if matches!(ev.kind, EventKind::TaskAdded | EventKind::TaskAddFailed) =>
-                    {
-                        if let Some(id) = ev.id {
-                            pending.retain(|p| *p != id);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        let mut still = Vec::new();
-                        for id in std::mem::take(&mut pending) {
-                            if !self.registry.contains(id).await {
-                                still.push(id);
-                            }
-                        }
-                        pending = still;
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        };
-        const CONFIRM_BACKSTOP: Duration = Duration::from_secs(5);
-        let _ = timeout(CONFIRM_BACKSTOP, confirm).await;
-    }
-
-    /// Initiates graceful shutdown: cancels all tasks and waits up to `grace` for them to stop.
-    ///
-    /// Tasks that do not stop cooperatively within the configured grace period are force-terminated;
-    /// see [`drain_with_grace`](Self::drain_with_grace).
-    pub(crate) async fn shutdown(&self) -> Result<(), RuntimeError> {
-        self.bus.publish(Event::new(EventKind::ShutdownRequested));
-        let res = self.drain_with_grace().await;
-        self.runtime_token.cancel();
-        self.join_subscriber_listener().await;
-        self.subs.close().await;
-        res
-    }
-
-    /// Returns sorted list of currently alive task names.
-    pub(crate) async fn snapshot(&self) -> Vec<Arc<str>> {
-        self.alive.snapshot().await
-    }
-
-    /// Check whether a given task is currently alive.
-    pub(crate) async fn is_alive(&self, name: &str) -> bool {
-        self.alive.is_alive(name).await
-    }
-
-    /// Cancel a task by identity and wait for confirmation (`TaskRemoved`).
-    pub(crate) async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
-        self.cancel_with_timeout(id, self.cfg.grace).await
-    }
-
-    /// Cancel with explicit timeout.
-    pub(crate) async fn cancel_with_timeout(
-        &self,
-        id: TaskId,
-        wait_for: Duration,
-    ) -> Result<bool, RuntimeError> {
-        let mut rx = self.bus.subscribe();
-        if !self.registry.contains(id).await {
-            return Ok(false);
-        }
-
-        self.bus.publish(
-            Event::new(EventKind::TaskRemoveRequested)
-                .with_id(id)
-                .with_reason("manual_cancel"),
-        );
-        self.cmd_tx
-            .send(RegistryCommand::Remove(id))
-            .map_err(|_| RuntimeError::ShuttingDown)?;
-        self.wait_task_removed(&mut rx, id, wait_for).await
-    }
-
-    /// Submits a task to the controller (if enabled), returning the pre-minted [`TaskId`].
-    #[cfg(feature = "controller")]
-    pub(crate) async fn submit(
-        &self,
-        spec: crate::controller::ControllerSpec,
-    ) -> Result<TaskId, crate::controller::ControllerError> {
-        match self.controller.get() {
-            Some(ctrl) => ctrl.handle().submit(spec).await,
-            None => Err(crate::controller::ControllerError::NotConfigured),
-        }
-    }
-
-    /// Tries to submit a task without blocking, returning the pre-minted [`TaskId`].
-    #[cfg(feature = "controller")]
-    pub(crate) fn try_submit(
-        &self,
-        spec: crate::controller::ControllerSpec,
-    ) -> Result<TaskId, crate::controller::ControllerError> {
-        match self.controller.get() {
-            Some(ctrl) => ctrl.handle().try_submit(spec),
-            None => Err(crate::controller::ControllerError::NotConfigured),
-        }
-    }
-
-    /// Submits a task to the controller and returns a watcher for its final outcome.
-    #[cfg(feature = "controller")]
-    pub(crate) async fn submit_and_watch(
-        &self,
-        spec: crate::controller::ControllerSpec,
-    ) -> Result<
-        (TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>),
-        crate::controller::ControllerError,
-    > {
-        match self.controller.get() {
-            Some(ctrl) => ctrl.handle().submit_and_watch(spec).await,
-            None => Err(crate::controller::ControllerError::NotConfigured),
-        }
-    }
-
-    /// Returns a point-in-time snapshot of the controller's slots, or `None` if no controller is configured.
-    #[cfg(feature = "controller")]
-    pub(crate) async fn controller_snapshot(
-        &self,
-    ) -> Option<crate::controller::ControllerSnapshot> {
-        match self.controller.get() {
-            Some(ctrl) => Some(ctrl.snapshot().await),
-            None => None,
-        }
-    }
-
-    /// Listens to the internal event bus and distributes each received [`Event`] to all active subscribers.
-    ///
-    /// The listener also updates the [`AliveTracker`] before distributing them, to keep the latest per-task state in sync.
-    ///
-    /// On `Lagged`, it creates a [`EventKind::SubscriberOverflow`] event and emits it **directly to subscribers**,
-    /// bypassing the bus - to avoid reinforcing backpressure loops while still reporting the loss.
-    ///
-    /// On runtime shutdown the loop drains any buffered events to subscribers and exits.
-    fn subscriber_listener(&self) {
-        let mut rx = self.bus.subscribe();
-        let set = Arc::clone(&self.subs);
-        let alive = Arc::clone(&self.alive);
-        let rt = self.runtime_token.clone();
-
-        let handle = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-
-                    msg = rx.recv() => match msg {
-                        Ok(arc_ev) => {
-                            alive.update(&arc_ev).await;
-                            set.emit_arc(arc_ev);
-                        }
-                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                            let e = Event::new(EventKind::SubscriberOverflow)
-                                .with_task("subscriber_listener")
-                                .with_reason(format!("lagged({skipped})"));
-
-                            let arc_e = Arc::new(e);
-                            alive.update(&arc_e).await;
-                            set.emit_arc(arc_e);
-                        }
-                        Err(broadcast::error::RecvError::Closed) => break,
-                    },
-
-                    _ = rt.cancelled() => {
-                        while let Ok(arc_ev) = rx.try_recv() {
-                            alive.update(&arc_ev).await;
-                            set.emit_arc(arc_ev);
-                        }
-                        break;
-                    }
-                }
-            }
-        });
-
-        *self.subscriber_handle.lock().unwrap() = Some(handle);
-    }
-
-    /// Awaits the subscriber listener.
-    async fn join_subscriber_listener(&self) {
-        let handle = self.subscriber_handle.lock().unwrap().take();
-        if let Some(handle) = handle {
-            let _ = handle.await;
-        }
-    }
-
-    /// Waits for either shutdown signal or natural completion of all tasks.
-    async fn drive_shutdown(&self) -> Result<(), RuntimeError> {
-        let res = tokio::select! {
-            sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
-            _ = self.registry.wait_until_empty() => Ok(()),
-        };
-        self.runtime_token.cancel();
-        self.join_subscriber_listener().await;
-        self.subs.close().await;
-        res
-    }
-
-    /// Handles the outcome of [`wait_for_shutdown_signal`](crate::core::shutdown::wait_for_shutdown_signal).
-    async fn on_shutdown_signal(&self, res: std::io::Result<()>) -> Result<(), RuntimeError> {
-        match res {
-            Ok(()) => {
-                self.bus.publish(Event::new(EventKind::ShutdownRequested));
-                self.drain_with_grace().await
-            }
-            Err(e) => Err(RuntimeError::SignalSetupFailed { source: e }),
-        }
-    }
-
-    /// Cancels all tasks and waits up to `grace` for them to stop, force-aborting stragglers.
-    async fn drain_with_grace(&self) -> Result<(), RuntimeError> {
-        let grace = self.cfg.grace;
-        let stuck = self.registry.cancel_all_within(grace).await;
-        if stuck.is_empty() {
-            self.bus
-                .publish(Event::new(EventKind::AllStoppedWithinGrace));
-            Ok(())
-        } else {
-            self.bus.publish(Event::new(EventKind::GraceExceeded));
-            Err(RuntimeError::GraceExceeded { grace, stuck })
-        }
-    }
-
-    /// Waits up to `wait_for` for a task to **actually terminate**, signalled by its `TaskRemoved`
-    /// event (published by the registry only after the actor's `JoinHandle` completes).
-    ///
-    /// The `TaskRemoved` event may be lost to broadcast lag, that's why on `Lagged`/`Closed` and on timeout this falls back to the registry's termination state
-    /// (`is_terminated`: not registered **and** not awaiting join) instead of reporting a spurious `TaskRemoveTimeout`.
-    async fn wait_task_removed(
-        &self,
-        rx: &mut broadcast::Receiver<Arc<Event>>,
-        id: TaskId,
-        wait_for: Duration,
-    ) -> Result<bool, RuntimeError> {
-        let wait_for_event = async {
-            loop {
-                match rx.recv().await {
-                    Ok(ev) if matches!(ev.kind, EventKind::TaskRemoved) && ev.id == Some(id) => {
-                        return true;
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if self.registry.is_terminated(id).await {
-                            return true;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        return self.registry.is_terminated(id).await;
-                    }
-                }
-            }
-        };
-
-        match timeout(wait_for, wait_for_event).await {
-            Ok(true) => Ok(true),
-            Ok(false) | Err(_) => {
-                if self.registry.is_terminated(id).await {
-                    Ok(true)
-                } else {
-                    Err(RuntimeError::TaskRemoveTimeout {
-                        id,
-                        timeout: wait_for,
-                    })
-                }
-            }
-        }
+    /// Test-only access to the runtime, for constructing a standalone controller against a live core.
+    #[cfg(all(test, feature = "controller"))]
+    pub(crate) fn core(&self) -> &Arc<SupervisorCore> {
+        &self.core
     }
 }
 
@@ -626,48 +122,7 @@ impl Supervisor {
 mod tests {
     use super::*;
     use crate::{TaskContext, TaskFn, TaskRef};
-
-    #[tokio::test]
-    async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
-        let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
-        let mut rx = sup.bus.subscribe();
-
-        let err = std::io::Error::other("signal registration failed");
-        let out = sup.on_shutdown_signal(Err(err)).await;
-
-        assert!(
-            matches!(out, Err(RuntimeError::SignalSetupFailed { .. })),
-            "a signal-setup error must surface as SignalSetupFailed, got {out:?}"
-        );
-
-        let mut saw_shutdown = false;
-        while let Ok(ev) = rx.try_recv() {
-            if matches!(ev.kind, EventKind::ShutdownRequested) {
-                saw_shutdown = true;
-            }
-        }
-        assert!(
-            !saw_shutdown,
-            "a signal-setup error must NOT masquerade as a shutdown request"
-        );
-    }
-
-    #[tokio::test]
-    async fn real_signal_publishes_shutdown_requested() {
-        let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
-        let mut rx = sup.bus.subscribe();
-
-        let out = sup.on_shutdown_signal(Ok(())).await;
-        assert!(out.is_ok(), "a real signal drains gracefully: {out:?}");
-
-        let mut saw_shutdown = false;
-        while let Ok(ev) = rx.try_recv() {
-            if matches!(ev.kind, EventKind::ShutdownRequested) {
-                saw_shutdown = true;
-            }
-        }
-        assert!(saw_shutdown, "a real signal must publish ShutdownRequested");
-    }
+    use std::time::Duration;
 
     #[tokio::test]
     async fn shutdown_force_terminates_noncooperative_task_within_grace() {
@@ -720,7 +175,7 @@ mod tests {
             .await
             .expect("task should register");
 
-        let res = timeout(Duration::from_secs(5), handle.shutdown())
+        let res = tokio::time::timeout(Duration::from_secs(5), handle.shutdown())
             .await
             .expect("cooperative shutdown must not hang");
         assert!(
@@ -751,62 +206,6 @@ mod tests {
         assert!(
             matches!(res, Err(RuntimeError::TaskAlreadyExists { .. })),
             "duplicate add must return TaskAlreadyExists, got {res:?}"
-        );
-
-        let _ = handle.shutdown().await;
-    }
-
-    #[tokio::test]
-    async fn wait_task_removed_survives_bus_lag() {
-        let cfg = SupervisorConfig {
-            bus_capacity: 8,
-            ..Default::default()
-        };
-        let sup = Supervisor::new(cfg, vec![]);
-        let handle = sup.serve();
-
-        let t: TaskRef = TaskFn::arc("laggy", |ctx: TaskContext| async move {
-            ctx.cancelled().await;
-            Ok(())
-        });
-        let id = handle
-            .add_and_wait(TaskSpec::restartable(t), Duration::from_secs(1))
-            .await
-            .expect("add should succeed");
-
-        let mut lagged_rx = sup.subscribe_bus();
-        let mut observer = sup.subscribe_bus();
-
-        sup.remove(id).expect("remove should be accepted");
-
-        let observed = timeout(Duration::from_secs(2), async {
-            loop {
-                if let Ok(ev) = observer.recv().await
-                    && ev.kind == EventKind::TaskRemoved
-                    && ev.id == Some(id)
-                {
-                    return;
-                }
-            }
-        })
-        .await;
-        observed.expect("TaskRemoved must be observed by a healthy receiver");
-
-        for _ in 0..32 {
-            sup.bus
-                .publish(Event::new(EventKind::TaskStarting).with_task("noise"));
-        }
-
-        let res = timeout(
-            Duration::from_secs(1),
-            sup.wait_task_removed(&mut lagged_rx, id, Duration::from_millis(300)),
-        )
-        .await
-        .expect("wait_task_removed must not hang");
-        assert!(
-            matches!(res, Ok(true)),
-            "a lagged receiver must fall back to runtime state instead of reporting \
-             a spurious TaskRemoveTimeout, got {res:?}"
         );
 
         let _ = handle.shutdown().await;

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -48,10 +48,14 @@ use crate::{error::RuntimeError, subscribers::Subscribe, tasks::TaskSpec};
 ///
 /// [`SupervisorHandle`]: crate::SupervisorHandle
 pub struct Supervisor {
-    pub(super) core: Arc<SupervisorCore>,
+    core: Arc<SupervisorCore>,
 
     #[cfg(feature = "controller")]
-    pub(super) controller: Option<Arc<crate::controller::Controller>>,
+    controller: Option<Arc<crate::controller::Controller>>,
+    #[cfg(feature = "controller")]
+    runtime_token: tokio_util::sync::CancellationToken,
+    #[cfg(feature = "controller")]
+    controller_started: std::sync::atomic::AtomicBool,
 }
 
 impl std::fmt::Debug for Supervisor {
@@ -67,12 +71,28 @@ impl Supervisor {
     pub(super) fn from_parts(
         core: Arc<SupervisorCore>,
         #[cfg(feature = "controller")] controller: Option<Arc<crate::controller::Controller>>,
+        #[cfg(feature = "controller")] runtime_token: tokio_util::sync::CancellationToken,
     ) -> Arc<Self> {
         Arc::new(Self {
             core,
             #[cfg(feature = "controller")]
             controller,
+            #[cfg(feature = "controller")]
+            runtime_token,
+            #[cfg(feature = "controller")]
+            controller_started: std::sync::atomic::AtomicBool::new(false),
         })
+    }
+
+    /// Starts the controller's event loop exactly once.
+    #[cfg(feature = "controller")]
+    fn start_controller(&self) {
+        use std::sync::atomic::Ordering;
+        if let Some(ctrl) = &self.controller
+            && !self.controller_started.swap(true, Ordering::AcqRel)
+        {
+            ctrl.clone().run(self.runtime_token.clone());
+        }
     }
 
     /// Creates a new supervisor with the given config and subscribers (maybe empty).
@@ -95,9 +115,11 @@ impl Supervisor {
         SupervisorBuilder::new(cfg)
     }
 
-    /// Returns a [`SupervisorHandle`] for dynamic task management.
+    /// Returns a [`SupervisorHandle`](crate::SupervisorHandle) for dynamic task management.
     pub fn serve(self: &Arc<Self>) -> super::handle::SupervisorHandle {
         self.core.start();
+        #[cfg(feature = "controller")]
+        self.start_controller();
         let handle = super::handle::SupervisorHandle::new(Arc::clone(&self.core));
         #[cfg(feature = "controller")]
         let handle = handle.with_controller(self.controller.clone());
@@ -105,9 +127,9 @@ impl Supervisor {
     }
 
     /// Runs task specifications until completion or shutdown signal (static mode).
-    ///
-    /// Delegates to the runtime; the controller (if configured) is already running independently.
     pub async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
+        #[cfg(feature = "controller")]
+        self.start_controller();
         self.core.run(tasks).await
     }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -35,9 +35,9 @@ impl TaskId {
         self.0
     }
 
-    /// `TaskId` from its raw value.
+    /// Reconstructs a `TaskId` from its raw value.
     #[inline]
-    pub fn from_raw(raw: u64) -> Self {
+    pub(crate) fn from_raw(raw: u64) -> Self {
         TaskId(raw)
     }
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -34,12 +34,6 @@ impl TaskId {
     pub fn get(self) -> u64 {
         self.0
     }
-
-    /// Reconstructs a `TaskId` from its raw value.
-    #[inline]
-    pub(crate) fn from_raw(raw: u64) -> Self {
-        TaskId(raw)
-    }
 }
 
 impl std::fmt::Display for TaskId {
@@ -63,12 +57,5 @@ mod tests {
     #[test]
     fn never_mints_zero() {
         assert!(TaskId::next().get() >= 1);
-    }
-
-    #[test]
-    fn from_raw_round_trips() {
-        let id = TaskId::from_raw(42);
-        assert_eq!(id.get(), 42);
-        assert_eq!(id, TaskId::from_raw(42));
     }
 }


### PR DESCRIPTION
## 📝 Description
Split the monolithic Supervisor into a SupervisorCore runtime and facade

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally
