### PR TITLE
[core] Make task add wait for registry acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Taskvisor restarts them on failure and reports every step as an event. You can a
 // Dynamic mode
 let handle = sup.serve();
 
-let id = handle.add(spec)?;                       // returns a TaskId
+let id = handle.add(spec).await?;                 // registry accepted this TaskId
 handle.cancel(id).await?;                         // cancel by identity
 handle.cancel_by_label("task-name").await?;       // ...or by label
 let tasks = handle.list().await;                  // Vec<(TaskId, name)>
@@ -325,7 +325,7 @@ See [`examples/tracing.rs`](examples/tracing.rs) for the full program and [`exam
 ```rust,ignore
 // add_and_watch returns a TaskWaiter resolving to the final TaskOutcome.
 let (id, waiter) = handle
-    .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+    .add_and_watch(TaskSpec::once(job))
     .await?;
 
 match waiter.wait().await? {

--- a/benches/controller.rs
+++ b/benches/controller.rs
@@ -1,7 +1,7 @@
 //! # Controller: admission policy overhead
 //!
-//! The controller wraps `handle.add()` with admission policies (Queue, Replace, DropIfRunning).
-//! This benchmark compares direct `add()` vs `submit()` to isolate the controller's cost, and then compares the three policies.
+//! Measures controller submission and admission policies (Queue, Replace, DropIfRunning).
+//! The groups cover queued completion, replacement, rejection, the `try_submit` hot path, and multi-slot fan-out.
 //!
 //! ## What is measured
 //!

--- a/benches/dynamic.rs
+++ b/benches/dynamic.rs
@@ -6,8 +6,8 @@
 //!
 //! | Benchmark       | Description                                              |
 //! |-----------------|----------------------------------------------------------|
-//! | `add`           | `handle.add(spec)` — time to submit one task.            |
-//! | `add_remove`    | `handle.add(spec)` + `handle.cancel(name)` round-trip.   |
+//! | `add`           | `handle.add(spec).await` — registry acceptance latency.  |
+//! | `add_remove`    | `handle.add(spec).await` + cancel round-trip.            |
 //! | `list`          | `handle.list()` with N tasks already running.            |
 //! | `churn/N`       | Add N tasks, then shut down — measures cleanup at scale. |
 //!
@@ -81,17 +81,14 @@ fn bench_add(c: &mut Criterion) {
             b.iter_custom(|iters| {
                 let rt = rt_fn();
                 rt.block_on(async {
-                    let mut cfg = bench_config();
-                    cfg.registry_queue_capacity =
-                        usize::try_from(iters).unwrap_or(usize::MAX).max(1);
-                    let sup = Supervisor::new(cfg, vec![]);
+                    let sup = Supervisor::new(bench_config(), vec![]);
                     let handle = sup.serve();
 
                     let mut total = Duration::ZERO;
                     for i in 0..iters {
                         let spec = instant_task(&format!("a-{i}"));
                         let start = std::time::Instant::now();
-                        handle.add(spec).unwrap();
+                        handle.add(spec).await.unwrap();
                         total += start.elapsed();
                     }
 
@@ -119,14 +116,13 @@ fn bench_add_cancel(c: &mut Criterion) {
                     let sup = Supervisor::new(bench_config(), vec![]);
                     let handle = sup.serve();
 
-                    let wait = Duration::from_secs(5);
                     let mut total = Duration::ZERO;
                     for i in 0..iters {
                         let name = format!("ac-{i}");
                         let spec = worker_task(&name);
 
                         let start = std::time::Instant::now();
-                        let id = handle.add_and_wait(spec, wait).await.unwrap();
+                        let id = handle.add(spec).await.unwrap();
                         let _ = handle.cancel(id).await;
                         total += start.elapsed();
                     }
@@ -158,12 +154,8 @@ fn bench_list(c: &mut Criterion) {
                             let sup = Supervisor::new(bench_config(), vec![]);
                             let handle = sup.serve();
 
-                            let wait = Duration::from_secs(5);
                             for i in 0..n {
-                                handle
-                                    .add_and_wait(worker_task(&format!("w-{i}")), wait)
-                                    .await
-                                    .unwrap();
+                                handle.add(worker_task(&format!("w-{i}"))).await.unwrap();
                             }
 
                             let mut total = Duration::ZERO;
@@ -201,13 +193,9 @@ fn bench_churn(c: &mut Criterion) {
                             let sup = Supervisor::new(bench_config(), vec![]);
                             let handle = sup.serve();
 
-                            let wait = Duration::from_secs(5);
                             let start = std::time::Instant::now();
                             for i in 0..n {
-                                handle
-                                    .add_and_wait(worker_task(&format!("ch-{i}")), wait)
-                                    .await
-                                    .unwrap();
+                                handle.add(worker_task(&format!("ch-{i}"))).await.unwrap();
                             }
                             let _ = handle.shutdown().await;
                             start.elapsed()

--- a/examples/cpu_job.rs
+++ b/examples/cpu_job.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_backoff(BackoffPolicy::constant(Duration::from_millis(200)));
 
     // Await the job's final result: the supervisor retried it for us.
-    let (_id, waiter) = handle.add_and_watch(spec, Duration::from_secs(1)).await?;
+    let (_id, waiter) = handle.add_and_watch(spec).await?;
     println!("outcome: {:?}", waiter.wait().await?);
 
     handle.shutdown().await?;

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -42,7 +42,7 @@
 //! ## What this shows
 //!
 //! - `sup.serve()`: starts listeners, returns a handle. Non-blocking.
-//! - `handle.add(spec)`: register a new task dynamically, returns its `TaskId`.
+//! - `handle.add(spec).await`: register a new task dynamically, returns its `TaskId`.
 //! - `handle.remove(id)`: cancel and deregister by identity (or `remove_by_label(name)`).
 //! - `handle.cancel(id)`: cancel and wait for confirmation (or `cancel_by_label(name)`).
 //! - `handle.list()`: snapshot of active `(TaskId, name)` pairs.
@@ -103,8 +103,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add workers dynamically
     println!("Adding worker-a and worker-b...");
-    let id_a = handle.add(make_worker("worker-a"))?;
-    let id_b = handle.add(make_worker("worker-b"))?;
+    let id_a = handle.add(make_worker("worker-a")).await?;
+    let id_b = handle.add(make_worker("worker-b")).await?;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
     println!("Active: {:?}", handle.list().await);
@@ -117,7 +117,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add worker-c
     println!("\nAdding worker-c...");
-    handle.add(make_worker("worker-c"))?;
+    handle.add(make_worker("worker-c")).await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Cancel worker-b

--- a/examples/outcomes.rs
+++ b/examples/outcomes.rs
@@ -19,7 +19,7 @@
 //!
 //! ## What this shows
 //!
-//! - `handle.add_and_watch(spec, timeout)`: register a task and get `(TaskId, TaskWaiter)`.
+//! - `handle.add_and_watch(spec)`: register a task and get `(TaskId, TaskWaiter)`.
 //! - `waiter.wait().await`: block until the task terminates, returning a `TaskOutcome`.
 //! - The three outcomes you will most often see:
 //!   - [`TaskOutcome::Completed`] - a one-shot job that succeeded.
@@ -62,8 +62,6 @@ use std::time::Duration;
 
 use taskvisor::prelude::*;
 
-const ADD_TIMEOUT: Duration = Duration::from_secs(1);
-
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
@@ -75,9 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(())
     });
-    let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::once(job), ADD_TIMEOUT)
-        .await?;
+    let (_id, waiter) = handle.add_and_watch(TaskSpec::once(job)).await?;
     println!("  import -> {:?}\n", waiter.wait().await?);
 
     // 2) A task that always fails, with a bounded retry budget -> Failed.
@@ -95,13 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spec = TaskSpec::restartable(flaky)
         .with_backoff(BackoffPolicy::constant(Duration::from_millis(20)))
         .with_max_retries(NonZeroU32::new(2).unwrap());
-    match handle
-        .add_and_watch(spec, ADD_TIMEOUT)
-        .await?
-        .1
-        .wait()
-        .await?
-    {
+    match handle.add_and_watch(spec).await?.1.wait().await? {
         TaskOutcome::Failed {
             reason, exit_code, ..
         } => {
@@ -116,9 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ctx.cancelled().await;
         Ok(())
     });
-    let (id, waiter) = handle
-        .add_and_watch(TaskSpec::restartable(worker), ADD_TIMEOUT)
-        .await?;
+    let (id, waiter) = handle.add_and_watch(TaskSpec::restartable(worker)).await?;
     tokio::time::sleep(Duration::from_millis(100)).await;
     println!("  cancelling worker...");
     handle.cancel(id).await?;

--- a/examples/slots.rs
+++ b/examples/slots.rs
@@ -23,7 +23,7 @@
 //! - Three demos: Queue (sequential), Replace (latest-wins), DropIfRunning (reject-while-busy).
 //! - `handle.submit(ControllerSpec::queue(spec))`: submit to a slot.
 //!
-//! ## How it differs from `handle.add()`
+//! ## How it differs from `handle.add(...).await`
 //!
 //! `add` registers a task directly in the registry: no slot, no admission policy.
 //! `submit` goes through the controller, which manages the slot lifecycle and decides whether to accept, queue, or reject.

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -1267,7 +1267,7 @@ mod tests {
             Ok(())
         });
         let id = handle
-            .add_and_wait(TaskSpec::restartable(task), Duration::from_secs(1))
+            .add(TaskSpec::restartable(task))
             .await
             .expect("task should register");
         (sup, handle, id)

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -144,7 +144,7 @@ impl SupervisorBuilder {
     /// Builder: sets the registry management command queue capacity.
     ///
     /// The effective capacity is at least `1`.
-    /// Sync management methods fail fast when the queue is full.
+    /// Management methods that do not wait for capacity fail fast when the queue is full.
     pub fn with_registry_queue_capacity(mut self, registry_queue_capacity: usize) -> Self {
         self.cfg.registry_queue_capacity = registry_queue_capacity;
         self

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -60,7 +60,7 @@ pub struct SupervisorConfig {
     /// This bounds pending add and remove commands.
     /// The registry may process one additional command while this many commands are buffered.
     ///
-    /// Sync management methods fail with [`RuntimeError::CommandQueueFull`](crate::RuntimeError::CommandQueueFull) when the queue has no capacity.
+    /// Management methods that do not wait for queue capacity fail with [`RuntimeError::CommandQueueFull`](crate::RuntimeError::CommandQueueFull) when the queue has no capacity.
     ///
     /// Use [`registry_queue_capacity_clamped`](Self::registry_queue_capacity_clamped) when creating the queue; the effective capacity is at least `1`.
     pub registry_queue_capacity: usize,

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -12,11 +12,9 @@
 //! [`SupervisorCore`]: crate::core::SupervisorCore
 
 use std::{sync::Arc, time::Duration};
-use tokio::sync::broadcast;
 
 use crate::core::SupervisorCore;
 use crate::error::RuntimeError;
-use crate::events::EventKind;
 use crate::identity::TaskId;
 use crate::tasks::TaskSpec;
 
@@ -51,7 +49,7 @@ use super::outcome::TaskWaiter;
 ///         }
 ///     });
 ///
-///     let id = handle.add(TaskSpec::restartable(task))?;
+///     let id = handle.add(TaskSpec::restartable(task)).await?;
 ///     let _ = handle.cancel(id).await?;
 ///     handle.shutdown().await?;
 ///     Ok(())
@@ -93,66 +91,50 @@ impl SupervisorHandle {
         self
     }
 
-    /// Adds a task to the supervisor at runtime.
+    /// Adds a task and waits for registry acceptance.
     ///
-    /// This is fire-and-forget.
-    /// It mints a [`TaskId`], reserves command queue capacity, publishes `TaskAddRequested`, queues an `Add` command, and returns the id.
+    /// This waits for command queue capacity and then for the direct registry reply.
+    /// `Ok(id)` means the registry accepted the task identity and label.
+    /// Registration does not depend on lifecycle event delivery.
     ///
-    /// `Ok(id)` means the add command was accepted by the runtime command channel.
-    /// It does not mean the registry has accepted the task yet.
-    ///
-    /// For duplicate-name errors or registration confirmation, use [`add_and_wait`](Self::add_and_wait).
+    /// Dropping this future after its command was queued does not roll the Add back.
+    /// The registry may still accept and start the task.
     ///
     /// # Errors
     ///
-    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
-    pub fn add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        self.core.add_task(spec)
+    /// - [`RuntimeError::TaskAlreadyExists`] when the task name is already in use.
+    pub async fn add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        self.core.add_task(spec).await
     }
 
-    /// Adds a task and waits for registry confirmation.
+    /// Tries to add a task without waiting for command queue capacity.
     ///
-    /// This subscribes to the event bus before sending the add command, then waits for the matching `TaskAdded` or `TaskAddFailed` event.
-    ///
-    /// Returns `Ok(TaskId)` when the task is registered.
-    /// Correlation uses the minted [`TaskId`], not the task name.
+    /// When queue admission succeeds, this still waits for the direct registry reply.
+    /// `Ok(id)` therefore has the same meaning as [`add`](Self::add).
     ///
     /// # Errors
     ///
     /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     /// - [`RuntimeError::TaskAlreadyExists`] when the task name is already in use.
-    /// - [`RuntimeError::TaskAddTimeout`] when no confirmation arrives in time.
-    pub async fn add_and_wait(
-        &self,
-        spec: TaskSpec,
-        timeout: Duration,
-    ) -> Result<TaskId, RuntimeError> {
-        let target: Arc<str> = Arc::from(spec.task().name());
-        let mut rx = self.core.subscribe_bus();
-        let id = self.core.add_task(spec)?;
-        self.wait_registered(&mut rx, id, target, timeout).await
+    pub async fn try_add(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        self.core.try_add_task(spec).await
     }
 
-    /// Adds a task, waits for registration, and returns a [`TaskWaiter`].
+    /// Adds a task and returns a [`TaskWaiter`] after registry acceptance.
     ///
     /// The waiter resolves to the final [`TaskOutcome`](crate::TaskOutcome) of the supervised task run.
-    ///
-    /// Returns `Ok((TaskId, TaskWaiter))` when the task is registered.
-    /// Registration semantics are the same as [`add_and_wait`](Self::add_and_wait).
+    /// Registration semantics are the same as [`add`](Self::add).
     ///
     /// # Errors
     ///
-    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     /// - [`RuntimeError::TaskAlreadyExists`] when the task name is already in use.
-    /// - [`RuntimeError::TaskAddTimeout`] when no confirmation arrives in time.
     ///
     /// ## Example
     ///
     /// ```rust,no_run
-    /// # use std::time::Duration;
     /// # use taskvisor::prelude::*;
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
@@ -162,7 +144,7 @@ impl SupervisorHandle {
     /// });
     ///
     /// let (_id, waiter) = handle
-    ///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+    ///     .add_and_watch(TaskSpec::once(job))
     ///     .await?;
     ///
     /// let outcome = waiter.wait().await?;
@@ -172,64 +154,9 @@ impl SupervisorHandle {
     pub async fn add_and_watch(
         &self,
         spec: TaskSpec,
-        timeout: Duration,
     ) -> Result<(TaskId, TaskWaiter), RuntimeError> {
-        let target: Arc<str> = Arc::from(spec.task().name());
-        let mut rx = self.core.subscribe_bus();
-        let (id, done_rx) = self.core.add_task_watched(spec)?;
-        self.wait_registered(&mut rx, id, target, timeout).await?;
+        let (id, done_rx) = self.core.add_task_watched(spec).await?;
         Ok((id, TaskWaiter::new(id, done_rx)))
-    }
-
-    /// Waits for the registry confirmation event for `id`.
-    ///
-    /// On bus lag or closure, this falls back to registry state before returning a timeout.
-    /// The fallback prevents false negatives when the confirmation event was missed but the task is still registered.
-    async fn wait_registered(
-        &self,
-        rx: &mut broadcast::Receiver<Arc<crate::Event>>,
-        id: TaskId,
-        target: Arc<str>,
-        timeout: Duration,
-    ) -> Result<TaskId, RuntimeError> {
-        let target2 = Arc::clone(&target);
-        let wait = async move {
-            loop {
-                match rx.recv().await {
-                    Ok(ev) if ev.id == Some(id) && ev.kind == EventKind::TaskAdded => {
-                        return Ok(id);
-                    }
-                    Ok(ev) if ev.id == Some(id) && ev.kind == EventKind::TaskAddFailed => {
-                        return Err(RuntimeError::TaskAlreadyExists { name: target2 });
-                    }
-                    Ok(_) => continue,
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if self.core.contains_id(id).await {
-                            return Ok(id);
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-            if self.core.contains_id(id).await {
-                Ok(id)
-            } else {
-                Err(RuntimeError::TaskAddTimeout {
-                    name: target2,
-                    timeout,
-                })
-            }
-        };
-
-        match tokio::time::timeout(timeout, wait).await {
-            Ok(result) => result,
-            Err(_) => Err(RuntimeError::TaskAddTimeout {
-                name: target,
-                timeout,
-            }),
-        }
     }
 
     /// Removes a task by identity.

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -244,7 +244,6 @@ impl TaskOutcome {
 /// ## Example
 ///
 /// ```rust,no_run
-/// # use std::time::Duration;
 /// # use taskvisor::prelude::*;
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
@@ -254,7 +253,7 @@ impl TaskOutcome {
 /// });
 ///
 /// let (id, waiter) = handle
-///     .add_and_watch(TaskSpec::once(job), Duration::from_secs(1))
+///     .add_and_watch(TaskSpec::once(job))
 ///     .await?;
 ///
 /// match waiter.wait().await? {

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -330,6 +330,7 @@ impl SupervisorCore {
     }
 
     /// Returns true if `id` is currently registered.
+    #[cfg(any(test, feature = "controller"))]
     pub(crate) async fn contains_id(&self, id: TaskId) -> bool {
         self.registry.contains(id).await
     }

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -150,12 +150,25 @@ impl SupervisorCore {
         self.shutting_down.store(true, Ordering::Release);
     }
 
-    /// Queues a task add command and returns its minted [`TaskId`].
+    /// Adds a task and waits for the registry registration decision.
     ///
-    /// `Ok(id)` means the command was sent to the registry listener.
-    /// Registration may still fail later, for example because the task name already exists.
-    pub(crate) fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
-        self.add_task_inner(TaskId::next(), spec, None)
+    /// This waits for queue capacity before sending the command.
+    pub(crate) async fn add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        let (id, reply) = self
+            .enqueue_add_task_wait(TaskId::next(), spec, None)
+            .await
+            .map_err(|(error, _done)| error)?;
+        Self::await_add_reply(id, reply).await
+    }
+
+    /// Tries to add a task without waiting for queue capacity.
+    ///
+    /// After the command enters the queue, this still waits for the registry registration decision.
+    pub(crate) async fn try_add_task(&self, spec: TaskSpec) -> Result<TaskId, RuntimeError> {
+        let (id, reply) = self
+            .enqueue_add_task(TaskId::next(), spec, None)
+            .map_err(|(error, _done)| error)?;
+        Self::await_add_reply(id, reply).await
     }
 
     /// Queues a task add command under a pre-minted identity.
@@ -177,41 +190,35 @@ impl SupervisorCore {
         Ok(id)
     }
 
-    /// Queues a watched task add command.
+    /// Adds a watched task and waits for the registry registration decision.
     ///
     /// Returns the minted [`TaskId`] and a receiver that resolves to the final [`TaskOutcome`](crate::TaskOutcome)
     /// if the task is registered and later terminates.
-    pub(crate) fn add_task_watched(
+    pub(crate) async fn add_task_watched(
         &self,
         spec: TaskSpec,
     ) -> Result<(TaskId, tokio::sync::oneshot::Receiver<crate::TaskOutcome>), RuntimeError> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let id = self.add_task_inner(TaskId::next(), spec, Some(tx))?;
+        let (id, reply) = self
+            .enqueue_add_task_wait(TaskId::next(), spec, Some(tx))
+            .await
+            .map_err(|(error, _done)| error)?;
+        let id = Self::await_add_reply(id, reply).await?;
         Ok((id, rx))
     }
 
-    /// Sends the registry `Add` command and publishes `TaskAddRequested`.
-    ///
-    /// Returns `CommandQueueFull` when the bounded queue has no capacity.
-    /// Returns `ShuttingDown` if admission is already closed or the registry command channel is closed.
-    fn add_task_inner(
-        &self,
-        id: TaskId,
-        spec: TaskSpec,
-        done: Option<OutcomeTx>,
-    ) -> Result<TaskId, RuntimeError> {
-        match self.enqueue_add_task(id, spec, done) {
-            Ok((id, reply)) => {
-                drop(reply);
-                Ok(id)
-            }
-            Err((err, _done)) => Err(err),
+    /// Resolves one authoritative registry Add reply.
+    async fn await_add_reply(id: TaskId, reply: AddReplyRx) -> Result<TaskId, RuntimeError> {
+        match reply.await {
+            Ok(Ok(())) => Ok(id),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(RuntimeError::ShuttingDown),
         }
     }
 
     /// Queues one add command and returns its authoritative registry reply.
     ///
-    /// This is fail-fast while the public management API remains synchronous.
+    /// Used by `try_add` and the controller's fail-fast admission path.
     fn enqueue_add_task(
         &self,
         id: TaskId,
@@ -230,23 +237,14 @@ impl SupervisorCore {
                 return Err((RuntimeError::ShuttingDown, done));
             }
         };
-        let label: Arc<str> = Arc::from(spec.task().name());
-        let (reply, reply_rx) = oneshot::channel();
-        self.bus.publish(
-            Event::new(EventKind::TaskAddRequested)
-                .with_task(label)
-                .with_id(id),
-        );
-        permit.send(RegistryCommand::Add {
-            id,
-            spec,
-            outcome: done,
-            reply,
-        });
-        Ok((id, reply_rx))
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err((RuntimeError::ShuttingDown, done));
+        }
+        Ok(self.commit_add(permit, id, spec, done))
     }
 
-    /// Waits for bounded queue capacity, then queues one static-run add command.
+    /// Waits for bounded queue capacity, then queues one Add command.
     async fn enqueue_add_task_wait(
         &self,
         id: TaskId,
@@ -264,6 +262,20 @@ impl SupervisorCore {
             drop(permit);
             return Err((RuntimeError::ShuttingDown, done));
         }
+        Ok(self.commit_add(permit, id, spec, done))
+    }
+
+    /// Publishes the request event and makes an already-reserved Add visible.
+    ///
+    /// Reserving capacity before this call keeps rejected commands silent while
+    /// preserving `TaskAddRequested` before the registry result event.
+    fn commit_add(
+        &self,
+        permit: mpsc::Permit<'_, RegistryCommand>,
+        id: TaskId,
+        spec: TaskSpec,
+        done: Option<OutcomeTx>,
+    ) -> (TaskId, AddReplyRx) {
         let label: Arc<str> = Arc::from(spec.task().name());
         let (reply, reply_rx) = oneshot::channel();
         self.bus.publish(
@@ -277,7 +289,7 @@ impl SupervisorCore {
             outcome: done,
             reply,
         });
-        Ok((id, reply_rx))
+        (id, reply_rx)
     }
 
     /// Queues a remove command by runtime identity.
@@ -328,6 +340,7 @@ impl SupervisorCore {
     }
 
     /// Returns a new bus receiver for event subscription.
+    #[cfg(test)]
     pub(crate) fn subscribe_bus(&self) -> broadcast::Receiver<Arc<Event>> {
         self.bus.subscribe()
     }
@@ -671,17 +684,12 @@ impl SupervisorCore {
 mod tests {
     use super::*;
     use crate::subscribers::Subscribe;
-    use std::sync::Mutex;
+    use std::{future::Future, pin::Pin, sync::Mutex, task::Poll};
 
-    /// Subscriber that records a clone of every event it receives.
-    ///
-    /// A large queue keeps the recorder from lagging itself, so tests assert on the bus
-    /// contents, not on subscriber-side drops.
     struct RecordingSub {
         seen: Arc<Mutex<Vec<Event>>>,
     }
     impl RecordingSub {
-        /// Returns the subscriber plus a shared handle to the events it records.
         fn new() -> (Arc<Self>, Arc<Mutex<Vec<Event>>>) {
             let seen = Arc::new(Mutex::new(Vec::new()));
             (
@@ -719,6 +727,14 @@ mod tests {
         let registry = Registry::new(bus.clone(), token.clone(), None, cfg.grace, cmd_rx);
         let alive = Arc::new(AliveTracker::new());
         SupervisorCore::new_internal(cfg, bus, subs, alive, registry, token, cmd_tx)
+    }
+
+    async fn assert_pending_once<F: Future>(mut future: Pin<&mut F>) {
+        std::future::poll_fn(|cx| match future.as_mut().poll(cx) {
+            Poll::Pending => Poll::Ready(()),
+            Poll::Ready(_) => panic!("future completed before the expected ordering point"),
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -837,7 +853,7 @@ mod tests {
             ctx.cancelled().await;
             Ok(())
         });
-        assert!(core.add_task(TaskSpec::restartable(early)).is_ok());
+        assert!(core.add_task(TaskSpec::restartable(early)).await.is_ok());
 
         core.mark_shutting_down();
 
@@ -845,11 +861,224 @@ mod tests {
             ctx.cancelled().await;
             Ok(())
         });
-        let res = core.add_task(TaskSpec::restartable(late));
+        let res = core.add_task(TaskSpec::restartable(late)).await;
         assert!(
             matches!(res, Err(RuntimeError::ShuttingDown)),
             "add() after shutdown began must be rejected, got {res:?}"
         );
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confirmed_add_waits_for_capacity_and_registry_reply() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the only queue slot");
+
+        let task: TaskRef = TaskFn::arc("backpressured-add", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let mut add = Box::pin(core.add_task(TaskSpec::restartable(task)));
+        assert_pending_once(add.as_mut()).await;
+        assert!(core.id_for_label("backpressured-add").await.is_none());
+
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), filler_reply)
+                .await
+                .expect("filler reply must resolve"),
+            Ok(Ok(false))
+        ));
+        let id = timeout(Duration::from_secs(2), add)
+            .await
+            .expect("add must wake after capacity is released")
+            .expect("registry must accept the task");
+        assert!(core.contains_id(id).await);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backpressured_add_returns_shutting_down_when_queue_closes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the only queue slot");
+
+        let runs = Arc::new(AtomicUsize::new(0));
+        let task_runs = Arc::clone(&runs);
+        let task: TaskRef = TaskFn::arc("closed-while-waiting", move |_ctx: TaskContext| {
+            task_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let mut add = Box::pin(core.add_task(TaskSpec::once(task)));
+        assert_pending_once(add.as_mut()).await;
+
+        core.runtime_token.cancel();
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), add)
+                .await
+                .expect("closing the queue must wake the waiting Add"),
+            Err(RuntimeError::ShuttingDown)
+        ));
+        let _ = timeout(Duration::from_secs(2), filler_reply)
+            .await
+            .expect("the buffered filler must still resolve");
+        core.registry.join_listener().await;
+        assert!(core.id_for_label("closed-while-waiting").await.is_none());
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn try_add_reports_full_without_event_or_task_start() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the only queue slot");
+
+        let runs = Arc::new(AtomicUsize::new(0));
+        let task_runs = Arc::clone(&runs);
+        let task: TaskRef = TaskFn::arc("try-add-full", move |_ctx: TaskContext| {
+            task_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        assert!(matches!(
+            core.try_add_task(TaskSpec::once(task)).await,
+            Err(RuntimeError::CommandQueueFull)
+        ));
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+        assert!(core.id_for_label("try-add-full").await.is_none());
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.kind != EventKind::TaskAddRequested
+                    || event.task.as_deref() != Some("try-add-full"),
+                "an Add rejected before enqueue must not publish TaskAddRequested"
+            );
+        }
+
+        core.start();
+        let _ = timeout(Duration::from_secs(2), filler_reply)
+            .await
+            .expect("filler reply must resolve");
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn try_add_waits_for_registry_decision_after_admission() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        let task: TaskRef = TaskFn::arc("try-add-confirmed", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let mut add = Box::pin(core.try_add_task(TaskSpec::restartable(task)));
+        assert_pending_once(add.as_mut()).await;
+        assert!(core.id_for_label("try-add-confirmed").await.is_none());
+
+        core.start();
+        let id = timeout(Duration::from_secs(2), add)
+            .await
+            .expect("try_add must resolve after the registry processes its command")
+            .expect("registry must accept the task");
+        assert!(core.contains_id(id).await);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_add_before_enqueue_rolls_back_admission() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the only queue slot");
+
+        let runs = Arc::new(AtomicUsize::new(0));
+        let task_runs = Arc::clone(&runs);
+        let task: TaskRef = TaskFn::arc("dropped-before-enqueue", move |_ctx: TaskContext| {
+            task_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let mut add = Box::pin(core.add_task(TaskSpec::once(task)));
+        assert_pending_once(add.as_mut()).await;
+        drop(add);
+
+        core.start();
+        let _ = timeout(Duration::from_secs(2), filler_reply)
+            .await
+            .expect("filler reply must resolve");
+        assert!(core.id_for_label("dropped-before-enqueue").await.is_none());
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_add_after_enqueue_does_not_roll_command_back() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        let (started_tx, started_rx) = oneshot::channel();
+        let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+        let task_started = Arc::clone(&started_tx);
+        let task: TaskRef = TaskFn::arc("dropped-after-enqueue", move |ctx: TaskContext| {
+            let task_started = Arc::clone(&task_started);
+            async move {
+                if let Some(tx) = task_started.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                ctx.cancelled().await;
+                Ok(())
+            }
+        });
+
+        let mut add = Box::pin(core.add_task(TaskSpec::once(task)));
+        assert_pending_once(add.as_mut()).await;
+        drop(add);
+
+        core.start();
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .expect("the queued task must start after its caller is dropped")
+            .expect("the task must signal start");
+        assert!(core.id_for_label("dropped-after-enqueue").await.is_some());
 
         let _ = core.shutdown().await;
     }
@@ -1110,6 +1339,7 @@ mod tests {
         });
         let id = core
             .add_task(TaskSpec::restartable(t))
+            .await
             .expect("add accepted");
 
         let registered = timeout(Duration::from_secs(2), async {

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -43,7 +43,7 @@ use crate::{error::RuntimeError, subscribers::Subscribe, tasks::TaskSpec};
 /// let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
 /// let handle = supervisor.serve();
 ///
-/// // handle.add(...)?;
+/// // handle.add(...).await?;
 /// // handle.cancel(id).await?;
 /// // handle.shutdown().await?;
 /// # Ok(()) }
@@ -184,7 +184,7 @@ mod tests {
             Ok(())
         });
         handle
-            .add_and_wait(TaskSpec::once(stubborn), Duration::from_secs(1))
+            .add(TaskSpec::once(stubborn))
             .await
             .expect("task should register");
 
@@ -217,7 +217,7 @@ mod tests {
             Ok(())
         });
         handle
-            .add_and_wait(TaskSpec::restartable(good), Duration::from_secs(1))
+            .add(TaskSpec::restartable(good))
             .await
             .expect("task should register");
 
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_and_wait_duplicate_name_returns_already_exists() {
+    async fn add_duplicate_name_returns_already_exists() {
         let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
         let handle = sup.serve();
 
@@ -242,13 +242,11 @@ mod tests {
             })
         };
         handle
-            .add_and_wait(TaskSpec::restartable(make()), Duration::from_secs(1))
+            .add(TaskSpec::restartable(make()))
             .await
             .expect("first add should succeed");
 
-        let res = handle
-            .add_and_wait(TaskSpec::restartable(make()), Duration::from_secs(1))
-            .await;
+        let res = handle.add(TaskSpec::restartable(make())).await;
         assert!(
             matches!(res, Err(RuntimeError::TaskAlreadyExists { .. })),
             "duplicate add must return TaskAlreadyExists, got {res:?}"
@@ -267,7 +265,7 @@ mod tests {
             Ok(())
         });
         let id = handle
-            .add_and_wait(TaskSpec::restartable(t), Duration::from_secs(1))
+            .add(TaskSpec::restartable(t))
             .await
             .expect("add should succeed");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,15 +60,6 @@ pub enum RuntimeError {
         timeout: Duration,
     },
 
-    /// Timed out while waiting for registration confirmation.
-    #[error("timeout waiting for task '{name}' registration after {timeout:?}")]
-    TaskAddTimeout {
-        /// Task name that was not confirmed in time.
-        name: Arc<str>,
-        /// Wait duration before timing out.
-        timeout: Duration,
-    },
-
     /// OS signal listener setup failed.
     ///
     /// Signal-based shutdown is unavailable.
@@ -102,7 +93,6 @@ impl RuntimeError {
             RuntimeError::TaskAlreadyExists { .. } => "runtime_task_already_exists",
             RuntimeError::CommandQueueFull => "runtime_command_queue_full",
             RuntimeError::TaskRemoveTimeout { .. } => "runtime_task_remove_timeout",
-            RuntimeError::TaskAddTimeout { .. } => "runtime_task_add_timeout",
             RuntimeError::SignalSetupFailed { .. } => "runtime_signal_setup_failed",
             RuntimeError::ShuttingDown => "runtime_shutting_down",
             RuntimeError::AlreadyRunning => "runtime_already_running",

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -30,6 +30,7 @@ async fn add_storm_unique_names_all_register_then_drain_to_empty() {
             let h = handle.clone();
             joins.push(tokio::spawn(async move {
                 h.add(TaskSpec::restartable(make_coop(&format!("w-{i}"))))
+                    .await
                     .expect("add")
             }));
         }
@@ -80,12 +81,20 @@ async fn add_storm_duplicate_name_exactly_one_registers() {
         for _ in 0..N {
             let h = handle.clone();
             joins.push(tokio::spawn(async move {
-                h.add(TaskSpec::restartable(make_coop("dup"))).expect("add")
+                h.add(TaskSpec::restartable(make_coop("dup"))).await
             }));
         }
+        let mut accepted = 0;
+        let mut rejected = 0;
         for j in joins {
-            let _ = j.await.unwrap();
+            match j.await.unwrap() {
+                Ok(_) => accepted += 1,
+                Err(RuntimeError::TaskAlreadyExists { .. }) => rejected += 1,
+                Err(other) => panic!("unexpected add error: {other:?}"),
+            }
         }
+        assert_eq!(accepted, 1);
+        assert_eq!(rejected, N - 1);
 
         assert!(
             poll_until(Duration::from_secs(10), || async {
@@ -119,12 +128,9 @@ async fn distinct_ids_minted_concurrently_are_unique() {
         for i in 0..N {
             let h = handle.clone();
             joins.push(tokio::spawn(async move {
-                h.add_and_wait(
-                    TaskSpec::restartable(make_coop(&format!("task-{i}"))),
-                    Duration::from_secs(5),
-                )
-                .await
-                .expect("add_and_wait")
+                h.add(TaskSpec::restartable(make_coop(&format!("task-{i}"))))
+                    .await
+                    .expect("add")
             }));
         }
         let mut ids = HashSet::new();
@@ -152,11 +158,7 @@ async fn same_name_concurrent_adds_only_one_survives() {
         for _ in 0..K {
             let h = handle.clone();
             joins.push(tokio::spawn(async move {
-                h.add_and_wait(
-                    TaskSpec::restartable(make_coop("contended")),
-                    Duration::from_secs(5),
-                )
-                .await
+                h.add(TaskSpec::restartable(make_coop("contended"))).await
             }));
         }
         let mut ok = 0;
@@ -193,6 +195,7 @@ async fn interleaved_add_and_remove_drains_to_empty() {
             joins.push(tokio::spawn(async move {
                 let id = h
                     .add(TaskSpec::restartable(make_coop(&format!("t-{i}"))))
+                    .await
                     .expect("add");
                 let _ = h.remove(id);
                 id
@@ -225,10 +228,7 @@ async fn cancel_storm_by_id_returns_true_and_drains() {
         for i in 0..N {
             ids.push(
                 handle
-                    .add_and_wait(
-                        TaskSpec::restartable(make_coop(&format!("c-{i}"))),
-                        Duration::from_secs(2),
-                    )
+                    .add(TaskSpec::restartable(make_coop(&format!("c-{i}"))))
                     .await
                     .expect("register"),
             );
@@ -263,10 +263,7 @@ async fn double_cancel_same_id_concurrent_at_most_one_true() {
     const K: usize = 16;
     with_timeout(20, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("one")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("one")))
             .await
             .expect("register");
 
@@ -307,6 +304,7 @@ async fn rapid_short_lived_once_tasks_alive_tracker_converges_empty() {
             let h = handle.clone();
             joins.push(tokio::spawn(async move {
                 h.add(TaskSpec::once(make_ok_once(&format!("o-{i}"))))
+                    .await
                     .expect("add")
             }));
         }
@@ -332,6 +330,7 @@ async fn add_storm_with_concurrency_limit_bound_respected_no_deadlock() {
         for i in 0..N {
             handle
                 .add(TaskSpec::restartable(make_coop(&format!("lim-{i}"))))
+                .await
                 .expect("add");
         }
         assert!(
@@ -359,11 +358,28 @@ async fn add_then_immediate_shutdown_storm_returns_within_grace() {
     let handle = served(5, 0);
     const N: usize = 150;
     with_timeout(20, async {
-        let h = handle.clone();
+        let mut adds = Vec::with_capacity(N);
         for i in 0..N {
-            let _ = h.add(TaskSpec::restartable(make_coop(&format!("s-{i}"))));
+            let h = handle.clone();
+            adds.push(tokio::spawn(async move {
+                h.add(TaskSpec::restartable(make_coop(&format!("s-{i}"))))
+                    .await
+            }));
         }
-        match with_timeout(10, handle.shutdown()).await {
+        let (shutdown, add_results) = tokio::join!(with_timeout(10, handle.shutdown()), async {
+            let mut results = Vec::with_capacity(N);
+            for add in adds {
+                results.push(add.await.expect("add task must not panic"));
+            }
+            results
+        });
+        for result in add_results {
+            assert!(
+                result.is_ok() || matches!(result, Err(RuntimeError::ShuttingDown)),
+                "concurrent add must be accepted or rejected by shutdown: {result:?}"
+            );
+        }
+        match shutdown {
             Ok(()) => {}
             Err(RuntimeError::GraceExceeded { .. }) => {}
             other => panic!("shutdown must return Ok or GraceExceeded, got {other:?}"),

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -174,12 +174,9 @@ async fn cooperative_cancellation_returning_ok_yields_task_stopped() {
 
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("coop-ok")),
-                Duration::from_secs(1),
-            )
+            .add(TaskSpec::restartable(make_coop("coop-ok")))
             .await
-            .expect("add_and_wait ok");
+            .expect("add ok");
 
         assert!(handle.cancel(id).await.expect("cancel ok"));
 
@@ -223,9 +220,9 @@ async fn cancellation_returning_canceled_error_yields_task_canceled() {
 
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(TaskSpec::restartable(task), Duration::from_secs(1))
+            .add(TaskSpec::restartable(task))
             .await
-            .expect("add_and_wait ok");
+            .expect("add ok");
 
         assert!(handle.cancel(id).await.expect("cancel ok"));
 

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -23,12 +23,9 @@ fn served_with_collector(grace_secs: u64) -> (SupervisorHandle, Arc<EventCollect
 
 async fn stale_id(handle: &SupervisorHandle) -> TaskId {
     let id = handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("throwaway")),
-            Duration::from_secs(2),
-        )
+        .add(TaskSpec::restartable(make_coop("throwaway")))
         .await
-        .expect("add_and_wait ok");
+        .expect("add ok");
     assert!(handle.cancel(id).await.expect("cancel ok"));
     assert!(
         poll_until(Duration::from_secs(2), || async {
@@ -45,6 +42,7 @@ async fn add_returns_taskid_and_task_runs() {
     with_timeout(10, async {
         let id = handle
             .add(TaskSpec::restartable(make_coop("worker")))
+            .await
             .expect("add ok");
         assert!(
             poll_until(Duration::from_secs(2), || async {
@@ -61,16 +59,13 @@ async fn add_returns_taskid_and_task_runs() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn add_and_wait_confirms_running_returns_id() {
+async fn add_confirms_registration_and_returns_id() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("w")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("w")))
             .await
-            .expect("add_and_wait ok");
+            .expect("add ok");
         assert!(
             poll_until(Duration::from_secs(1), || async {
                 handle.is_alive("w").await
@@ -87,37 +82,31 @@ async fn add_and_wait_confirms_running_returns_id() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn two_tasks_same_name_get_different_ids_only_first_runs() {
-    let (handle, collector) = served_with_collector(5);
+async fn duplicate_add_returns_error_and_only_first_runs() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let (handle, _collector) = served_with_collector(5);
     with_timeout(10, async {
         let id1 = handle
             .add(TaskSpec::restartable(make_coop("dup")))
-            .expect("add1");
-        let id2 = handle
-            .add(TaskSpec::restartable(make_coop("dup")))
-            .expect("add2");
-        assert_ne!(id1, id2, "same name must still mint distinct ids");
-
-        assert!(
-            poll_until(Duration::from_secs(2), || async {
-                collector
-                    .by_id(id1)
-                    .iter()
-                    .any(|e| e.kind == EventKind::TaskAdded)
-                    && collector
-                        .by_id(id2)
-                        .iter()
-                        .any(|e| e.kind == EventKind::TaskAddFailed)
-            })
             .await
-        );
+            .expect("add1");
 
-        let failed = collector
-            .by_id(id2)
-            .into_iter()
-            .find(|e| e.kind == EventKind::TaskAddFailed)
-            .unwrap();
-        assert!(failed.reason.as_deref().unwrap().contains("already_exists"));
+        let rejected_runs = Arc::new(AtomicUsize::new(0));
+        let task_runs = Arc::clone(&rejected_runs);
+        let rejected: TaskRef = TaskFn::arc("dup", move |_ctx: TaskContext| {
+            task_runs.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let error = handle
+            .add(TaskSpec::once(rejected))
+            .await
+            .expect_err("duplicate add must fail");
+        assert!(matches!(
+            error,
+            RuntimeError::TaskAlreadyExists { ref name } if name.as_ref() == "dup"
+        ));
+        assert_eq!(rejected_runs.load(Ordering::SeqCst), 0);
 
         let list = handle.list().await;
         assert_eq!(list.len(), 1);
@@ -129,21 +118,15 @@ async fn two_tasks_same_name_get_different_ids_only_first_runs() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn add_and_wait_duplicate_name_returns_already_exists() {
+async fn add_duplicate_name_returns_already_exists() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let _ = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("dup")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("dup")))
             .await
             .expect("first add ok");
         let err = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("dup")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("dup")))
             .await
             .expect_err("second add must fail");
         match err {
@@ -156,23 +139,14 @@ async fn add_and_wait_duplicate_name_returns_already_exists() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn add_and_wait_tiny_timeout_accepts_ok_or_addtimeout() {
+async fn fast_task_registration_has_no_library_timeout() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
-        let res = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("slow_reg")),
-                Duration::from_millis(1),
-            )
-            .await;
-        match res {
-            Ok(_) => {}
-            Err(RuntimeError::TaskAddTimeout { name, timeout }) => {
-                assert_eq!(&*name, "slow_reg");
-                assert_eq!(timeout, Duration::from_millis(1));
-            }
-            other => panic!("unexpected result: {other:?}"),
-        }
+        let id = handle
+            .add(TaskSpec::once(make_ok_once("fast-registration")))
+            .await
+            .expect("registry reply must confirm even a fast task");
+        assert!(id.get() > 0);
         let _ = handle.shutdown().await;
     })
     .await;
@@ -183,17 +157,11 @@ async fn remove_by_id_removes_only_that_id() {
     let (handle, collector) = served_with_collector(5);
     with_timeout(10, async {
         let id_a = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("a")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("a")))
             .await
             .expect("add a");
         let id_b = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("b")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("b")))
             .await
             .expect("add b");
 
@@ -223,20 +191,14 @@ async fn remove_unknown_id_is_noop_without_terminal_event() {
     let (handle, collector) = served_with_collector(5);
     with_timeout(10, async {
         let id_keep = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("keep")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("keep")))
             .await
             .expect("add keep");
         let stale = stale_id(&handle).await;
 
         handle.remove(stale).expect("remove stale ok");
         handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("remove-unknown-barrier")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("remove-unknown-barrier")))
             .await
             .expect("later add confirms that the unknown remove was processed");
         assert!(
@@ -258,10 +220,7 @@ async fn remove_by_label_returns_true_then_false() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let _ = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("svc")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("svc")))
             .await
             .expect("add svc");
 
@@ -289,10 +248,7 @@ async fn cancel_by_id_true_then_false_on_double_cancel() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("c")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("c")))
             .await
             .expect("add c");
         assert!(handle.cancel(id).await.expect("cancel1"));
@@ -319,10 +275,7 @@ async fn cancel_by_label_true_then_false() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let _ = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("lbl")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("lbl")))
             .await
             .expect("add lbl");
         assert!(handle.cancel_by_label("lbl").await.expect("c1"));
@@ -345,10 +298,7 @@ async fn cancel_with_timeout_true_for_cooperative_task() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("coop")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("coop")))
             .await
             .expect("add coop");
         assert!(
@@ -372,7 +322,7 @@ async fn cancel_with_timeout_errors_on_stuck_task() {
             Ok(())
         });
         let id = handle
-            .add_and_wait(TaskSpec::restartable(task), Duration::from_secs(2))
+            .add(TaskSpec::restartable(task))
             .await
             .expect("add stubborn");
 
@@ -414,7 +364,7 @@ async fn individually_removed_stuck_task_is_force_aborted_after_grace() {
             Ok(())
         });
         let id = handle
-            .add_and_wait(TaskSpec::restartable(task), Duration::from_secs(2))
+            .add(TaskSpec::restartable(task))
             .await
             .expect("add stuck-runner");
 
@@ -440,24 +390,15 @@ async fn list_reflects_registered_set_sorted_by_id() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let id_x = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("x")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("x")))
             .await
             .unwrap();
         let id_y = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("y")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("y")))
             .await
             .unwrap();
         let id_z = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("z")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("z")))
             .await
             .unwrap();
 
@@ -489,17 +430,11 @@ async fn snapshot_and_is_alive_track_alive_set() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let _ = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("live")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("live")))
             .await
             .unwrap();
         let _ = handle
-            .add_and_wait(
-                TaskSpec::once(make_ok_once("oneshot")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::once(make_ok_once("oneshot")))
             .await
             .unwrap();
 
@@ -546,10 +481,7 @@ async fn events_carry_correct_id_across_full_lifecycle() {
     let (handle, collector) = served_with_collector(5);
     with_timeout(10, async {
         let id = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("life")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("life")))
             .await
             .unwrap();
         assert!(handle.cancel(id).await.expect("cancel"));
@@ -582,10 +514,7 @@ async fn re_add_same_label_after_removal_succeeds_with_new_id() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
         let id1 = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("reuse")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("reuse")))
             .await
             .unwrap();
         assert!(handle.cancel(id1).await.expect("cancel"));
@@ -596,10 +525,7 @@ async fn re_add_same_label_after_removal_succeeds_with_new_id() {
             .await
         );
         let id2 = handle
-            .add_and_wait(
-                TaskSpec::restartable(make_coop("reuse")),
-                Duration::from_secs(2),
-            )
+            .add(TaskSpec::restartable(make_coop("reuse")))
             .await
             .unwrap();
         assert_ne!(id1, id2, "re-added label must get a fresh id");
@@ -619,15 +545,10 @@ async fn add_after_shutdown_returns_shutting_down() {
         with_timeout(5, handle.shutdown())
             .await
             .expect("shutdown ok");
-        assert!(
-            poll_until(Duration::from_secs(2), || async {
-                matches!(
-                    h2.add(TaskSpec::once(make_ok_once("late"))),
-                    Err(RuntimeError::ShuttingDown)
-                )
-            })
-            .await
-        );
+        assert!(matches!(
+            h2.add(TaskSpec::once(make_ok_once("late"))).await,
+            Err(RuntimeError::ShuttingDown)
+        ));
     })
     .await;
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -311,10 +311,7 @@ async fn always_interval_none_restarts_repeatedly_no_backoff_scheduled() {
     let spec = TaskSpec::restartable(task).with_restart(RestartPolicy::Always { interval: None });
 
     with_timeout(15, async {
-        handle
-            .add_and_wait(spec, Duration::from_secs(1))
-            .await
-            .expect("add_and_wait ok");
+        handle.add(spec).await.expect("add ok");
         assert!(
             poll_until(Duration::from_secs(5), || async {
                 counter.load(Ordering::SeqCst) >= 5
@@ -355,10 +352,7 @@ async fn always_interval_some_emits_success_source_backoff_between_runs() {
     });
 
     with_timeout(15, async {
-        handle
-            .add_and_wait(spec, Duration::from_secs(1))
-            .await
-            .expect("add_and_wait ok");
+        handle.add(spec).await.expect("add ok");
         assert!(
             poll_until(Duration::from_secs(5), || async {
                 counter.load(Ordering::SeqCst) >= 3
@@ -410,10 +404,7 @@ async fn success_driven_restart_does_not_consume_failure_retry_budget() {
         .with_backoff(fast_backoff());
 
     with_timeout(15, async {
-        handle
-            .add_and_wait(spec, Duration::from_secs(1))
-            .await
-            .expect("add_and_wait ok");
+        handle.add(spec).await.expect("add ok");
         assert!(
             poll_until(Duration::from_secs(5), || async {
                 n.load(Ordering::SeqCst) >= 6

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -135,10 +135,7 @@ async fn subscriber_deadline_bounds_explicit_shutdown() {
     let handle = supervisor.serve();
 
     let add_result = handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("subscriber-deadline")),
-            Duration::from_secs(5),
-        )
+        .add(TaskSpec::restartable(make_coop("subscriber-deadline")))
         .await;
     let callback_entered = wait_for_callback(&gate, |state| state.entered).await;
     let mut shutdown_task = tokio::spawn(async move { handle.shutdown().await });
@@ -234,17 +231,11 @@ async fn subscriber_deadline_bounds_natural_run_completion() {
 async fn shutdown_cooperative_returns_ok_emits_all_stopped_within_grace() {
     let (handle, collector) = served(Duration::from_secs(5));
     handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("c1")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::restartable(make_coop("c1")))
         .await
         .unwrap();
     handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("c2")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::restartable(make_coop("c2")))
         .await
         .unwrap();
 
@@ -269,10 +260,7 @@ async fn shutdown_cooperative_returns_ok_emits_all_stopped_within_grace() {
 async fn shutdown_stubborn_under_small_grace_returns_grace_exceeded_force_aborts() {
     let (handle, collector) = served(Duration::from_millis(200));
     handle
-        .add_and_wait(
-            TaskSpec::once(make_stubborn("stubborn")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::once(make_stubborn("stubborn")))
         .await
         .unwrap();
 
@@ -305,17 +293,11 @@ async fn shutdown_empty_registry_returns_ok_all_stopped() {
 async fn shutdown_mixed_reports_only_stubborn_in_stuck() {
     let (handle, collector) = served(Duration::from_millis(500));
     handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("coop")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::restartable(make_coop("coop")))
         .await
         .unwrap();
     handle
-        .add_and_wait(
-            TaskSpec::once(make_stubborn("stuck")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::once(make_stubborn("stuck")))
         .await
         .unwrap();
 
@@ -337,7 +319,7 @@ async fn shutdown_mixed_reports_only_stubborn_in_stuck() {
 async fn shutdown_zero_grace_force_terminates_stubborn_immediately() {
     let (handle, collector) = served(Duration::ZERO);
     handle
-        .add_and_wait(TaskSpec::once(make_stubborn("z")), Duration::from_secs(1))
+        .add(TaskSpec::once(make_stubborn("z")))
         .await
         .unwrap();
 
@@ -355,17 +337,11 @@ async fn shutdown_zero_grace_force_terminates_stubborn_immediately() {
 async fn shutdown_emits_task_removed_for_each_drained_task() {
     let (handle, collector) = served(Duration::from_secs(5));
     let id_a = handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("a")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::restartable(make_coop("a")))
         .await
         .unwrap();
     let id_b = handle
-        .add_and_wait(
-            TaskSpec::restartable(make_coop("b")),
-            Duration::from_secs(1),
-        )
+        .add(TaskSpec::restartable(make_coop("b")))
         .await
         .unwrap();
 

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -8,8 +8,6 @@ use std::time::Duration;
 use common::*;
 use taskvisor::prelude::*;
 
-const ADD_TIMEOUT: Duration = Duration::from_secs(1);
-
 fn supervisor() -> (std::sync::Arc<Supervisor>, SupervisorHandle) {
     let sup = Supervisor::new(SupervisorConfig::default(), vec![]);
     let handle = sup.serve();
@@ -29,7 +27,7 @@ async fn outcome_reason_is_byte_identical_to_the_event_reason() {
         .with_backoff(fast_backoff())
         .with_max_retries(NonZeroU32::new(2).unwrap());
     let (id, waiter) = handle
-        .add_and_watch(spec, ADD_TIMEOUT)
+        .add_and_watch(spec)
         .await
         .expect("add_and_watch should succeed");
 
@@ -74,7 +72,7 @@ async fn completed_outcome_for_successful_once_task() {
     let (_sup, handle) = supervisor();
 
     let (id, waiter) = handle
-        .add_and_watch(TaskSpec::once(make_ok_once("ok")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::once(make_ok_once("ok")))
         .await
         .expect("add_and_watch should succeed");
     assert_eq!(waiter.id(), id);
@@ -96,7 +94,7 @@ async fn failed_outcome_carries_reason_and_exit_code() {
         .with_backoff(fast_backoff())
         .with_max_retries(NonZeroU32::new(2).unwrap());
     let (_id, waiter) = handle
-        .add_and_watch(spec, ADD_TIMEOUT)
+        .add_and_watch(spec)
         .await
         .expect("add_and_watch should succeed");
 
@@ -124,10 +122,7 @@ async fn fatal_outcome_for_fatal_error() {
     let (_sup, handle) = supervisor();
 
     let (_id, waiter) = handle
-        .add_and_watch(
-            TaskSpec::restartable(make_fatal("doomed", Some(137))),
-            ADD_TIMEOUT,
-        )
+        .add_and_watch(TaskSpec::restartable(make_fatal("doomed", Some(137))))
         .await
         .expect("add_and_watch should succeed");
 
@@ -155,7 +150,7 @@ async fn failed_outcome_after_task_panic_with_never_policy() {
     let (_sup, handle) = supervisor();
 
     let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::once(make_panic("kaboom")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::once(make_panic("kaboom")))
         .await
         .expect("add_and_watch should succeed");
 
@@ -183,7 +178,7 @@ async fn spurious_canceled_return_resolves_canceled_outcome() {
         Err(TaskError::Canceled)
     });
     let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::restartable(liar), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(liar))
         .await
         .expect("add_and_watch should succeed");
 
@@ -212,7 +207,7 @@ async fn shutdown_drain_force_aborts_stubborn_watched_task() {
         Ok(())
     });
     let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::once(stubborn), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::once(stubborn))
         .await
         .expect("add_and_watch should succeed");
 
@@ -236,7 +231,7 @@ async fn waiter_stays_pending_across_periodic_reruns() {
             interval: Some(Duration::from_millis(20)),
         });
     let (id, waiter) = handle
-        .add_and_watch(spec, ADD_TIMEOUT)
+        .add_and_watch(spec)
         .await
         .expect("add_and_watch should succeed");
 
@@ -255,7 +250,7 @@ async fn cancelled_outcome_when_task_is_cancelled() {
     let (_sup, handle) = supervisor();
 
     let (id, waiter) = handle
-        .add_and_watch(TaskSpec::restartable(make_coop("coop")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(make_coop("coop")))
         .await
         .expect("add_and_watch should succeed");
 
@@ -284,7 +279,7 @@ async fn force_aborted_outcome_for_noncooperative_task() {
         Ok(())
     });
     let (id, waiter) = handle
-        .add_and_watch(TaskSpec::once(stubborn), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::once(stubborn))
         .await
         .expect("add_and_watch should succeed");
 
@@ -303,12 +298,12 @@ async fn duplicate_name_returns_already_exists_not_a_waiter() {
     let (_sup, handle) = supervisor();
 
     let first = handle
-        .add_and_watch(TaskSpec::restartable(make_coop("dup")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(make_coop("dup")))
         .await;
     assert!(first.is_ok(), "first add must succeed");
 
     let second = handle
-        .add_and_watch(TaskSpec::restartable(make_coop("dup")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(make_coop("dup")))
         .await;
     assert!(
         matches!(second, Err(RuntimeError::TaskAlreadyExists { .. })),
@@ -323,7 +318,7 @@ async fn shutdown_resolves_pending_waiters() {
     let (_sup, handle) = supervisor();
 
     let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::restartable(make_coop("worker")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(make_coop("worker")))
         .await
         .expect("add_and_watch should succeed");
 
@@ -347,7 +342,7 @@ async fn dropping_waiter_does_not_affect_task() {
     let (_sup, handle) = supervisor();
 
     let (id, waiter) = handle
-        .add_and_watch(TaskSpec::restartable(make_coop("ignored")), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::restartable(make_coop("ignored")))
         .await
         .expect("add_and_watch should succeed");
     drop(waiter);
@@ -379,7 +374,7 @@ async fn outcome_is_delivered_even_under_bus_lag() {
         .with_backoff(fast_backoff())
         .with_max_retries(NonZeroU32::new(5).unwrap());
     let (_id, waiter) = handle
-        .add_and_watch(spec, ADD_TIMEOUT)
+        .add_and_watch(spec)
         .await
         .expect("add_and_watch should succeed");
 
@@ -406,7 +401,7 @@ async fn task_error_source_survives_end_to_end_to_the_outcome() {
     });
 
     let (_id, waiter) = handle
-        .add_and_watch(TaskSpec::once(task), ADD_TIMEOUT)
+        .add_and_watch(TaskSpec::once(task))
         .await
         .expect("add_and_watch should succeed");
 


### PR DESCRIPTION
## 📝 Description

- Made `add` async.
- `Add` now waits for free queue space.
- `Add` returns Ok(id) only after the registry accepts the task.
- Added `try_add` for callers that do not want to wait for queue space.
- Made `add_and_watch` wait for the registry reply.

## 🔄 Related Issues
Resolves #121

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] `task ci` passes locally

## New API
```rust
let id = handle.add(spec).await?;
let id = handle.try_add(spec).await?;
let (id, waiter) = handle.add_and_watch(spec).await?;
```
