### PR TITLE
[feat] add test-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ exclude = [
 ]
 
 [features]
-default = []
-controller = ["dep:dashmap"]
-logging = []
-tracing = ["dep:tracing"]
+controller         = ["dep:dashmap"]
+default            = []
+logging            = []
+test-util          = []
+tracing            = ["dep:tracing"]
 tokio-util-interop = []
 
 [package.metadata.docs.rs]
-features     = ["logging", "tracing", "controller", "tokio-util-interop"]
+features     = ["logging", "tracing", "controller", "tokio-util-interop", "test-util"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ cargo bench --bench controller --features controller # admission control
 | `tracing`            | Built-in `TracingBridge` subscriber: events flow into your `tracing` log pipeline     |
 | `logging`            | Built-in `LogWriter` subscriber: event output to stdout (demo/reference)              |
 | `tokio-util-interop` | Access to the raw `CancellationToken` behind `TaskContext`, for APIs that need one    |
+| `test-util`          | Test helpers: `TaskContext::detached()`, `TaskId::for_tests()`, and more              |
 
 ```toml
 taskvisor = { version = "0.4", features = ["controller", "tracing"] }

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -320,9 +320,9 @@ impl Controller {
                 Event::new(EventKind::ControllerRejected)
                     .with_task(spec.slot_name().to_owned())
                     .with_id(id)
-                    .with_reason("controller_shutting_down"),
+                    .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
             );
-            self.finalize_rejected(id, "controller_shutting_down");
+            self.finalize_rejected(id, crate::reasons::CONTROLLER_SHUTTING_DOWN);
             return;
         }
 
@@ -506,9 +506,9 @@ impl Controller {
                 Event::new(EventKind::ControllerRejected)
                     .with_task(Arc::clone(&slot_name))
                     .with_id(id)
-                    .with_reason("removed_from_queue"),
+                    .with_reason(crate::reasons::REMOVED_FROM_QUEUE),
             );
-            self.finalize_rejected(id, "removed_from_queue");
+            self.finalize_rejected(id, crate::reasons::REMOVED_FROM_QUEUE);
             self.gc_if_idle(&slot_name, slot);
             return;
         }
@@ -708,7 +708,12 @@ impl Controller {
     #[inline]
     fn reject_if_full(&self, slot_name: &str, id: TaskId, slot_len: usize) -> bool {
         if slot_len >= self.config.max_slot_queue {
-            let reason = format!("queue_full: {}/{}", slot_len, self.config.max_slot_queue);
+            let reason = format!(
+                "{}: {}/{}",
+                crate::reasons::QUEUE_FULL,
+                slot_len,
+                self.config.max_slot_queue
+            );
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(slot_name)
@@ -739,9 +744,9 @@ impl Controller {
                 Event::new(EventKind::ControllerRejected)
                     .with_task(Arc::clone(slot_name))
                     .with_id(displaced_id)
-                    .with_reason("superseded_by_replace"),
+                    .with_reason(crate::reasons::SUPERSEDED_BY_REPLACE),
             );
-            self.finalize_rejected(displaced_id, "superseded_by_replace");
+            self.finalize_rejected(displaced_id, crate::reasons::SUPERSEDED_BY_REPLACE);
         } else {
             slot.queue.push_front((id, task_spec));
         }
@@ -803,7 +808,10 @@ mod tests {
         let ev = rx.try_recv().expect("displaced head must be rejected");
         assert_eq!(ev.kind, EventKind::ControllerRejected);
         assert_eq!(ev.id, Some(displaced));
-        assert_eq!(ev.reason.as_deref(), Some("superseded_by_replace"));
+        assert_eq!(
+            ev.reason.as_deref(),
+            Some(crate::reasons::SUPERSEDED_BY_REPLACE)
+        );
     }
 
     #[test]

--- a/src/controller/core/shutdown.rs
+++ b/src/controller/core/shutdown.rs
@@ -37,9 +37,9 @@ impl Controller {
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_id(id)
-                    .with_reason("controller_shutting_down"),
+                    .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
             );
-            self.finalize_rejected(id, "controller_shutting_down");
+            self.finalize_rejected(id, crate::reasons::CONTROLLER_SHUTTING_DOWN);
         }
 
         while let Ok(sub) = rx.try_recv() {
@@ -47,12 +47,12 @@ impl Controller {
                 Event::new(EventKind::ControllerRejected)
                     .with_task(sub.spec.slot_name().to_owned())
                     .with_id(sub.id)
-                    .with_reason("controller_shutting_down"),
+                    .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
             );
 
             if let Some(done) = sub.done {
                 let _ = done.send(TaskOutcome::Rejected {
-                    reason: Arc::from("controller_shutting_down"),
+                    reason: Arc::from(crate::reasons::CONTROLLER_SHUTTING_DOWN),
                 });
             }
         }

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -91,9 +91,10 @@ use crate::{
     TaskError,
     core::runner::run_once,
     error::SharedError,
-    events::{Bus, Event, EventKind, REASON_MAX_RETRIES_EXCEEDED},
+    events::{Bus, Event, EventKind},
     identity::TaskId,
     policies::{BackoffPolicy, RestartPolicy},
+    reasons,
     tasks::Task,
 };
 
@@ -323,7 +324,7 @@ impl TaskActor {
                                     .with_task(task_name.clone())
                                     .with_id(id)
                                     .with_attempt(attempt)
-                                    .with_reason("policy_exhausted_success"),
+                                    .with_reason(reasons::POLICY_EXHAUSTED_SUCCESS),
                             );
                             return ActorExitReason::Completed;
                         }
@@ -358,7 +359,7 @@ impl TaskActor {
                             .with_task(task_name.clone())
                             .with_id(id)
                             .with_attempt(attempt)
-                            .with_reason("task_returned_canceled"),
+                            .with_reason(reasons::TASK_RETURNED_CANCELED),
                     );
                     return ActorExitReason::Canceled;
                 }
@@ -379,7 +380,7 @@ impl TaskActor {
                         {
                             Arc::from(format!(
                                 "{}({}/{}): {}",
-                                REASON_MAX_RETRIES_EXCEEDED,
+                                reasons::MAX_RETRIES_EXCEEDED,
                                 backoff_attempt,
                                 limit.get(),
                                 e

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -156,6 +156,45 @@ impl TaskOutcome {
         matches!(self, TaskOutcome::Completed)
     }
 
+    /// Creates a [`Failed`](Self::Failed) outcome for tests.
+    ///
+    /// Real outcomes normally come from the runtime.
+    /// The `Failed` and `Fatal` variants are `#[non_exhaustive]`;
+    /// other crates cannot build them directly.
+    ///
+    /// This helper lets tests cover code that handles failed outcomes; `source` is `None`.
+    ///
+    /// ```rust
+    /// use taskvisor::TaskOutcome;
+    ///
+    /// let outcome = TaskOutcome::failed_for_tests("boom", Some(3));
+    /// assert!(!outcome.is_success());
+    /// ```
+    #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+    #[must_use]
+    pub fn failed_for_tests(reason: impl Into<Arc<str>>, exit_code: Option<i32>) -> Self {
+        Self::Failed {
+            reason: reason.into(),
+            exit_code,
+            source: None,
+        }
+    }
+
+    /// Creates a [`Fatal`](Self::Fatal) outcome for tests.
+    ///
+    /// See [`failed_for_tests`](Self::failed_for_tests) for why this helper exists; `source` is `None`.
+    #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+    #[must_use]
+    pub fn fatal_for_tests(reason: impl Into<Arc<str>>, exit_code: Option<i32>) -> Self {
+        Self::Fatal {
+            reason: reason.into(),
+            exit_code,
+            source: None,
+        }
+    }
+
     /// Returns the original error source for [`Failed`](Self::Failed) or [`Fatal`](Self::Fatal).
     ///
     /// Returns `None` when the outcome has no source error.
@@ -260,6 +299,23 @@ impl TaskWaiter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "test-util")]
+    #[test]
+    fn test_constructors_build_the_terminal_failure_variants() {
+        let failed = TaskOutcome::failed_for_tests("boom", Some(3));
+        assert!(matches!(
+            &failed,
+            TaskOutcome::Failed { reason, exit_code: Some(3), .. } if reason.as_ref() == "boom"
+        ));
+        assert!(failed.source().is_none(), "test outcomes carry no source");
+
+        let fatal = TaskOutcome::fatal_for_tests("bad config", None);
+        assert!(matches!(
+            &fatal,
+            TaskOutcome::Fatal { reason, exit_code: None, .. } if reason.as_ref() == "bad config"
+        ));
+    }
 
     #[test]
     fn labels_are_stable_and_distinct() {

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -61,6 +61,7 @@ use crate::core::actor::{ActorExitReason, TaskActor, TaskActorParams};
 use crate::core::outcome::TaskOutcome;
 use crate::events::{Bus, Event, EventKind};
 use crate::identity::TaskId;
+use crate::reasons;
 use crate::tasks::TaskSpec;
 
 /// Sender used to resolve a watched task with its final [`TaskOutcome`].
@@ -485,7 +486,8 @@ impl Registry {
     /// Spawns an actor and registers it under `id`.
     ///
     /// Duplicate task names are rejected.
-    /// If a watched add supplied `done`, it is resolved as [`TaskOutcome::Rejected`] with reason `already_exists`.
+    /// If a watched add includes `done`, it resolves as [`TaskOutcome::Rejected`]
+    /// with reason [`ALREADY_EXISTS`](crate::reasons::ALREADY_EXISTS).
     ///
     /// Direct `add_and_watch` callers still receive [`RuntimeError::TaskAlreadyExists`](crate::RuntimeError::TaskAlreadyExists) because registration confirmation fails before the waiter is returned.
     async fn spawn_and_register(&self, id: TaskId, spec: TaskSpec, done: Option<OutcomeTx>) {
@@ -496,14 +498,14 @@ impl Registry {
             drop(st);
             if let Some(done) = done {
                 let _ = done.send(TaskOutcome::Rejected {
-                    reason: Arc::from("already_exists"),
+                    reason: Arc::from(reasons::ALREADY_EXISTS),
                 });
             }
             self.bus.publish(
                 Event::new(EventKind::TaskAddFailed)
                     .with_task(label)
                     .with_id(id)
-                    .with_reason("already_exists"),
+                    .with_reason(reasons::ALREADY_EXISTS),
             );
             return;
         }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -62,10 +62,6 @@ use crate::identity::TaskId;
 /// Global counter minting unique, monotonic `seq` values at event construction.
 static EVENT_SEQ: AtomicU64 = AtomicU64::new(1);
 
-/// Reason prefix set by the actor when a task permanently stops after exhausting its retry budget.
-/// `TracingBridge` raises such events to WARN.
-pub(crate) const REASON_MAX_RETRIES_EXCEEDED: &str = "max_retries_exceeded";
-
 /// Classification of runtime events.
 ///
 /// Every event has `seq`, `at`, and `kind`.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -54,7 +54,6 @@
 //! With the `logging` feature, `LogWriter` provides a small built-in example.
 
 mod event;
-pub(crate) use event::REASON_MAX_RETRIES_EXCEEDED;
 pub use event::{BackoffSource, Event, EventKind};
 
 mod bus;

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -58,6 +58,22 @@ impl TaskId {
     pub fn get(self) -> u64 {
         self.0
     }
+
+    /// Creates a fresh id for tests.
+    ///
+    /// ```rust
+    /// use taskvisor::TaskId;
+    ///
+    /// let a = TaskId::for_tests();
+    /// let b = TaskId::for_tests();
+    /// assert_ne!(a, b);
+    /// ```
+    #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+    #[must_use]
+    pub fn for_tests() -> Self {
+        Self::next()
+    }
 }
 
 impl std::fmt::Display for TaskId {
@@ -82,5 +98,16 @@ mod tests {
     #[test]
     fn never_mints_zero() {
         assert!(TaskId::next().get() >= 1);
+    }
+
+    #[cfg(feature = "test-util")]
+    #[test]
+    fn for_tests_draws_from_the_runtime_sequence() {
+        let runtime = TaskId::next();
+        let test = TaskId::for_tests();
+        let runtime_after = TaskId::next();
+
+        assert!(test.get() > runtime.get(), "test ids share the sequence");
+        assert!(runtime_after.get() > test.get(), "no collision is possible");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,10 @@
 //! ## Optional Features
 //!
 //! - `tokio-util-interop`: exposes raw `tokio_util::sync::CancellationToken` interop through [`TaskContext`] and the prelude.
-//! - `controller`: slot-based admission control with `ControllerSpec`, `AdmissionPolicy`, and `ControllerConfig`.
-//! - `tracing`: built-in `TracingBridge` subscriber that forwards runtime events to the `tracing` ecosystem.
-//! - `logging`: built-in `LogWriter` subscriber for examples and simple logs (dev, preview only).
+//! - `controller`:         slot-based admission control with `ControllerSpec`, `AdmissionPolicy`, and `ControllerConfig`.
+//! - `tracing`:            built-in `TracingBridge` subscriber that forwards runtime events to the `tracing` ecosystem.
+//! - `logging`:            built-in `LogWriter` subscriber for examples and simple logs (dev, preview only).
+//! - `test-util`:          test helpers ([`TaskContext::detached`], [`TaskId::for_tests`], `TaskOutcome::*_for_tests`).
 //!
 //! ## Quick Start
 //!
@@ -123,6 +124,8 @@ pub mod prelude;
 
 pub mod identity;
 pub use identity::TaskId;
+
+pub mod reasons;
 
 pub mod core;
 pub use core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! - `controller`:         slot-based admission control with `ControllerSpec`, `AdmissionPolicy`, and `ControllerConfig`.
 //! - `tracing`:            built-in `TracingBridge` subscriber that forwards runtime events to the `tracing` ecosystem.
 //! - `logging`:            built-in `LogWriter` subscriber for examples and simple logs (dev, preview only).
-//! - `test-util`:          test helpers ([`TaskContext::detached`], [`TaskId::for_tests`], `TaskOutcome::*_for_tests`).
+//! - `test-util`:          test helpers (`TaskContext::detached()`, `TaskId::for_tests()`, `TaskOutcome::*_for_tests`).
 //!
 //! ## Quick Start
 //!

--- a/src/reasons.rs
+++ b/src/reasons.rs
@@ -1,0 +1,70 @@
+//! # Stable `reason` strings.
+//!
+//! Some events and outcomes have a `reason` string.
+//! This module lists the stable strings.
+//!
+//! ## Where each value appears
+//!
+//! | Constant                     | Used by                                                | Meaning                                |
+//! |------------------------------|--------------------------------------------------------|----------------------------------------|
+//! | [`POLICY_EXHAUSTED_SUCCESS`] | `ActorExhausted`                                       | Normal one-shot finish.                |
+//! | [`TASK_RETURNED_CANCELED`]   | `ActorExhausted`                                       | The task stopped itself.               |
+//! | [`MAX_RETRIES_EXCEEDED`]     | `ActorExhausted` (prefix)                              | Retry limit reached.                   |
+//! | [`ALREADY_EXISTS`]           | `TaskAddFailed`, `TaskOutcome::Rejected`               | A task with this name already exists.  |
+//! | [`QUEUE_FULL`]               | `ControllerRejected`, `TaskOutcome::Rejected` (prefix) | The slot queue is full.                |
+//! | [`REMOVED_FROM_QUEUE`]       | `ControllerRejected`, `TaskOutcome::Rejected`          | A queued task was removed.             |
+//! | [`SUPERSEDED_BY_REPLACE`]    | `ControllerRejected`, `TaskOutcome::Rejected`          | A newer `Replace` task took its place. |
+//! | [`CONTROLLER_SHUTTING_DOWN`] | `ControllerRejected`, `TaskOutcome::Rejected`          | The controller is shutting down.       |
+//!
+//! Controller rejection values are used only with the `controller` feature.
+//! The constants themselves are always available.
+
+/// `ActorExhausted` reason: the task finished successfully under a `Never`/`OnFailure` policy.
+/// This is not an error.
+pub const POLICY_EXHAUSTED_SUCCESS: &str = "policy_exhausted_success";
+
+/// `ActorExhausted` reason:
+/// the task body returned [`TaskError::Canceled`](crate::TaskError::Canceled), but the runtime did not cancel it.
+/// This is not an error.
+pub const TASK_RETURNED_CANCELED: &str = "task_returned_canceled";
+
+/// `ActorExhausted` reason **prefix**: the task stopped after it used all retry attempts.
+///
+/// The full reason is `max_retries_exceeded(<attempt>/<limit>): <last error>`.
+/// Match with `starts_with`, not equality.
+pub const MAX_RETRIES_EXCEEDED: &str = "max_retries_exceeded";
+
+/// Registration/rejection reason: another running task already uses this name.
+pub const ALREADY_EXISTS: &str = "already_exists";
+
+/// Rejection reason **prefix**: a controller slot queue is full.
+///
+/// The full reason is `queue_full: <depth>/<limit>`.
+/// Match with `starts_with`, not equality.
+pub const QUEUE_FULL: &str = "queue_full";
+
+/// Rejection reason: a queued task was removed before it started.
+pub const REMOVED_FROM_QUEUE: &str = "removed_from_queue";
+
+/// Rejection reason: a newer `Replace` task took this task's place.
+pub const SUPERSEDED_BY_REPLACE: &str = "superseded_by_replace";
+
+/// Rejection reason: the controller is shutting down.
+pub const CONTROLLER_SHUTTING_DOWN: &str = "controller_shutting_down";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reason_values_are_pinned() {
+        assert_eq!(POLICY_EXHAUSTED_SUCCESS, "policy_exhausted_success");
+        assert_eq!(TASK_RETURNED_CANCELED, "task_returned_canceled");
+        assert_eq!(MAX_RETRIES_EXCEEDED, "max_retries_exceeded");
+        assert_eq!(ALREADY_EXISTS, "already_exists");
+        assert_eq!(QUEUE_FULL, "queue_full");
+        assert_eq!(REMOVED_FROM_QUEUE, "removed_from_queue");
+        assert_eq!(SUPERSEDED_BY_REPLACE, "superseded_by_replace");
+        assert_eq!(CONTROLLER_SHUTTING_DOWN, "controller_shutting_down");
+    }
+}

--- a/src/subscribers/embedded/tracing.rs
+++ b/src/subscribers/embedded/tracing.rs
@@ -22,7 +22,8 @@
 
 use tracing::Level;
 
-use crate::events::{BackoffSource, Event, EventKind, REASON_MAX_RETRIES_EXCEEDED};
+use crate::events::{BackoffSource, Event, EventKind};
+use crate::reasons::MAX_RETRIES_EXCEEDED;
 use crate::subscribers::Subscribe;
 
 /// Subscriber that forwards runtime events to [`tracing`].
@@ -53,12 +54,11 @@ fn level_for(e: &Event) -> Level {
         | EventKind::SubscriberOverflow
         | EventKind::TaskAddFailed => Level::WARN,
 
-        // A task that gave up after its retry budget is a terminal failure signal.
         EventKind::ActorExhausted => {
             let gave_up = e
                 .reason
                 .as_deref()
-                .is_some_and(|r| r.starts_with(REASON_MAX_RETRIES_EXCEEDED));
+                .is_some_and(|r| r.starts_with(MAX_RETRIES_EXCEEDED));
             if gave_up { Level::WARN } else { Level::INFO }
         }
 

--- a/src/tasks/context.rs
+++ b/src/tasks/context.rs
@@ -27,6 +27,45 @@ impl TaskContext {
         Self { cancel }
     }
 
+    /// A task context that is not connected to a supervisor.
+    ///
+    /// It starts active. Use it in tests when you want to call [`Task::spawn`](crate::Task::spawn)
+    /// or any function that takes a [`TaskContext`] without starting a supervisor.
+    ///
+    /// ```rust
+    /// use taskvisor::TaskContext;
+    ///
+    /// let ctx = TaskContext::detached();
+    /// assert!(!ctx.is_cancelled());
+    /// ```
+    #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+    #[must_use]
+    pub fn detached() -> Self {
+        Self::from_token(CancellationToken::new())
+    }
+
+    /// A task context that is already cancelled.
+    ///
+    /// Use it in tests to check cancellation code:
+    /// [`run_until_cancelled`](Self::run_until_cancelled) returns
+    /// [`Err(TaskError::Canceled)`](TaskError::Canceled) without polling the future.
+    ///
+    /// ```rust
+    /// use taskvisor::TaskContext;
+    ///
+    /// let ctx = TaskContext::detached_cancelled();
+    /// assert!(ctx.is_cancelled());
+    /// ```
+    #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+    #[must_use]
+    pub fn detached_cancelled() -> Self {
+        let token = CancellationToken::new();
+        token.cancel();
+        Self::from_token(token)
+    }
+
     /// Waits until the context is cancelled.
     ///
     /// Resolves immediately if the context is already cancelled.
@@ -110,6 +149,29 @@ mod tests {
     };
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test]
+    async fn detached_context_starts_active() {
+        let ctx = TaskContext::detached();
+
+        assert!(!ctx.is_cancelled());
+        let out = ctx.run_until_cancelled(async { 7 }).await;
+        assert_eq!(out.expect("detached context starts active"), 7);
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test]
+    async fn detached_cancelled_context_short_circuits() {
+        let ctx = TaskContext::detached_cancelled();
+
+        assert!(ctx.is_cancelled());
+        let out = ctx.run_until_cancelled(async { 7 }).await;
+        assert!(
+            matches!(out, Err(TaskError::Canceled)),
+            "an already-cancelled context must win the race"
+        );
+    }
 
     #[tokio::test]
     async fn run_until_cancelled_returns_output_when_future_completes_first() {


### PR DESCRIPTION
## 📝 Description

Adds stable `reasons::*` constants for event and outcome reasons, and uses them internally instead of hard-coded strings. Also adds a small `test-util` feature with helpers for testing crates that build on taskvisor.

## 🔄 Related Issues
Resolves #108

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] `task ci` passes locally

## Example
```rust
use taskvisor::{reasons, TaskContext, TaskId, TaskOutcome};

let ctx = TaskContext::detached();
let id = TaskId::for_tests();

let outcome = TaskOutcome::failed_for_tests(reasons::MAX_RETRIES_EXCEEDED, None);
assert!(!outcome.is_success());
```