### PR TITLE
[core] Bound the registry command queue

### DIFF
--- a/benches/dynamic.rs
+++ b/benches/dynamic.rs
@@ -81,7 +81,10 @@ fn bench_add(c: &mut Criterion) {
             b.iter_custom(|iters| {
                 let rt = rt_fn();
                 rt.block_on(async {
-                    let sup = Supervisor::new(bench_config(), vec![]);
+                    let mut cfg = bench_config();
+                    cfg.registry_queue_capacity =
+                        usize::try_from(iters).unwrap_or(usize::MAX).max(1);
+                    let sup = Supervisor::new(cfg, vec![]);
                     let handle = sup.serve();
 
                     let mut total = Duration::ZERO;

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -141,6 +141,15 @@ impl SupervisorBuilder {
         self
     }
 
+    /// Builder: sets the registry management command queue capacity.
+    ///
+    /// The effective capacity is at least `1`.
+    /// Sync management methods fail fast when the queue is full.
+    pub fn with_registry_queue_capacity(mut self, registry_queue_capacity: usize) -> Self {
+        self.cfg.registry_queue_capacity = registry_queue_capacity;
+        self
+    }
+
     /// Builder: sets the default restart policy for tasks created through [`SupervisorConfig::task_spec`].
     ///
     /// Restart controls whether a task runs again after it exits.
@@ -200,7 +209,7 @@ impl SupervisorBuilder {
             .max_concurrent
             .map(|n| Arc::new(sync::Semaphore::new(n.get())));
 
-        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(self.cfg.registry_queue_capacity_clamped());
         let registry = Registry::new(
             bus.clone(),
             runtime_token.clone(),
@@ -257,6 +266,7 @@ mod tests {
             .with_max_retries(10)
             .with_max_concurrent(4)
             .with_bus_capacity(2048)
+            .with_registry_queue_capacity(256)
             .with_restart(RestartPolicy::Never)
             .with_backoff(backoff);
 
@@ -266,6 +276,7 @@ mod tests {
         assert_eq!(b.cfg.max_retries.map(|n| n.get()), Some(10));
         assert_eq!(b.cfg.max_concurrent.map(|n| n.get()), Some(4));
         assert_eq!(b.cfg.bus_capacity, 2048);
+        assert_eq!(b.cfg.registry_queue_capacity, 256);
         assert!(
             matches!(b.cfg.restart, RestartPolicy::Never),
             "with_restart must store the given policy"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -14,8 +14,8 @@
 //!
 //! ## Normalized Fields
 //!
-//! `bus_capacity` is normalized with [`bus_capacity_clamped`](SupervisorConfig::bus_capacity_clamped) before the event bus is created.
-//! This keeps the broadcast channel capacity at least `1`.
+//! `bus_capacity` and `registry_queue_capacity` are normalized to at least `1`
+//! before their channels are created.
 
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::time::Duration;
@@ -55,6 +55,16 @@ pub struct SupervisorConfig {
     /// Use [`bus_capacity_clamped`](Self::bus_capacity_clamped) when creating the bus; the effective capacity is at least `1`.
     pub bus_capacity: usize,
 
+    /// Capacity of the registry management command queue.
+    ///
+    /// This bounds pending add and remove commands.
+    /// The registry may process one additional command while this many commands are buffered.
+    ///
+    /// Sync management methods fail with [`RuntimeError::CommandQueueFull`](crate::RuntimeError::CommandQueueFull) when the queue has no capacity.
+    ///
+    /// Use [`registry_queue_capacity_clamped`](Self::registry_queue_capacity_clamped) when creating the queue; the effective capacity is at least `1`.
+    pub registry_queue_capacity: usize,
+
     /// Default restart policy for tasks created with [`task_spec`](Self::task_spec).
     ///
     /// Individual [`TaskSpec`] values may override this.
@@ -93,6 +103,15 @@ impl SupervisorConfig {
         self.bus_capacity.max(1)
     }
 
+    /// Returns the effective registry command queue capacity.
+    ///
+    /// The returned value is always at least `1`.
+    #[inline]
+    #[must_use]
+    pub fn registry_queue_capacity_clamped(&self) -> usize {
+        self.registry_queue_capacity.max(1)
+    }
+
     /// Builds a [`TaskSpec`] that inherits this config's task defaults.
     ///
     /// The created spec receives:
@@ -127,6 +146,7 @@ impl Default for SupervisorConfig {
     /// - `grace = 60s`
     /// - `max_concurrent = None`
     /// - `bus_capacity = 1024`
+    /// - `registry_queue_capacity = 1024`
     /// - `restart = RestartPolicy::OnFailure`
     /// - `backoff = BackoffPolicy::default()`
     /// - `timeout = None`
@@ -136,6 +156,7 @@ impl Default for SupervisorConfig {
             grace: Duration::from_secs(60),
             max_concurrent: None,
             bus_capacity: 1024,
+            registry_queue_capacity: 1024,
             timeout: None,
             restart: RestartPolicy::default(),
             backoff: BackoffPolicy::default(),
@@ -153,6 +174,7 @@ mod tests {
         let cfg = SupervisorConfig::default();
         assert_eq!(cfg.max_concurrent, None, "default is unlimited concurrency");
         assert_eq!(cfg.timeout, None, "default has no per-task timeout");
+        assert_eq!(cfg.registry_queue_capacity, 1024);
     }
 
     #[test]
@@ -175,6 +197,15 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(cfg.bus_capacity_clamped(), 1);
+    }
+
+    #[test]
+    fn registry_queue_capacity_clamped_never_zero() {
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 0,
+            ..Default::default()
+        };
+        assert_eq!(cfg.registry_queue_capacity_clamped(), 1);
     }
 
     #[test]

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -96,7 +96,7 @@ impl SupervisorHandle {
     /// Adds a task to the supervisor at runtime.
     ///
     /// This is fire-and-forget.
-    /// It mints a [`TaskId`], publishes `TaskAddRequested`, sends an `Add` command to the registry, and returns the id as soon as the command is queued.
+    /// It mints a [`TaskId`], reserves command queue capacity, publishes `TaskAddRequested`, queues an `Add` command, and returns the id.
     ///
     /// `Ok(id)` means the add command was accepted by the runtime command channel.
     /// It does not mean the registry has accepted the task yet.
@@ -105,6 +105,7 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub fn add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
         self.core.add_task(spec)
@@ -119,6 +120,7 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     /// - [`RuntimeError::TaskAlreadyExists`] when the task name is already in use.
     /// - [`RuntimeError::TaskAddTimeout`] when no confirmation arrives in time.
@@ -142,6 +144,7 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     /// - [`RuntimeError::TaskAlreadyExists`] when the task name is already in use.
     /// - [`RuntimeError::TaskAddTimeout`] when no confirmation arrives in time.
@@ -232,7 +235,7 @@ impl SupervisorHandle {
     /// Removes a task by identity.
     ///
     /// This is fire-and-forget.
-    /// It publishes `TaskRemoveRequested`, sends a remove command to the registry, and returns when the command is queued.
+    /// It reserves command queue capacity, publishes `TaskRemoveRequested`, queues a remove command, and returns.
     ///
     /// `Ok(())` does not mean the task existed or has already stopped.
     /// Unknown ids are handled by the registry as no-op removals.
@@ -241,6 +244,7 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
         self.core.remove(id)
@@ -253,6 +257,7 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub async fn remove_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
         match self.core.id_for_label(name).await {
@@ -305,6 +310,7 @@ impl SupervisorHandle {
     /// # Errors
     ///
     /// - [`RuntimeError::TaskRemoveTimeout`] when removal was not confirmed in time.
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
         self.core.cancel(id).await
@@ -336,6 +342,7 @@ impl SupervisorHandle {
     /// # Errors
     ///
     /// - [`RuntimeError::TaskRemoveTimeout`] when confirmation does not arrive in time.
+    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub async fn cancel_with_timeout(
         &self,

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -14,7 +14,7 @@
 //! Management plane:
 //!   SupervisorCore                 Registry
 //!        |                            |
-//!        |-- command (mpsc) --------->|
+//!        |-- command (bounded mpsc) ->|
 //!        |                            |-- update registry state
 //!        |<-- reply (oneshot) --------|
 //!
@@ -256,7 +256,7 @@ pub(crate) struct Registry {
     semaphore: Option<Arc<Semaphore>>,
     grace: Duration,
     empty_notify: Notify,
-    cmd_rx: std::sync::Mutex<Option<mpsc::UnboundedReceiver<RegistryCommand>>>,
+    cmd_rx: std::sync::Mutex<Option<mpsc::Receiver<RegistryCommand>>>,
     completion_tx: mpsc::UnboundedSender<TaskId>,
     completion_rx: std::sync::Mutex<Option<mpsc::UnboundedReceiver<TaskId>>>,
     pending_joins: Arc<PendingJoins>,
@@ -270,7 +270,7 @@ impl Registry {
         runtime_token: CancellationToken,
         semaphore: Option<Arc<Semaphore>>,
         grace: Duration,
-        cmd_rx: mpsc::UnboundedReceiver<RegistryCommand>,
+        cmd_rx: mpsc::Receiver<RegistryCommand>,
     ) -> Arc<Self> {
         let (completion_tx, completion_rx) = mpsc::unbounded_channel();
         Arc::new(Self {
@@ -803,7 +803,7 @@ mod tests {
     fn registry() -> Arc<Registry> {
         let bus = Bus::new(64);
         let token = CancellationToken::new();
-        let (_tx, rx) = mpsc::unbounded_channel();
+        let (_tx, rx) = mpsc::channel(64);
         Registry::new(bus, token, None, Duration::from_secs(5), rx)
     }
 
@@ -814,24 +814,24 @@ mod tests {
         Arc<Registry>,
         Bus,
         CancellationToken,
-        mpsc::UnboundedSender<RegistryCommand>,
+        mpsc::Sender<RegistryCommand>,
     ) {
         let bus = Bus::new(bus_capacity);
         let token = CancellationToken::new();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(64);
         let registry = Registry::new(bus.clone(), token.clone(), None, grace, rx);
         registry.clone().spawn_listener();
         (registry, bus, token, tx)
     }
 
     fn send_add(
-        tx: &mpsc::UnboundedSender<RegistryCommand>,
+        tx: &mpsc::Sender<RegistryCommand>,
         id: TaskId,
         spec: TaskSpec,
         outcome: Option<OutcomeTx>,
     ) -> AddReplyRx {
         let (reply, reply_rx) = oneshot::channel();
-        tx.send(RegistryCommand::Add {
+        tx.try_send(RegistryCommand::Add {
             id,
             spec,
             outcome,
@@ -841,9 +841,9 @@ mod tests {
         reply_rx
     }
 
-    fn send_remove(tx: &mpsc::UnboundedSender<RegistryCommand>, id: TaskId) -> RemoveReplyRx {
+    fn send_remove(tx: &mpsc::Sender<RegistryCommand>, id: TaskId) -> RemoveReplyRx {
         let (reply, reply_rx) = oneshot::channel();
-        tx.send(RegistryCommand::Remove { id, reply })
+        tx.try_send(RegistryCommand::Remove { id, reply })
             .expect("registry command channel must stay open");
         reply_rx
     }
@@ -1554,9 +1554,8 @@ mod tests {
 
         let bus = Bus::new(64);
         let token = CancellationToken::new();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1);
         let reg = Registry::new(bus, token.clone(), None, Duration::from_millis(50), rx);
-        reg.clone().spawn_listener();
 
         let task: TaskRef = TaskFn::arc("buffered", |ctx: TaskContext| async move {
             ctx.cancelled().await;
@@ -1565,7 +1564,7 @@ mod tests {
         let (done_tx, done_rx) = oneshot::channel();
         let (reply_tx, reply_rx) = oneshot::channel();
         let id = TaskId::next();
-        tx.send(RegistryCommand::Add {
+        tx.try_send(RegistryCommand::Add {
             id,
             spec: TaskSpec::restartable(task),
             outcome: Some(done_tx),
@@ -1574,6 +1573,7 @@ mod tests {
         .expect("channel is open before shutdown");
 
         token.cancel();
+        reg.clone().spawn_listener();
         tokio::time::timeout(Duration::from_secs(2), reg.join_listener())
             .await
             .expect("join_listener must not hang");
@@ -1603,7 +1603,7 @@ mod tests {
 
         let (reply, _reply_rx) = oneshot::channel();
         assert!(
-            tx.send(RegistryCommand::Remove {
+            tx.try_send(RegistryCommand::Remove {
                 id: TaskId::next(),
                 reply,
             })

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -97,7 +97,7 @@ pub(crate) struct SupervisorCore {
     started: AtomicBool,
     running: AtomicBool,
     shutting_down: AtomicBool,
-    cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
+    cmd_tx: mpsc::Sender<RegistryCommand>,
     subscriber_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
@@ -121,7 +121,7 @@ impl SupervisorCore {
         alive: Arc<AliveTracker>,
         registry: Arc<Registry>,
         runtime_token: CancellationToken,
-        cmd_tx: mpsc::UnboundedSender<RegistryCommand>,
+        cmd_tx: mpsc::Sender<RegistryCommand>,
     ) -> Arc<Self> {
         Arc::new(Self {
             cfg,
@@ -192,6 +192,7 @@ impl SupervisorCore {
 
     /// Sends the registry `Add` command and publishes `TaskAddRequested`.
     ///
+    /// Returns `CommandQueueFull` when the bounded queue has no capacity.
     /// Returns `ShuttingDown` if admission is already closed or the registry command channel is closed.
     fn add_task_inner(
         &self,
@@ -209,6 +210,8 @@ impl SupervisorCore {
     }
 
     /// Queues one add command and returns its authoritative registry reply.
+    ///
+    /// This is fail-fast while the public management API remains synchronous.
     fn enqueue_add_task(
         &self,
         id: TaskId,
@@ -218,29 +221,63 @@ impl SupervisorCore {
         if self.is_shutting_down() {
             return Err((RuntimeError::ShuttingDown, done));
         }
+        let permit = match self.cmd_tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(())) => {
+                return Err((RuntimeError::CommandQueueFull, done));
+            }
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                return Err((RuntimeError::ShuttingDown, done));
+            }
+        };
+        let label: Arc<str> = Arc::from(spec.task().name());
+        let (reply, reply_rx) = oneshot::channel();
         self.bus.publish(
             Event::new(EventKind::TaskAddRequested)
-                .with_task(spec.task().name())
+                .with_task(label)
                 .with_id(id),
         );
-        let (reply, reply_rx) = oneshot::channel();
-        match self.cmd_tx.send(RegistryCommand::Add {
+        permit.send(RegistryCommand::Add {
             id,
             spec,
             outcome: done,
             reply,
-        }) {
-            Ok(()) => Ok((id, reply_rx)),
-            Err(mpsc::error::SendError(cmd)) => {
-                let done = match cmd {
-                    RegistryCommand::Add { outcome, .. } => outcome,
-                    RegistryCommand::Remove { .. } => {
-                        unreachable!("an Add send error must return the Add command")
-                    }
-                };
-                Err((RuntimeError::ShuttingDown, done))
-            }
+        });
+        Ok((id, reply_rx))
+    }
+
+    /// Waits for bounded queue capacity, then queues one static-run add command.
+    async fn enqueue_add_task_wait(
+        &self,
+        id: TaskId,
+        spec: TaskSpec,
+        done: Option<OutcomeTx>,
+    ) -> Result<(TaskId, AddReplyRx), (RuntimeError, Option<OutcomeTx>)> {
+        if self.is_shutting_down() {
+            return Err((RuntimeError::ShuttingDown, done));
         }
+        let permit = match self.cmd_tx.reserve().await {
+            Ok(permit) => permit,
+            Err(_) => return Err((RuntimeError::ShuttingDown, done)),
+        };
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err((RuntimeError::ShuttingDown, done));
+        }
+        let label: Arc<str> = Arc::from(spec.task().name());
+        let (reply, reply_rx) = oneshot::channel();
+        self.bus.publish(
+            Event::new(EventKind::TaskAddRequested)
+                .with_task(label)
+                .with_id(id),
+        );
+        permit.send(RegistryCommand::Add {
+            id,
+            spec,
+            outcome: done,
+            reply,
+        });
+        Ok((id, reply_rx))
     }
 
     /// Queues a remove command by runtime identity.
@@ -248,19 +285,30 @@ impl SupervisorCore {
     /// This is fire-and-forget.
     /// `Ok(())` means the command was sent, not that the task existed or has already stopped.
     pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
-        self.bus
-            .publish(Event::new(EventKind::TaskRemoveRequested).with_id(id));
-        let reply = self.enqueue_remove(id)?;
+        let reply = self.enqueue_remove(id, None)?;
         drop(reply);
         Ok(())
     }
 
-    /// Queues one remove command and returns its authoritative registry reply.
-    fn enqueue_remove(&self, id: TaskId) -> Result<RemoveReplyRx, RuntimeError> {
+    /// Publishes one remove request, queues its command, and returns the authoritative reply.
+    ///
+    /// This is fail-fast while the public management API remains synchronous.
+    fn enqueue_remove(
+        &self,
+        id: TaskId,
+        reason: Option<&'static str>,
+    ) -> Result<RemoveReplyRx, RuntimeError> {
+        let permit = self.cmd_tx.try_reserve().map_err(|error| match error {
+            mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
+            mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
+        })?;
         let (reply, reply_rx) = oneshot::channel();
-        self.cmd_tx
-            .send(RegistryCommand::Remove { id, reply })
-            .map_err(|_| RuntimeError::ShuttingDown)?;
+        let mut event = Event::new(EventKind::TaskRemoveRequested).with_id(id);
+        if let Some(reason) = reason {
+            event = event.with_reason(reason);
+        }
+        self.bus.publish(event);
+        permit.send(RegistryCommand::Remove { id, reply });
         Ok(reply_rx)
     }
 
@@ -316,7 +364,12 @@ impl SupervisorCore {
             let mut rx = self.bus.subscribe();
             let mut pending_ids = Vec::with_capacity(tasks.len());
             for spec in tasks {
-                pending_ids.push(self.add_task(spec)?);
+                let (id, reply) = self
+                    .enqueue_add_task_wait(TaskId::next(), spec, None)
+                    .await
+                    .map_err(|(error, _done)| error)?;
+                drop(reply);
+                pending_ids.push(id);
             }
             self.wait_tasks_registered(&mut rx, &pending_ids).await;
         }
@@ -409,12 +462,7 @@ impl SupervisorCore {
             return Ok(false);
         }
 
-        self.bus.publish(
-            Event::new(EventKind::TaskRemoveRequested)
-                .with_id(id)
-                .with_reason("manual_cancel"),
-        );
-        let reply = self.enqueue_remove(id)?;
+        let reply = self.enqueue_remove(id, Some("manual_cancel"))?;
         drop(reply);
         self.wait_task_removed(&mut rx, id, wait_for).await
     }
@@ -667,7 +715,7 @@ mod tests {
         let bus = Bus::new(cfg.bus_capacity_clamped());
         let subs = Arc::new(SubscriberSet::new(subs, bus.clone()));
         let token = CancellationToken::new();
-        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(cfg.registry_queue_capacity_clamped());
         let registry = Registry::new(bus.clone(), token.clone(), None, cfg.grace, cmd_rx);
         let alive = Arc::new(AliveTracker::new());
         SupervisorCore::new_internal(cfg, bus, subs, alive, registry, token, cmd_tx)
@@ -802,6 +850,178 @@ mod tests {
             matches!(res, Err(RuntimeError::ShuttingDown)),
             "add() after shutdown began must be rejected, got {res:?}"
         );
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bounded_command_queue_reports_full_and_recovers_capacity() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskOutcome, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the first command must fill the only queue slot");
+
+        let runs = Arc::new(AtomicUsize::new(0));
+        let rejected_runs = Arc::clone(&runs);
+        let rejected: TaskRef = TaskFn::arc("queue-full-add", move |_ctx: TaskContext| {
+            rejected_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let rejected_id = TaskId::next();
+        let (outcome, outcome_rx) = oneshot::channel();
+        let full_add = core.enqueue_add_task(rejected_id, TaskSpec::once(rejected), Some(outcome));
+        match full_add {
+            Err((RuntimeError::CommandQueueFull, Some(returned))) => {
+                returned
+                    .send(TaskOutcome::Rejected {
+                        reason: Arc::from("command_queue_full"),
+                    })
+                    .expect("the full command must return its outcome sender");
+            }
+            other => panic!("second command must report CommandQueueFull, got {other:?}"),
+        }
+        assert!(matches!(
+            outcome_rx.await,
+            Ok(TaskOutcome::Rejected { reason }) if reason.as_ref() == "command_queue_full"
+        ));
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+        assert!(!core.contains_id(rejected_id).await);
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(rejected_id) || event.kind != EventKind::TaskAddRequested,
+                "a command rejected before enqueue must not publish TaskAddRequested"
+            );
+        }
+
+        let rejected_remove_id = TaskId::next();
+        assert!(matches!(
+            core.remove(rejected_remove_id),
+            Err(RuntimeError::CommandQueueFull)
+        ));
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(rejected_remove_id)
+                    || event.kind != EventKind::TaskRemoveRequested,
+                "a command rejected before enqueue must not publish TaskRemoveRequested"
+            );
+        }
+
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), filler_reply)
+                .await
+                .expect("filler reply must resolve"),
+            Ok(Ok(false))
+        ));
+
+        let accepted: TaskRef = TaskFn::arc("capacity-recovered", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let accepted_id = TaskId::next();
+        let (_, accepted_reply) = core
+            .enqueue_add_task(accepted_id, TaskSpec::restartable(accepted), None)
+            .expect("capacity must recover after the filler is received");
+        assert!(matches!(
+            timeout(Duration::from_secs(2), accepted_reply)
+                .await
+                .expect("accepted add reply must resolve"),
+            Ok(Ok(()))
+        ));
+        assert!(core.contains_id(accepted_id).await);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn static_run_backpressures_initial_batch_larger_than_queue() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let runs = Arc::new(AtomicUsize::new(0));
+        let tasks = (0..4)
+            .map(|index| {
+                let runs = Arc::clone(&runs);
+                let task: TaskRef =
+                    TaskFn::arc(format!("static-{index}"), move |_ctx: TaskContext| {
+                        runs.fetch_add(1, Ordering::SeqCst);
+                        async { Ok(()) }
+                    });
+                TaskSpec::once(task)
+            })
+            .collect();
+
+        timeout(Duration::from_secs(2), core.run(tasks))
+            .await
+            .expect("static run must not block on its bounded initial queue")
+            .expect("static run must not fail when its batch exceeds queue capacity");
+        assert_eq!(runs.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn closed_command_queue_returns_shutting_down_and_watcher() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskOutcome, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        core.start();
+        core.runtime_token.cancel();
+        timeout(Duration::from_secs(2), core.registry.join_listener())
+            .await
+            .expect("registry listener must stop");
+        let mut events = core.bus.subscribe();
+
+        let remove_id = TaskId::next();
+        assert!(matches!(
+            core.remove(remove_id),
+            Err(RuntimeError::ShuttingDown)
+        ));
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(remove_id) || event.kind != EventKind::TaskRemoveRequested,
+                "a remove rejected by a closed queue must not publish TaskRemoveRequested"
+            );
+        }
+
+        let runs = Arc::new(AtomicUsize::new(0));
+        let rejected_runs = Arc::clone(&runs);
+        let task: TaskRef = TaskFn::arc("closed-command", move |_ctx: TaskContext| {
+            rejected_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let (outcome, outcome_rx) = oneshot::channel();
+        match core.enqueue_add_task(TaskId::next(), TaskSpec::once(task), Some(outcome)) {
+            Err((RuntimeError::ShuttingDown, Some(returned))) => {
+                returned
+                    .send(TaskOutcome::Rejected {
+                        reason: Arc::from("shutting_down"),
+                    })
+                    .expect("closed queue must return its outcome sender");
+            }
+            other => panic!("closed command queue must return ShuttingDown, got {other:?}"),
+        }
+        assert!(matches!(
+            outcome_rx.await,
+            Ok(TaskOutcome::Rejected { reason }) if reason.as_ref() == "shutting_down"
+        ));
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
 
         let _ = core.shutdown().await;
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,12 @@ pub enum RuntimeError {
         name: Arc<str>,
     },
 
+    /// The bounded registry command queue has no free capacity.
+    ///
+    /// The command was not accepted and no registry state was changed.
+    #[error("registry command queue is full")]
+    CommandQueueFull,
+
     /// Timed out while waiting for removal confirmation.
     #[error("timeout waiting for task {id} removal after {timeout:?}")]
     TaskRemoveTimeout {
@@ -94,6 +100,7 @@ impl RuntimeError {
         match self {
             RuntimeError::GraceExceeded { .. } => "runtime_grace_exceeded",
             RuntimeError::TaskAlreadyExists { .. } => "runtime_task_already_exists",
+            RuntimeError::CommandQueueFull => "runtime_command_queue_full",
             RuntimeError::TaskRemoveTimeout { .. } => "runtime_task_remove_timeout",
             RuntimeError::TaskAddTimeout { .. } => "runtime_task_add_timeout",
             RuntimeError::SignalSetupFailed { .. } => "runtime_signal_setup_failed",
@@ -337,6 +344,13 @@ impl Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_queue_full_has_stable_label() {
+        let error = RuntimeError::CommandQueueFull;
+        assert_eq!(error.as_label(), "runtime_command_queue_full");
+        assert_eq!(error.to_string(), "registry command queue is full");
+    }
 
     #[test]
     fn exit_code_is_some_for_fail_with_code() {


### PR DESCRIPTION
## 📝 Description
- Added `registry_queue_capacity` to `SupervisorConfig`.
- Added `with_registry_queue_capacity` to `SupervisorBuilder`.
- Set the default queue capacity to `1024`.
- Replaced the unbounded registry command channel with a bounded Tokio channel.
- Added async queue waiting for the initial task batch in `Supervisor::run()`.

## 🔄 Related Issues
Resolves #119

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] `task ci` passes locally
