### PR TITLE
[policy] Validate BackoffPolicy invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Restart on failure, with a short backoff between attempts.
-    let spec = TaskSpec::restartable(flaky).with_backoff(BackoffPolicy {
-        first: Duration::from_millis(50),
-        ..BackoffPolicy::default()
-    });
+    let backoff = BackoffPolicy::new(
+        Duration::from_millis(50),
+        Duration::from_secs(30),
+        1.0,
+        JitterPolicy::None,
+    )
+    .unwrap();
+    let spec = TaskSpec::restartable(flaky).with_backoff(backoff);
 
     let subs: Vec<Arc<dyn Subscribe>> = vec![Arc::new(Printer)];
     Supervisor::new(SupervisorConfig::default(), subs).run(vec![spec]).await?;
@@ -297,12 +301,14 @@ do_work().await
 use std::time::Duration;
 use taskvisor::{BackoffPolicy, JitterPolicy};
 
-let backoff = BackoffPolicy {
-    first: Duration::from_millis(200),
-    max: Duration::from_secs(30),
-    factor: 2.0,                    // 200ms -> 400ms -> 800ms -> ...
-    jitter: JitterPolicy::Equal,    // recommended: [delay/2, delay]
-};
+let backoff = BackoffPolicy::new(
+    Duration::from_millis(200),     // first
+    Duration::from_secs(30),        // max
+    2.0,                            // factor: 200ms -> 400ms -> 800ms -> ...
+    JitterPolicy::Equal,            // recommended: [delay/2, delay]
+)
+.unwrap();
+// optional: .with_floor(Duration::from_millis(50)) to keep jittered delays above a minimum
 ```
 
 ### Per-task timeout with max retries

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -122,11 +122,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let spec = TaskSpec::restartable(flaky).with_backoff(BackoffPolicy {
-        first: Duration::from_millis(100),
-        factor: 1.0,
-        ..BackoffPolicy::default()
-    });
+    // first=100ms, factor=1.0 are the defaults already.
+    let spec = TaskSpec::restartable(flaky).with_backoff(BackoffPolicy::default());
 
     let subs: Vec<Arc<dyn Subscribe>> = vec![Arc::clone(&metrics) as _];
     let sup = Supervisor::new(SupervisorConfig::default(), subs);

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -100,12 +100,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             interval: Some(Duration::from_millis(500)),
         }),
         TaskSpec::restartable(resilient)
-            .with_backoff(BackoffPolicy {
-                first: Duration::from_millis(200),
-                max: Duration::from_secs(5),
-                factor: 2.0,
-                ..BackoffPolicy::default()
-            })
+            .with_backoff(
+                BackoffPolicy::new(
+                    Duration::from_millis(200),
+                    Duration::from_secs(5),
+                    2.0,
+                    JitterPolicy::None,
+                )
+                .expect("valid backoff"),
+            )
             .with_max_retries(3),
     ];
 

--- a/examples/outcomes.rs
+++ b/examples/outcomes.rs
@@ -92,10 +92,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
     let spec = TaskSpec::restartable(flaky)
-        .with_backoff(BackoffPolicy {
-            first: Duration::from_millis(20),
-            ..BackoffPolicy::default()
-        })
+        .with_backoff(
+            BackoffPolicy::new(
+                Duration::from_millis(20),
+                Duration::from_secs(30),
+                1.0,
+                JitterPolicy::None,
+            )
+            .expect("valid backoff"),
+        )
         .with_max_retries(2);
     match handle
         .add_and_watch(spec, ADD_TIMEOUT)

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -392,12 +392,13 @@ mod tests {
     type BoxFut = Pin<Box<dyn Future<Output = Result<(), TaskError>> + Send + 'static>>;
 
     fn fast_backoff() -> BackoffPolicy {
-        BackoffPolicy {
-            first: Duration::from_millis(1),
-            max: Duration::from_millis(1),
-            factor: 1.0,
-            jitter: crate::JitterPolicy::None,
-        }
+        BackoffPolicy::new(
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+            1.0,
+            crate::JitterPolicy::None,
+        )
+        .expect("valid backoff")
     }
 
     fn params(restart: RestartPolicy, max_retries: u32) -> TaskActorParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ mod tasks;
 pub use tasks::{BoxTaskFuture, Task, TaskContext, TaskFn, TaskRef, TaskSpec};
 
 mod policies;
-pub use policies::{BackoffPolicy, JitterPolicy, RestartPolicy};
+pub use policies::{BackoffError, BackoffPolicy, JitterPolicy, RestartPolicy};
 
 mod events;
 pub use events::{BackoffSource, Event, EventKind};

--- a/src/policies/backoff.rs
+++ b/src/policies/backoff.rs
@@ -4,8 +4,8 @@
 //!
 //! It is parameterized by:
 //! - [`BackoffPolicy::factor`] the multiplicative growth factor.
-//! - [`BackoffPolicy::first`] the initial delay.
 //! - [`BackoffPolicy::max`] the maximum delay cap.
+//! - [`BackoffPolicy::first`] the initial delay.
 //!
 //! The delay for attempt `n` is computed as `first × factor^n`, clamped to `max`, then jitter is applied.
 //!
@@ -14,12 +14,13 @@
 //! use std::time::Duration;
 //! use taskvisor::{BackoffPolicy, JitterPolicy};
 //!
-//! let backoff = BackoffPolicy {
-//!     first: Duration::from_millis(100),
-//!     max: Duration::from_secs(10),
-//!     factor: 2.0,
-//!     jitter: JitterPolicy::None,
-//! };
+//! let backoff = BackoffPolicy::new(
+//!     Duration::from_millis(100),
+//!     Duration::from_secs(10),
+//!     2.0,
+//!     JitterPolicy::None,
+//! )
+//! .unwrap();
 //!
 //! // Attempt 0 - uses 'first' (100ms), clamped to max
 //! assert_eq!(backoff.next(0), Duration::from_millis(100));
@@ -33,7 +34,26 @@
 
 use std::time::Duration;
 
+use thiserror::Error;
+
 use crate::policies::jitter::JitterPolicy;
+
+/// Error returned by [`BackoffPolicy::new`] when parameters violate the policy invariants.
+#[derive(Debug, Clone, Copy, PartialEq, Error)]
+#[non_exhaustive]
+pub enum BackoffError {
+    /// `factor` was not finite or was below `1.0` (a backoff factor must not shrink delays).
+    #[error("backoff factor must be finite and >= 1.0, got {0}")]
+    InvalidFactor(f64),
+    /// `first` exceeded `max` (the initial delay cannot be larger than the cap).
+    #[error("backoff first delay {first:?} exceeds max {max:?}")]
+    FirstExceedsMax {
+        /// The offending initial delay.
+        first: Duration,
+        /// The configured cap.
+        max: Duration,
+    },
+}
 
 /// Retry backoff policy.
 ///
@@ -41,47 +61,109 @@ use crate::policies::jitter::JitterPolicy;
 ///
 /// # Also
 ///
+/// - [`TaskSpec`](crate::TaskSpec) - wires restart + backoff + timeout together
 /// - [`RestartPolicy`](crate::RestartPolicy) - whether to restart at all
 /// - [`JitterPolicy`] - randomization applied to computed delay
-/// - [`TaskSpec`](crate::TaskSpec) - wires restart + backoff + timeout together
 #[derive(Clone, Copy, Debug)]
 pub struct BackoffPolicy {
-    /// Initial delay before the first retry.
-    pub first: Duration,
-    /// Maximum delay cap for retries.
-    pub max: Duration,
-    /// Multiplicative growth factor (`>= 1.0` recommended).
-    pub factor: f64,
-    /// Jitter policy that spreads retries out in time.
-    pub jitter: JitterPolicy,
+    jitter: JitterPolicy,
+    first: Duration,
+    floor: Duration,
+    max: Duration,
+    factor: f64,
 }
 
 impl Default for BackoffPolicy {
     /// Returns a strategy with:
     /// - `factor = 1.0` (constant delay);
     /// - `first = 100ms`;
-    /// - `max = 30s`.
+    /// - `max = 30s`;
+    /// - `floor = 0` (no floor).
     fn default() -> Self {
         Self {
             first: Duration::from_millis(100),
             max: Duration::from_secs(30),
             jitter: JitterPolicy::None,
             factor: 1.0,
+            floor: Duration::ZERO,
         }
     }
 }
 
 impl BackoffPolicy {
+    /// Creates a validated backoff policy.
+    ///
+    /// # Errors
+    /// - [`BackoffError::InvalidFactor`] if `factor` is not finite or `< 1.0`.
+    /// - [`BackoffError::FirstExceedsMax`] if `first > max`.
+    ///
+    /// The delay floor defaults to `0`; set one with [`with_floor`](Self::with_floor).
+    pub fn new(
+        first: Duration,
+        max: Duration,
+        factor: f64,
+        jitter: JitterPolicy,
+    ) -> Result<Self, BackoffError> {
+        if !factor.is_finite() || factor < 1.0 {
+            return Err(BackoffError::InvalidFactor(factor));
+        }
+        if first > max {
+            return Err(BackoffError::FirstExceedsMax { first, max });
+        }
+        Ok(Self {
+            first,
+            max,
+            factor,
+            jitter,
+            floor: Duration::ZERO,
+        })
+    }
+
+    /// Sets a minimum delay floor, applied to every computed delay (after jitter).
+    ///
+    /// Useful with [`JitterPolicy::Full`], which can otherwise return near-zero delays.
+    /// A floor above `max` is clamped to `max`.
+    #[must_use]
+    pub fn with_floor(mut self, floor: Duration) -> Self {
+        self.floor = floor.min(self.max);
+        self
+    }
+
+    /// Initial delay before the first retry.
+    #[must_use]
+    pub fn first(&self) -> Duration {
+        self.first
+    }
+
+    /// Maximum delay cap for retries.
+    #[must_use]
+    pub fn max(&self) -> Duration {
+        self.max
+    }
+
+    /// Multiplicative growth factor (always finite and `>= 1.0`).
+    #[must_use]
+    pub fn factor(&self) -> f64 {
+        self.factor
+    }
+
+    /// Jitter policy applied to computed delays.
+    #[must_use]
+    pub fn jitter(&self) -> JitterPolicy {
+        self.jitter
+    }
+
+    /// Minimum delay floor (`0` if unset).
+    #[must_use]
+    pub fn floor(&self) -> Duration {
+        self.floor
+    }
+
     /// Computes the delay for the given attempt number (0-indexed).
     ///
     /// The base delay is `first × factor^attempt`, clamped to [`BackoffPolicy::max`].
     /// Jitter is applied to the clamped base, but the result is **never** fed back into subsequent calculations.
     /// Each attempt derives its base independently.
-    ///
-    /// # Notes
-    /// - If `factor` is less than 1.0, delays decrease with higher attempts (not typical).
-    /// - If `factor` equals 1.0, delay remains constant at `first` (up to `max`).
-    /// - If `factor` is greater than 1.0, delays grow exponentially up to `max`.
     pub fn next(&self, attempt: u32) -> Duration {
         let max_secs = self.max.as_secs_f64();
         let clamped_exp = attempt.min(i32::MAX as u32) as i32;
@@ -94,13 +176,14 @@ impl BackoffPolicy {
                 Duration::from_secs_f64(unclamped_secs)
             };
 
-        match self.jitter {
+        let delay = match self.jitter {
             JitterPolicy::Decorrelated => {
                 self.jitter
                     .apply_decorrelated(self.first.min(self.max), base, self.max)
             }
             _ => self.jitter.apply(base),
-        }
+        };
+        delay.max(self.floor)
     }
 }
 
@@ -116,6 +199,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         assert_eq!(policy.next(0), Duration::from_millis(100));
     }
@@ -127,6 +211,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
 
         assert_eq!(policy.next(0), Duration::from_millis(100));
@@ -143,6 +228,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 1.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         for attempt in 0..10 {
             assert_eq!(
@@ -161,6 +247,7 @@ mod tests {
             max: Duration::from_secs(1),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         assert_eq!(policy.next(10), Duration::from_secs(1));
     }
@@ -172,6 +259,7 @@ mod tests {
             max: Duration::from_secs(5),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         assert_eq!(policy.next(0), Duration::from_secs(5));
     }
@@ -183,6 +271,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 2.0,
             jitter: JitterPolicy::Full,
+            floor: Duration::ZERO,
         };
 
         for attempt in 5..15 {
@@ -205,6 +294,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 2.0,
             jitter: JitterPolicy::Equal,
+            floor: Duration::ZERO,
         };
 
         for attempt in 0..15 {
@@ -235,6 +325,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 2.0,
             jitter: JitterPolicy::Decorrelated,
+            floor: Duration::ZERO,
         };
 
         let mut min_late = Duration::from_secs(999);
@@ -264,6 +355,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 1.0,
             jitter: JitterPolicy::Full,
+            floor: Duration::ZERO,
         };
         for attempt in 0..50 {
             let delay = policy.next(attempt);
@@ -278,6 +370,7 @@ mod tests {
             max: Duration::from_secs(30),
             factor: 1.0,
             jitter: JitterPolicy::Equal,
+            floor: Duration::ZERO,
         };
         for attempt in 0..50 {
             let delay = policy.next(attempt);
@@ -293,6 +386,7 @@ mod tests {
             max: Duration::from_secs(60),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         assert_eq!(policy.next(100), Duration::from_secs(60));
     }
@@ -304,7 +398,82 @@ mod tests {
             max: Duration::from_secs(10),
             factor: 2.0,
             jitter: JitterPolicy::None,
+            floor: Duration::ZERO,
         };
         assert_eq!(policy.next(u32::MAX), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn new_rejects_non_finite_or_subunit_factor() {
+        let bad = [f64::NAN, f64::INFINITY, 0.5, 0.0, -1.0];
+        for f in bad {
+            assert!(
+                matches!(
+                    BackoffPolicy::new(
+                        Duration::from_millis(100),
+                        Duration::from_secs(30),
+                        f,
+                        JitterPolicy::None
+                    ),
+                    Err(BackoffError::InvalidFactor(_))
+                ),
+                "factor {f} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn new_rejects_first_exceeding_max() {
+        let res = BackoffPolicy::new(
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+            2.0,
+            JitterPolicy::None,
+        );
+        assert!(matches!(res, Err(BackoffError::FirstExceedsMax { .. })));
+    }
+
+    #[test]
+    fn new_accepts_valid_policy() {
+        let p = BackoffPolicy::new(
+            Duration::from_millis(100),
+            Duration::from_secs(30),
+            2.0,
+            JitterPolicy::None,
+        )
+        .expect("valid");
+        assert_eq!(p.next(1), Duration::from_millis(200));
+    }
+
+    #[test]
+    fn floor_raises_jittered_delays() {
+        let p = BackoffPolicy::new(
+            Duration::from_millis(100),
+            Duration::from_secs(30),
+            2.0,
+            JitterPolicy::Full,
+        )
+        .expect("valid")
+        .with_floor(Duration::from_millis(50));
+
+        for attempt in 0..12 {
+            assert!(
+                p.next(attempt) >= Duration::from_millis(50),
+                "attempt {attempt}: below floor"
+            );
+        }
+    }
+
+    #[test]
+    fn floor_is_clamped_to_max() {
+        let p = BackoffPolicy::new(
+            Duration::from_millis(100),
+            Duration::from_secs(5),
+            1.0,
+            JitterPolicy::None,
+        )
+        .expect("valid")
+        .with_floor(Duration::from_secs(999));
+        assert!(p.next(0) <= Duration::from_secs(5));
     }
 }

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -17,7 +17,7 @@
 //! - `RestartPolicy::OnFailure` (recommended default for most tasks).
 
 mod backoff;
-pub use backoff::BackoffPolicy;
+pub use backoff::{BackoffError, BackoffPolicy};
 
 mod restart;
 pub use restart::RestartPolicy;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -151,10 +151,11 @@ pub fn make_panic(name: &str) -> TaskRef {
 }
 
 pub fn fast_backoff() -> BackoffPolicy {
-    BackoffPolicy {
-        first: Duration::from_millis(1),
-        max: Duration::from_millis(1),
-        factor: 1.0,
-        jitter: JitterPolicy::None,
-    }
+    BackoffPolicy::new(
+        Duration::from_millis(1),
+        Duration::from_millis(1),
+        1.0,
+        JitterPolicy::None,
+    )
+    .expect("valid backoff")
 }


### PR DESCRIPTION
## 📝 Description
Adds a checked `BackoffPolicy::new` constructor, exposes `BackoffError`, and makes backoff fields private behind accessors. 

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] CI passes locally

## Breaking
`BackoffPolicy` fields are now private, struct literals like
```rust
BackoffPolicy { first, max, factor, jitter }
```
no longer compile.

Use
```rust
BackoffPolicy::new(first, max, factor, jitter)?
BackoffPolicy::default()
```