### PR TITLE
[fix] Controller lag recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ criterion          = { version = "0.8.2", features = ["async_tokio"] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 prometheus         = { version = "0.14.0", default-features = false }
 rayon              = "1.12.0"
+tokio              = { version = "1.52.3", features = ["test-util"] }
 
 [[example]]
 name              = "slots"

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -37,11 +37,11 @@
 use std::{
     future::Future,
     sync::{Arc, Weak},
-    time::Instant,
 };
 
 use dashmap::DashMap;
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use tokio::sync::broadcast;
@@ -64,6 +64,19 @@ use super::{
 mod introspect;
 mod recovery;
 mod shutdown;
+
+/// Keeps the earliest pending controller-recovery deadline.
+///
+/// Returns the new deadline when the timer must be reset.
+fn schedule_recovery(recovery_at: &mut Option<Instant>, candidate: Instant) -> Option<Instant> {
+    match recovery_at {
+        Some(current) if *current <= candidate => None,
+        _ => {
+            *recovery_at = Some(candidate);
+            Some(candidate)
+        }
+    }
+}
 
 /// Submission accepted by the controller intake channel.
 struct Submission {
@@ -250,20 +263,52 @@ impl Controller {
             .ok_or(ControllerError::AlreadyStarted)?;
 
         let mut bus_rx = self.bus.subscribe();
+        let mut recovery_at = None;
+        let recovery_timer = tokio::time::sleep(recovery::RECOVERY_DELAY);
+        tokio::pin!(recovery_timer);
         loop {
             tokio::select! {
                 _ = token.cancelled() => break,
 
+                _ = &mut recovery_timer, if recovery_at.is_some() => {
+                    recovery_at = None;
+                    if !self.is_shutting_down()
+                        && let Some(next_recovery) = self
+                            .guarded("recover_stale_slots", self.recover_stale_slots())
+                            .await
+                            .flatten()
+                        && let Some(deadline) = schedule_recovery(
+                            &mut recovery_at,
+                            next_recovery,
+                        )
+                    {
+                        recovery_timer.as_mut().reset(deadline);
+                    }
+                }
+
                 Some(sub) = rx.recv() => {
-                    self.guarded("handle_submission", self.handle_submission(sub)).await;
+                    let _ = self.guarded("handle_submission", self.handle_submission(sub)).await;
                 }
                 result = bus_rx.recv() => {
                     match result {
                         Ok(event) => {
-                            self.guarded("handle_event", self.handle_event(event)).await;
+                            let shutdown_requested = event.kind == EventKind::ShutdownRequested;
+                            let _ = self.guarded("handle_event", self.handle_event(event)).await;
+                            if shutdown_requested {
+                                recovery_at = None;
+                            }
                         }
                         Err(broadcast::error::RecvError::Lagged(_)) => {
-                            self.guarded("recover_stale_slots", self.recover_stale_slots()).await;
+                            if !self.is_shutting_down() {
+                                // Recovery may publish lifecycle events itself. Delay and coalesce
+                                // it so those events cannot start an immediate lag/recovery loop.
+                                if let Some(deadline) = schedule_recovery(
+                                    &mut recovery_at,
+                                    Instant::now() + recovery::RECOVERY_DELAY,
+                                ) {
+                                    recovery_timer.as_mut().reset(deadline);
+                                }
+                            }
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                     }
@@ -280,13 +325,18 @@ impl Controller {
     ///
     /// This guard does not repair partially updated slot state by itself.
     /// Callers that park watcher state must still make sure the watcher is resolved or returned on every failure path.
-    async fn guarded(&self, who: &'static str, fut: impl Future<Output = ()>) {
-        if let Err(msg) = crate::core::panic_guard::guarded(fut).await {
-            self.bus.publish(
-                Event::new(EventKind::ControllerRejected)
-                    .with_task("controller")
-                    .with_reason(format!("{who}_panicked: {msg}")),
-            );
+    /// Returns the work-unit output on success and `None` after a caught panic.
+    async fn guarded<T>(&self, who: &'static str, fut: impl Future<Output = T>) -> Option<T> {
+        match crate::core::panic_guard::guarded(fut).await {
+            Ok(output) => Some(output),
+            Err(msg) => {
+                self.bus.publish(
+                    Event::new(EventKind::ControllerRejected)
+                        .with_task("controller")
+                        .with_reason(format!("{who}_panicked: {msg}")),
+                );
+                None
+            }
         }
     }
 
@@ -967,7 +1017,7 @@ mod tests {
         let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
         let mut rx = ctrl.bus.subscribe();
 
-        ctrl.guarded("unit", async { panic!("boom {}", 1) }).await;
+        let _ = ctrl.guarded("unit", async { panic!("boom {}", 1) }).await;
 
         let ev = rx
             .try_recv()
@@ -1005,27 +1055,42 @@ mod tests {
             .expect("test host uptime must exceed one minute")
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn lag_recovery_keeps_retained_task_added_event() {
-        let bus = Bus::new(1);
-        let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
-        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), bus.clone());
-
-        let id = TaskId::next();
-        let slot_name: Arc<str> = Arc::from("s");
+    fn insert_admitting_slot(
+        ctrl: &Controller,
+        name: &str,
+        id: TaskId,
+        since: Instant,
+    ) -> Arc<Mutex<SlotState>> {
+        let slot_name: Arc<str> = Arc::from(name);
         let slot = Arc::new(Mutex::new(SlotState {
-            status: SlotStatus::Admitting {
-                since: Instant::now(),
-            },
+            status: SlotStatus::Admitting { since },
             running_id: Some(id),
             queue: std::collections::VecDeque::new(),
         }));
         ctrl.slots.insert(Arc::clone(&slot_name), Arc::clone(&slot));
-        ctrl.running.insert(id, Arc::clone(&slot_name));
+        ctrl.running.insert(id, slot_name);
+        slot
+    }
 
-        let runtime_token = CancellationToken::new();
-        let runner_ctrl = Arc::clone(&ctrl);
-        let runner_token = runtime_token.clone();
+    async fn wait_for_slot_status(
+        slot: &Arc<Mutex<SlotState>>,
+        expected: impl Fn(SlotStatus) -> bool,
+    ) -> bool {
+        for _ in 0..100 {
+            if expected(slot.lock().await.status) {
+                return true;
+            }
+            tokio::task::yield_now().await;
+        }
+        false
+    }
+
+    async fn start_controller_loop(
+        ctrl: &Arc<Controller>,
+        token: &CancellationToken,
+    ) -> tokio::task::JoinHandle<Result<(), ControllerError>> {
+        let runner_ctrl = Arc::clone(ctrl);
+        let runner_token = token.clone();
         let runner = tokio::spawn(async move { runner_ctrl.run_inner(runner_token).await });
 
         tokio::time::timeout(Duration::from_secs(1), async {
@@ -1038,30 +1103,159 @@ mod tests {
         })
         .await
         .expect("controller loop must take its receiver and subscribe to the bus");
+        runner
+    }
 
-        bus.publish(Event::new(EventKind::TaskStarting).with_task("lag-seed"));
-        bus.publish(
-            Event::new(EventKind::TaskAdded)
-                .with_task(Arc::clone(&slot_name))
-                .with_id(id),
-        );
-
-        let reached_running = poll_until(Duration::from_millis(250), || {
-            let slot = Arc::clone(&slot);
-            async move { matches!(slot.lock().await.status, SlotStatus::Running { .. }) }
-        })
-        .await;
-
-        runtime_token.cancel();
+    async fn stop_controller_loop(
+        token: CancellationToken,
+        runner: tokio::task::JoinHandle<Result<(), ControllerError>>,
+    ) {
+        token.cancel();
         tokio::time::timeout(Duration::from_secs(1), runner)
             .await
             .expect("controller loop must stop after cancellation")
             .expect("controller loop task must not panic")
             .expect("controller loop must exit cleanly");
+    }
+
+    async fn induce_lag_with_task_added(
+        bus: &Bus,
+        tail_name: &str,
+        tail_id: TaskId,
+        tail_slot: &Arc<Mutex<SlotState>>,
+    ) -> bool {
+        bus.publish(Event::new(EventKind::TaskStarting).with_task("lag-seed"));
+        bus.publish(
+            Event::new(EventKind::TaskAdded)
+                .with_task(tail_name.to_owned())
+                .with_id(tail_id),
+        );
+        wait_for_slot_status(tail_slot, |status| {
+            matches!(status, SlotStatus::Running { .. })
+        })
+        .await
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn lag_recovery_keeps_retained_task_added_event() {
+        let bus = Bus::new(1);
+        let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), bus.clone());
+
+        let id = TaskId::next();
+        let slot = insert_admitting_slot(&ctrl, "s", id, Instant::now());
+        let token = CancellationToken::new();
+        let runner = start_controller_loop(&ctrl, &token).await;
+
+        let reached_running = induce_lag_with_task_added(&bus, "s", id, &slot).await;
+        stop_controller_loop(token, runner).await;
 
         assert!(
             reached_running,
             "lag recovery must preserve and process the retained TaskAdded event"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn repeated_lag_keeps_first_deadline_and_rearms_young_slots() {
+        let bus = Bus::new(1);
+        let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), bus.clone());
+
+        let first = insert_admitting_slot(&ctrl, "first", TaskId::next(), Instant::now());
+        let first_tail_id = TaskId::next();
+        let first_tail = insert_admitting_slot(&ctrl, "first-tail", first_tail_id, Instant::now());
+        let token = CancellationToken::new();
+        let runner = start_controller_loop(&ctrl, &token).await;
+
+        assert!(
+            induce_lag_with_task_added(&bus, "first-tail", first_tail_id, &first_tail).await,
+            "first retained event must be processed"
+        );
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(
+            matches!(first.lock().await.status, SlotStatus::Admitting { .. }),
+            "recovery must not run before the safety delay"
+        );
+
+        let stale_since = Instant::now()
+            .checked_sub(recovery::RECOVERY_DELAY)
+            .expect("paused clock must support a five-second lookback");
+        let second = insert_admitting_slot(&ctrl, "second", TaskId::next(), stale_since);
+        let late = insert_admitting_slot(&ctrl, "late", TaskId::next(), Instant::now());
+        let second_tail_id = TaskId::next();
+        let second_tail =
+            insert_admitting_slot(&ctrl, "second-tail", second_tail_id, Instant::now());
+
+        assert!(
+            induce_lag_with_task_added(&bus, "second-tail", second_tail_id, &second_tail).await,
+            "second retained event must be processed"
+        );
+        assert!(
+            matches!(second.lock().await.status, SlotStatus::Admitting { .. }),
+            "repeated lag must not run stale-slot recovery immediately"
+        );
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(
+            wait_for_slot_status(&first, |status| matches!(status, SlotStatus::Idle)).await
+                && wait_for_slot_status(&second, |status| matches!(status, SlotStatus::Idle)).await,
+            "repeated lag must keep the first recovery deadline"
+        );
+        assert!(
+            matches!(late.lock().await.status, SlotStatus::Admitting { .. }),
+            "a newer slot must not be recovered before its safety delay"
+        );
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(
+            wait_for_slot_status(&late, |status| matches!(status, SlotStatus::Idle)).await,
+            "a newer slot must schedule its own delayed recovery"
+        );
+        stop_controller_loop(token, runner).await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn shutdown_request_cancels_pending_lag_recovery() {
+        let bus = Bus::new(1);
+        let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), bus.clone());
+
+        let target = insert_admitting_slot(&ctrl, "target", TaskId::next(), Instant::now());
+        let tail_id = TaskId::next();
+        let tail = insert_admitting_slot(&ctrl, "tail", tail_id, Instant::now());
+        let token = CancellationToken::new();
+        let runner = start_controller_loop(&ctrl, &token).await;
+
+        assert!(
+            induce_lag_with_task_added(&bus, "tail", tail_id, &tail).await,
+            "retained event must confirm that lag was handled"
+        );
+        bus.publish(Event::new(EventKind::ShutdownRequested));
+
+        let mut shutdown_observed = false;
+        for _ in 0..100 {
+            if ctrl.is_shutting_down() {
+                shutdown_observed = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(recovery::RECOVERY_DELAY + Duration::from_secs(1)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        let target_unchanged = matches!(target.lock().await.status, SlotStatus::Admitting { .. });
+
+        stop_controller_loop(token, runner).await;
+        assert!(
+            shutdown_observed,
+            "controller must observe shutdown request"
+        );
+        assert!(
+            target_unchanged,
+            "pending recovery must not run after shutdown is requested"
         );
     }
 
@@ -1094,7 +1288,7 @@ mod tests {
         );
         ctrl.running.insert(id, Arc::from("s"));
 
-        ctrl.recover_stale_slots().await;
+        let _ = ctrl.recover_stale_slots().await;
 
         let slot_arc = ctrl.slots.get("s").map(|e| e.clone()).expect("slot exists");
         let slot = slot_arc.lock().await;
@@ -1125,7 +1319,7 @@ mod tests {
         );
         ctrl.running.insert(id, Arc::from("s"));
 
-        ctrl.recover_stale_slots().await;
+        let _ = ctrl.recover_stale_slots().await;
 
         let removed = poll_until(Duration::from_secs(2), || async {
             !sup.core().contains_id(id).await

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -262,12 +262,7 @@ impl Controller {
                         Ok(event) => {
                             self.guarded("handle_event", self.handle_event(event)).await;
                         }
-                        Err(broadcast::error::RecvError::Lagged(n)) => {
-                            self.bus.publish(
-                                Event::new(EventKind::ControllerRejected)
-                                    .with_task("controller")
-                                    .with_reason(format!("bus_lagged: missed {n} events, recovering slots")),
-                            );
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
                             self.guarded("recover_stale_slots", self.recover_stale_slots()).await;
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
@@ -1008,6 +1003,66 @@ mod tests {
         Instant::now()
             .checked_sub(Duration::from_secs(60))
             .expect("test host uptime must exceed one minute")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn lag_recovery_keeps_retained_task_added_event() {
+        let bus = Bus::new(1);
+        let sup = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+        let ctrl = Controller::new(ControllerConfig::default(), sup.core(), bus.clone());
+
+        let id = TaskId::next();
+        let slot_name: Arc<str> = Arc::from("s");
+        let slot = Arc::new(Mutex::new(SlotState {
+            status: SlotStatus::Admitting {
+                since: Instant::now(),
+            },
+            running_id: Some(id),
+            queue: std::collections::VecDeque::new(),
+        }));
+        ctrl.slots.insert(Arc::clone(&slot_name), Arc::clone(&slot));
+        ctrl.running.insert(id, Arc::clone(&slot_name));
+
+        let runtime_token = CancellationToken::new();
+        let runner_ctrl = Arc::clone(&ctrl);
+        let runner_token = runtime_token.clone();
+        let runner = tokio::spawn(async move { runner_ctrl.run_inner(runner_token).await });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if ctrl.rx.read().await.is_none() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("controller loop must take its receiver and subscribe to the bus");
+
+        bus.publish(Event::new(EventKind::TaskStarting).with_task("lag-seed"));
+        bus.publish(
+            Event::new(EventKind::TaskAdded)
+                .with_task(Arc::clone(&slot_name))
+                .with_id(id),
+        );
+
+        let reached_running = poll_until(Duration::from_millis(250), || {
+            let slot = Arc::clone(&slot);
+            async move { matches!(slot.lock().await.status, SlotStatus::Running { .. }) }
+        })
+        .await;
+
+        runtime_token.cancel();
+        tokio::time::timeout(Duration::from_secs(1), runner)
+            .await
+            .expect("controller loop must stop after cancellation")
+            .expect("controller loop task must not panic")
+            .expect("controller loop must exit cleanly");
+
+        assert!(
+            reached_running,
+            "lag recovery must preserve and process the retained TaskAdded event"
+        );
     }
 
     async fn sup_with_live_task() -> (Arc<Supervisor>, crate::core::SupervisorHandle, TaskId) {

--- a/src/controller/core/recovery.rs
+++ b/src/controller/core/recovery.rs
@@ -8,23 +8,34 @@
 //! The bus is lossy.
 //! If the controller listener lags, one of those events may be missed.
 //! This module performs a conservative reconciliation pass against the runtime registry.
+//!
+//! Recovery is delayed and coalesced by the controller loop.
+//! This gives retained events time to drain and prevents events emitted during recovery from creating an immediate feedback loop.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use tokio::time::Instant;
 
 use crate::controller::slot::SlotStatus;
 use crate::events::{Event, EventKind};
 
-use super::Controller;
+use super::{Controller, schedule_recovery};
+
+/// Delay before controller state is reconciled after event-bus lag.
+pub(super) const RECOVERY_DELAY: Duration = Duration::from_secs(5);
 
 impl Controller {
     /// Reconciles stale non-idle slots after the controller misses bus events.
-    pub(super) async fn recover_stale_slots(&self) {
-        const RECOVERY_DEADLINE: Duration = Duration::from_secs(5);
+    ///
+    /// Returns the earliest deadline for a slot that is still too young to reconcile.
+    pub(super) async fn recover_stale_slots(&self) -> Option<Instant> {
+        if self.is_shutting_down() {
+            return None;
+        }
 
-        let Some(sup) = self.supervisor.upgrade() else {
-            return;
-        };
+        let sup = self.supervisor.upgrade()?;
+        let mut next_recovery = None;
 
         let slot_keys: Vec<Arc<str>> = self
             .slots
@@ -42,14 +53,16 @@ impl Controller {
                 continue;
             }
 
-            match slot.status {
-                SlotStatus::Admitting { since } if since.elapsed() < RECOVERY_DEADLINE => continue,
-                SlotStatus::Terminating { cancelled_at }
-                    if cancelled_at.elapsed() < RECOVERY_DEADLINE =>
-                {
-                    continue;
-                }
-                _ => {}
+            let eligible_at = match slot.status {
+                SlotStatus::Admitting { since } => Some(since + RECOVERY_DELAY),
+                SlotStatus::Terminating { cancelled_at } => Some(cancelled_at + RECOVERY_DELAY),
+                _ => None,
+            };
+            if let Some(eligible_at) = eligible_at
+                && eligible_at > Instant::now()
+            {
+                let _ = schedule_recovery(&mut next_recovery, eligible_at);
+                continue;
             }
 
             let alive = match slot.running_id {
@@ -96,5 +109,7 @@ impl Controller {
 
             self.gc_if_idle(&slot_name, slot);
         }
+
+        next_recovery
     }
 }

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -6,7 +6,9 @@
 //! This module only stores slot state.
 //! The transition logic lives in `controller::core`.
 
-use std::{collections::VecDeque, time::Instant};
+use std::collections::VecDeque;
+
+use tokio::time::Instant;
 
 use crate::TaskSpec;
 use crate::identity::TaskId;


### PR DESCRIPTION
## 📝 Description
The controller no longer runs recovery directly from the Lagged branch. 
Lag starts one five-second recovery timer. 
Repeated lag keeps the earliest deadline.

Recovery can schedule another retry for slots that are still too young. 
Pending recovery is cancelled during shutdown.

## 🔄 Related Issues
Resolves #112 

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] `task ci` passes locally
