### PR TITLE
[core] re-build registry process

### DIFF
--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -43,7 +43,7 @@
 //!
 //! - `sup.serve()`: starts listeners, returns a handle. Non-blocking.
 //! - `handle.add(spec).await`: register a new task dynamically, returns its `TaskId`.
-//! - `handle.remove(id)`: cancel and deregister by identity (or `remove_by_label(name)`).
+//! - `handle.remove(id).await`: claim removal by identity (or `remove_by_label(name).await`).
 //! - `handle.cancel(id)`: cancel and wait for confirmation (or `cancel_by_label(name)`).
 //! - `handle.list()`: snapshot of active `(TaskId, name)` pairs.
 //! - `handle.is_alive(name)`: check if a specific task is running.
@@ -111,7 +111,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Remove worker-a
     println!("\nRemoving worker-a...");
-    handle.remove(id_a)?;
+    let removed = handle.remove(id_a).await?;
+    println!("worker-a removal claimed: {removed}");
     tokio::time::sleep(Duration::from_millis(200)).await;
     println!("Active: {:?}", handle.list().await);
 

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -411,7 +411,7 @@ impl Controller {
             }
             (SlotStatus::Running { .. }, AdmissionPolicy::Replace) => {
                 if let Some(rid) = slot.running_id
-                    && let Err(e) = sup.remove(rid)
+                    && let Err(e) = sup.try_remove(rid).await
                 {
                     let reason = format!("remove_failed: {e}");
                     self.bus.publish(
@@ -595,7 +595,7 @@ impl Controller {
             }
             SlotStatus::Terminating { .. } => {
                 if let Some(rid) = slot.running_id
-                    && let Err(e) = sup.remove(rid)
+                    && let Err(e) = sup.try_remove(rid).await
                 {
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)

--- a/src/controller/core/recovery.rs
+++ b/src/controller/core/recovery.rs
@@ -84,7 +84,7 @@ impl Controller {
                     }
                     SlotStatus::Terminating { .. } => {
                         if let Some(rid) = slot.running_id
-                            && let Err(e) = sup.remove(rid)
+                            && let Err(e) = sup.try_remove(rid).await
                         {
                             self.bus.publish(
                                 Event::new(EventKind::ControllerRejected)

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -161,45 +161,54 @@ impl SupervisorHandle {
 
     /// Removes a task by identity.
     ///
-    /// This is fire-and-forget.
-    /// It reserves command queue capacity, publishes `TaskRemoveRequested`, queues a remove command, and returns.
+    /// This waits for command queue capacity and then for the direct registry reply.
+    /// `Ok(true)` means this call claimed the task, changed it to `Removing`, and sent cancellation.
+    /// `Ok(false)` means the task was unknown, already removing, or already terminated.
     ///
-    /// `Ok(())` does not mean the task existed or has already stopped.
-    /// Unknown ids are handled by the registry as no-op removals.
+    /// This does not wait for terminal task cleanup.
+    /// Use [`cancel`](Self::cancel) when the call must return after termination.
     ///
-    /// Use [`cancel`](Self::cancel) when you need to wait for `TaskRemoved`, or [`remove_by_label`](Self::remove_by_label) when you only have a task name.
+    /// Dropping this future after its command was queued does not roll the Remove back.
+    /// The registry may still claim and remove the task.
+    ///
+    /// # Errors
+    ///
+    /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
+    pub async fn remove(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        self.core.remove(id).await
+    }
+
+    /// Tries to remove a task without waiting for command queue capacity.
+    ///
+    /// When queue admission succeeds, this still waits for the direct registry reply.
+    /// Its boolean result has the same meaning as [`remove`](Self::remove).
     ///
     /// # Errors
     ///
     /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
-    pub fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
-        self.core.remove(id)
+    pub async fn try_remove(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        self.core.try_remove(id).await
     }
 
     /// Removes the task currently holding `name`.
     ///
-    /// Returns `Ok(true)` when a task with this label was found and the remove command was queued.
-    /// Returns `Ok(false)` when no registered task currently has this label.
+    /// Label lookup and the `Registered` to `Removing` transition happen in one registry operation.
+    /// `Ok(true)` means this call claimed the label owner and sent cancellation.
+    /// `Ok(false)` means there was no registered owner to claim.
+    /// This does not wait for terminal task cleanup.
     ///
     /// # Errors
     ///
-    /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub async fn remove_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
-        match self.core.id_for_label(name).await {
-            Some(id) => {
-                self.core.remove(id)?;
-                Ok(true)
-            }
-            None => Ok(false),
-        }
+        self.core.remove_by_label(Arc::from(name)).await
     }
 
     /// Returns registered tasks as `(id, label)` pairs.
     ///
     /// The list comes from the registry and is sorted by [`TaskId`].
-    /// It includes registered tasks in any lifecycle state, including starting, running, and stopping.
+    /// It includes both `Registered` and `Removing` tasks.
     ///
     /// See [`snapshot`](Self::snapshot) for the best-effort list of task names currently marked alive.
     pub async fn list(&self) -> Vec<(TaskId, Arc<str>)> {

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -35,15 +35,17 @@
 //!   -> publish TaskAdded
 //!
 //! Remove(id)
-//!   -> remove handle from registry
+//!   -> change Registered to Removing
 //!   -> cancel actor token
 //!   -> reply claimed
 //!   -> join actor
+//!   -> release id/name indexes
 //!   -> publish TaskRemoved
 //!
 //! Actor completion(id)
-//!   -> remove handle from registry
+//!   -> change Registered to Removing
 //!   -> join actor
+//!   -> release id/name indexes
 //!   -> publish TaskRemoved
 //! ```
 //!
@@ -53,8 +55,9 @@
 //! - Command replies report registry decisions, not terminal task outcomes.
 //! - Cleanup is idempotent. Duplicate or stale completion signals become no-ops.
 //! - The registry does not clean up on `TaskStopped` or `TaskFailed`.
-//! - Task name is a human label and a duplicate-name admission gate.
-//!   Cleanup waits for the actor completion signal and join result.
+//! - Task name is a label and a duplicate-name admission gate; reserved while the task is `Registered` or `Removing`.
+//! - `list`, identity lookup, and empty checks include removing tasks.
+//! - Cleanup waits for the actor completion signal and join result.
 //! - `TaskRemoved` means the registry has finished cleanup for that identity.
 //! - `TaskId` is the canonical identity.
 
@@ -112,8 +115,27 @@ pub(crate) enum RegistryCommand {
 struct Handle {
     join: JoinHandle<ActorExitReason>,
     cancel: CancellationToken,
-    label: Arc<str>,
     done: Option<OutcomeTx>,
+}
+
+/// Lifecycle phase of one authoritative registry entry.
+enum EntryState {
+    /// The actor can still be claimed by remove, completion, or shutdown.
+    Registered(Handle),
+    /// One owner has the actor handle and is waiting for its terminal join.
+    Removing,
+}
+
+/// Authoritative membership record kept until terminal join cleanup finishes.
+struct Entry {
+    label: Arc<str>,
+    state: EntryState,
+}
+
+/// Terminal result passed from the single join owner to registry cleanup.
+enum JoinCompletion {
+    Joined(Result<ActorExitReason, JoinError>),
+    ForceAborted,
 }
 
 /// Sends one completion signal when an actor task returns, panics, or is aborted.
@@ -134,7 +156,9 @@ impl Drop for ActorCompletionGuard {
 #[derive(Default)]
 struct Inner {
     /// Canonical task map keyed by runtime identity.
-    tasks: HashMap<TaskId, Handle>,
+    ///
+    /// Entries stay here in both `Registered` and `Removing` phases.
+    tasks: HashMap<TaskId, Entry>,
 
     /// Label lookup used for duplicate-name checks and label-based operations.
     by_label: HashMap<Arc<str>, TaskId>,
@@ -150,9 +174,9 @@ struct PendingInner {
     labels: HashMap<TaskId, Arc<str>>,
 }
 
-/// Tracks actor joins that are running outside the registry map.
+/// Tracks actor joins owned by removing entries.
 ///
-/// This is used after remove/cleanup paths move a handle out of `state.tasks` but still need to wait for the actor join and final `TaskRemoved`.
+/// This provides shutdown diagnostics and a wait barrier while the registry map remains the authority for task membership.
 #[derive(Default)]
 struct PendingJoins {
     inner: std::sync::Mutex<PendingInner>,
@@ -250,12 +274,12 @@ impl PendingJoins {
 /// - [`SupervisorCore`](super::runtime::SupervisorCore) - sends registry commands
 /// - [`TaskOutcome`] - final result for watched tasks
 pub(crate) struct Registry {
-    state: RwLock<Inner>,
+    state: Arc<RwLock<Inner>>,
     bus: Bus,
     runtime_token: CancellationToken,
     semaphore: Option<Arc<Semaphore>>,
     grace: Duration,
-    empty_notify: Notify,
+    empty_notify: Arc<Notify>,
     cmd_rx: std::sync::Mutex<Option<mpsc::Receiver<RegistryCommand>>>,
     completion_tx: mpsc::UnboundedSender<TaskId>,
     completion_rx: std::sync::Mutex<Option<mpsc::UnboundedReceiver<TaskId>>>,
@@ -274,12 +298,12 @@ impl Registry {
     ) -> Arc<Self> {
         let (completion_tx, completion_rx) = mpsc::unbounded_channel();
         Arc::new(Self {
-            state: RwLock::new(Inner::default()),
+            state: Arc::new(RwLock::new(Inner::default())),
             bus,
             runtime_token,
             semaphore,
             grace,
-            empty_notify: Notify::new(),
+            empty_notify: Arc::new(Notify::new()),
             cmd_rx: std::sync::Mutex::new(Some(cmd_rx)),
             completion_tx,
             completion_rx: std::sync::Mutex::new(Some(completion_rx)),
@@ -288,7 +312,7 @@ impl Registry {
         })
     }
 
-    /// Returns true when `id` is no longer registered and has no join in flight.
+    /// Returns true when `id` has no registry entry and no join in flight.
     ///
     /// Used as a fallback when a `TaskRemoved` event may have been missed because of broadcast lag.
     pub async fn is_terminated(&self, id: TaskId) -> bool {
@@ -300,8 +324,8 @@ impl Registry {
 
     /// Waits for detached join reporters to finish.
     ///
-    /// Detached join reporters are created after remove/cleanup paths take a task out of `state.tasks`.
-    /// They are no longer covered by [`cancel_all_within`](Self::cancel_all_within), but shutdown still needs their final `TaskRemoved` events before the subscriber listener stops.
+    /// Join reporters own actor handles for entries in the `Removing` phase.
+    /// Shutdown still needs their final `TaskRemoved` events before the subscriber listener stops.
     ///
     /// Returns labels for joins still in flight after `grace`.
     pub async fn wait_joins_within(&self, grace: Duration) -> Vec<Arc<str>> {
@@ -309,22 +333,14 @@ impl Registry {
         self.pending_joins.pending_labels()
     }
 
-    #[inline]
-    fn notify_after_remove(&self, len_after: usize) {
-        if len_after == 0 {
-            self.empty_notify.notify_one();
-        }
-    }
-
-    /// Waits until no tasks remain registered.
-    ///
-    /// This only checks the registry map.
-    /// Detached joins may still be in flight; use [`wait_joins_within`](Self::wait_joins_within) for those.
+    /// Waits until no registered or removing tasks remain.
     ///
     /// Uses register-before-check to avoid losing a wakeup.
     pub async fn wait_until_empty(&self) {
         loop {
             let notified = self.empty_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if self.is_empty().await {
                 return;
             }
@@ -437,19 +453,19 @@ impl Registry {
         }
     }
 
-    /// Returns registered tasks as `(id, label)` pairs, sorted by identity.
+    /// Returns registered and removing tasks as `(id, label)` pairs, sorted by identity.
     pub async fn list(&self) -> Vec<(TaskId, Arc<str>)> {
         let st = self.state.read().await;
         let mut v: Vec<(TaskId, Arc<str>)> = st
             .tasks
             .iter()
-            .map(|(id, h)| (*id, h.label.clone()))
+            .map(|(id, entry)| (*id, Arc::clone(&entry.label)))
             .collect();
         v.sort_by_key(|(id, _)| *id);
         v
     }
 
-    /// Returns true if `id` is currently registered.
+    /// Returns true if `id` is registered or removing.
     pub async fn contains(&self, id: TaskId) -> bool {
         self.state.read().await.tasks.contains_key(&id)
     }
@@ -459,9 +475,7 @@ impl Registry {
         self.state.read().await.by_label.get(name).copied()
     }
 
-    /// Returns true if no tasks are currently registered.
-    ///
-    /// Detached joins may still be running after the map becomes empty.
+    /// Returns true if no tasks are registered or removing.
     pub async fn is_empty(&self) -> bool {
         self.state.read().await.tasks.is_empty()
     }
@@ -469,7 +483,7 @@ impl Registry {
     /// Cancels all registered tasks and waits for them within one shared grace window.
     ///
     /// Steps:
-    /// - remove all handles from the registry map,
+    /// - change every `Registered` entry to `Removing`,
     /// - cancel every actor token,
     /// - join each actor until the shared deadline,
     /// - abort actors that do not finish in time,
@@ -478,43 +492,52 @@ impl Registry {
     /// Returns labels of tasks that were force-aborted.
     pub async fn cancel_all_within(&self, grace: Duration) -> Vec<Arc<str>> {
         let grace = grace.min(Duration::from_secs(60 * 60 * 24 * 365 * 30));
-        let handles: Vec<(TaskId, Handle)> = {
+        let handles: Vec<(TaskId, Arc<str>, Handle)> = {
             let mut st = self.state.write().await;
-            st.by_label.clear();
-            let drained = st.tasks.drain().collect::<Vec<_>>();
-            self.empty_notify.notify_waiters();
-            drained
+            let ids: Vec<TaskId> = st.tasks.keys().copied().collect();
+            ids.into_iter()
+                .filter_map(|id| {
+                    Self::claim_registered(&mut st, &self.pending_joins, id)
+                        .map(|(label, handle)| (id, label, handle))
+                })
+                .collect()
         };
-        for (id, h) in &handles {
-            self.pending_joins.inc(*id);
+        for (_, _, h) in &handles {
             h.cancel.cancel();
         }
 
         let deadline = tokio::time::Instant::now() + grace;
         let mut stuck = Vec::new();
 
-        for (id, h) in handles {
-            let label = h.label.clone();
+        for (id, label, h) in handles {
             let mut join = h.join;
             match tokio::time::timeout_at(deadline, &mut join).await {
                 Ok(res) => {
-                    self.pending_joins.dec(id);
-                    Self::report_join(&self.bus, id, &label, res, h.done);
+                    Self::finish_removal(
+                        &self.state,
+                        &self.empty_notify,
+                        &self.pending_joins,
+                        &self.bus,
+                        id,
+                        h.done,
+                        JoinCompletion::Joined(res),
+                    )
+                    .await;
                 }
                 Err(_elapsed) => {
                     join.abort();
                     let _ = join.await;
-                    self.pending_joins.dec(id);
-                    if let Some(done) = h.done {
-                        let _ = done.send(TaskOutcome::ForceAborted);
-                    }
-                    self.bus.publish(
-                        Event::new(EventKind::TaskRemoved)
-                            .with_task(Arc::clone(&label))
-                            .with_id(id)
-                            .with_reason("force_terminated_after_grace"),
-                    );
-                    stuck.push(label);
+                    stuck.push(Arc::clone(&label));
+                    Self::finish_removal(
+                        &self.state,
+                        &self.empty_notify,
+                        &self.pending_joins,
+                        &self.bus,
+                        id,
+                        h.done,
+                        JoinCompletion::ForceAborted,
+                    )
+                    .await;
                 }
             }
         }
@@ -541,8 +564,6 @@ impl Registry {
     /// Spawns an actor and registers it under `id`.
     ///
     /// Duplicate task names are rejected.
-    /// If a watched add includes `done`, it resolves as [`TaskOutcome::Rejected`]
-    /// with reason [`ALREADY_EXISTS`](crate::reasons::ALREADY_EXISTS).
     ///
     /// Direct `add_and_watch` callers still receive [`RuntimeError::TaskAlreadyExists`](crate::RuntimeError::TaskAlreadyExists) because registration confirmation fails before the waiter is returned.
     async fn spawn_and_register(
@@ -596,11 +617,13 @@ impl Registry {
 
         st.tasks.insert(
             id,
-            Handle {
-                join: join_handle,
-                cancel: task_token,
-                label: label.clone(),
-                done,
+            Entry {
+                label: Arc::clone(&label),
+                state: EntryState::Registered(Handle {
+                    join: join_handle,
+                    cancel: task_token,
+                    done,
+                }),
             },
         );
         st.by_label.insert(label.clone(), id);
@@ -620,15 +643,11 @@ impl Registry {
     ///
     /// If the task is unknown or cleanup already owns it, replies `Ok(false)` without publishing a terminal event.
     async fn remove_task(&self, id: TaskId, reply: oneshot::Sender<RemoveReply>) {
-        self.pending_joins.inc(id);
-        if let Some((handle, len_after)) = self.take_handle(id).await {
-            self.notify_after_remove(len_after);
-
+        if let Some((_label, handle)) = self.claim_task(id).await {
             handle.cancel.cancel();
             let _ = reply.send(Ok(true));
-            self.spawn_join_report(id, handle.label, handle.join, Some(self.grace), handle.done);
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
         } else {
-            self.pending_joins.dec(id);
             let _ = reply.send(Ok(false));
         }
     }
@@ -638,24 +657,40 @@ impl Registry {
     /// Called after the actor's reliable completion signal is received.
     /// Duplicate or stale completion signals are no-ops.
     async fn cleanup_task(&self, id: TaskId) {
-        self.pending_joins.inc(id);
-        if let Some((handle, len_after)) = self.take_handle(id).await {
-            self.notify_after_remove(len_after);
-            self.spawn_join_report(id, handle.label, handle.join, Some(self.grace), handle.done);
-        } else {
-            self.pending_joins.dec(id);
+        if let Some((_label, handle)) = self.claim_task(id).await {
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
         }
     }
 
-    /// Removes a handle and its label index entry atomically.
+    /// Changes one task from `Registered` to `Removing`.
     ///
-    /// Returns the removed handle and the number of registered tasks left.
-    async fn take_handle(&self, id: TaskId) -> Option<(Handle, usize)> {
+    /// The winning caller gets the only actor handle.
+    /// Identity and label indexes stay in the registry until that caller finishes the join.
+    async fn claim_task(&self, id: TaskId) -> Option<(Arc<str>, Handle)> {
         let mut st = self.state.write().await;
-        let h = st.tasks.remove(&id)?;
-        st.by_label.remove(&h.label);
-        let len_after = st.tasks.len();
-        Some((h, len_after))
+        Self::claim_registered(&mut st, &self.pending_joins, id)
+    }
+
+    /// Locked implementation of the `Registered` to `Removing` transition.
+    fn claim_registered(
+        st: &mut Inner,
+        pending_joins: &PendingJoins,
+        id: TaskId,
+    ) -> Option<(Arc<str>, Handle)> {
+        let entry = st.tasks.get_mut(&id)?;
+        if matches!(&entry.state, EntryState::Removing) {
+            return None;
+        }
+
+        let EntryState::Registered(handle) =
+            std::mem::replace(&mut entry.state, EntryState::Removing)
+        else {
+            unreachable!("a removing entry was checked above")
+        };
+        let label = Arc::clone(&entry.label);
+        pending_joins.inc(id);
+        pending_joins.label(id, Arc::clone(&label));
+        Some((label, handle))
     }
 
     /// Joins an actor in a detached task and reports its final result.
@@ -667,44 +702,86 @@ impl Registry {
     fn spawn_join_report(
         &self,
         id: TaskId,
-        name: Arc<str>,
         join: JoinHandle<ActorExitReason>,
         force_after: Option<Duration>,
         done: Option<OutcomeTx>,
     ) {
         let bus = self.bus.clone();
+        let state = Arc::clone(&self.state);
+        let empty_notify = Arc::clone(&self.empty_notify);
         let pending = Arc::clone(&self.pending_joins);
-        pending.label(id, Arc::clone(&name));
         tokio::spawn(async move {
             let mut join = join;
-            match force_after {
+            let completion = match force_after {
                 Some(grace) => match tokio::time::timeout(grace, &mut join).await {
-                    Ok(res) => {
-                        Self::report_join(&bus, id, &name, res, done);
-                        pending.dec(id);
-                    }
+                    Ok(res) => JoinCompletion::Joined(res),
                     Err(_) => {
                         join.abort();
                         let _ = join.await;
-                        if let Some(done) = done {
-                            let _ = done.send(TaskOutcome::ForceAborted);
-                        }
-                        bus.publish(
-                            Event::new(EventKind::TaskRemoved)
-                                .with_task(name)
-                                .with_id(id)
-                                .with_reason("force_terminated_after_grace"),
-                        );
-                        pending.dec(id);
+                        JoinCompletion::ForceAborted
                     }
                 },
-                None => {
-                    let res = join.await;
-                    Self::report_join(&bus, id, &name, res, done);
-                    pending.dec(id);
-                }
-            }
+                None => JoinCompletion::Joined(join.await),
+            };
+
+            Self::finish_removal(&state, &empty_notify, &pending, &bus, id, done, completion).await;
         });
+    }
+
+    /// Commits terminal cleanup for one `Removing` entry.
+    ///
+    /// State removal, outcome delivery, terminal events, and pending-join cleanup finish before an empty-registry waiter can continue.
+    async fn finish_removal(
+        state: &RwLock<Inner>,
+        empty_notify: &Notify,
+        pending_joins: &PendingJoins,
+        bus: &Bus,
+        id: TaskId,
+        done: Option<OutcomeTx>,
+        completion: JoinCompletion,
+    ) {
+        let mut st = state.write().await;
+        let is_removing = st
+            .tasks
+            .get(&id)
+            .is_some_and(|entry| matches!(&entry.state, EntryState::Removing));
+        if !is_removing {
+            drop(st);
+            pending_joins.dec(id);
+            return;
+        }
+
+        let entry = st
+            .tasks
+            .remove(&id)
+            .expect("the removing entry was checked above");
+        if st.by_label.get(entry.label.as_ref()) == Some(&id) {
+            st.by_label.remove(entry.label.as_ref());
+        }
+
+        match completion {
+            JoinCompletion::Joined(res) => {
+                Self::report_join(bus, id, &entry.label, res, done);
+            }
+            JoinCompletion::ForceAborted => {
+                if let Some(done) = done {
+                    let _ = done.send(TaskOutcome::ForceAborted);
+                }
+                bus.publish(
+                    Event::new(EventKind::TaskRemoved)
+                        .with_task(Arc::clone(&entry.label))
+                        .with_id(id)
+                        .with_reason("force_terminated_after_grace"),
+                );
+            }
+        }
+        pending_joins.dec(id);
+
+        let is_empty = st.tasks.is_empty();
+        drop(st);
+        if is_empty {
+            empty_notify.notify_waiters();
+        }
     }
 
     /// Reports the result of a joined actor.
@@ -805,6 +882,72 @@ mod tests {
         let token = CancellationToken::new();
         let (_tx, rx) = mpsc::channel(64);
         Registry::new(bus, token, None, Duration::from_secs(5), rx)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn terminal_cleanup_wakes_all_empty_waiters() {
+        use tokio::sync::Barrier;
+
+        let registry = registry();
+        let id = TaskId::next();
+        let label: Arc<str> = Arc::from("empty-waiters");
+        let mut state = registry.state.write().await;
+        state.by_label.insert(Arc::clone(&label), id);
+        state.tasks.insert(
+            id,
+            Entry {
+                label: Arc::clone(&label),
+                state: EntryState::Removing,
+            },
+        );
+        registry.pending_joins.inc(id);
+        registry.pending_joins.label(id, label);
+
+        let ready = Arc::new(Barrier::new(3));
+        let first_registry = Arc::clone(&registry);
+        let first_ready = Arc::clone(&ready);
+        let first = tokio::spawn(async move {
+            first_ready.wait().await;
+            first_registry.wait_until_empty().await;
+        });
+        let second_registry = Arc::clone(&registry);
+        let second_ready = Arc::clone(&ready);
+        let second = tokio::spawn(async move {
+            second_ready.wait().await;
+            second_registry.wait_until_empty().await;
+        });
+
+        ready.wait().await;
+        tokio::task::yield_now().await;
+        drop(state);
+
+        let state_barrier = registry.state.write().await;
+        drop(state_barrier);
+        assert!(!first.is_finished());
+        assert!(!second.is_finished());
+
+        Registry::finish_removal(
+            &registry.state,
+            &registry.empty_notify,
+            &registry.pending_joins,
+            &registry.bus,
+            id,
+            None,
+            JoinCompletion::Joined(Ok(ActorExitReason::Completed)),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(1), first)
+            .await
+            .expect("the first empty waiter must wake")
+            .expect("the first empty waiter must not panic");
+        tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("the second empty waiter must wake")
+            .expect("the second empty waiter must not panic");
+        assert!(registry.is_empty().await);
+        assert_eq!(registry.id_for_label("empty-waiters").await, None);
+        assert!(registry.pending_joins.is_empty());
     }
 
     fn started_registry(
@@ -1011,6 +1154,22 @@ mod tests {
             .await
             .expect("the task must observe cancellation");
         assert!(registry.pending_joins.contains(id));
+        assert!(
+            registry.contains(id).await,
+            "a removing task must keep its registry identity"
+        );
+        assert_eq!(
+            registry.list().await,
+            vec![(id, Arc::from("remove-once"))],
+            "a removing task must stay visible in registry listings"
+        );
+        assert_eq!(registry.id_for_label("remove-once").await, Some(id));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), registry.wait_until_empty())
+                .await
+                .is_err(),
+            "the registry cannot become empty before the actor join"
+        );
         while let Ok(event) = events.try_recv() {
             assert_ne!(
                 event.kind,
@@ -1034,6 +1193,117 @@ mod tests {
         )
         .await
         .expect("the released task must finish its join");
+        assert!(!registry.contains(id).await);
+        assert_eq!(registry.id_for_label("remove-once").await, None);
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn removing_task_keeps_label_reserved_until_terminal_join() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskError, TaskFn, TaskRef};
+
+        let (registry, _bus, token, tx) = started_registry(64, Duration::from_secs(5));
+        let cancellation_seen = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let seen_by_task = Arc::clone(&cancellation_seen);
+        let task_release = Arc::clone(&release);
+        let first: TaskRef = TaskFn::arc("reserved-name", move |ctx: TaskContext| {
+            let seen = Arc::clone(&seen_by_task);
+            let release = Arc::clone(&task_release);
+            async move {
+                ctx.cancelled().await;
+                seen.notify_one();
+                release.notified().await;
+                Err(TaskError::Canceled)
+            }
+        });
+        let first_id = TaskId::next();
+        assert!(
+            receive_reply(
+                send_add(&tx, first_id, TaskSpec::restartable(first), None),
+                "reserved-name add reply",
+            )
+            .await
+            .is_ok()
+        );
+        assert!(matches!(
+            receive_reply(send_remove(&tx, first_id), "reserved-name remove reply").await,
+            Ok(true)
+        ));
+        tokio::time::timeout(Duration::from_secs(2), cancellation_seen.notified())
+            .await
+            .expect("the old task must observe cancellation");
+
+        let duplicate_runs = Arc::new(AtomicUsize::new(0));
+        let runs_by_task = Arc::clone(&duplicate_runs);
+        let duplicate: TaskRef = TaskFn::arc("reserved-name", move |_ctx: TaskContext| {
+            runs_by_task.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        let duplicate_id = TaskId::next();
+        let duplicate_reply = receive_reply(
+            send_add(&tx, duplicate_id, TaskSpec::once(duplicate), None),
+            "removing duplicate add reply",
+        )
+        .await;
+        assert!(
+            matches!(
+                duplicate_reply,
+                Err(RuntimeError::TaskAlreadyExists { name })
+                    if name.as_ref() == "reserved-name"
+            ),
+            "a removing task must keep its label reserved"
+        );
+        assert_eq!(
+            duplicate_runs.load(Ordering::SeqCst),
+            0,
+            "a rejected replacement body must not run"
+        );
+        assert_eq!(registry.id_for_label("reserved-name").await, Some(first_id));
+        assert_eq!(
+            registry.list().await,
+            vec![(first_id, Arc::from("reserved-name"))]
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), registry.wait_until_empty())
+                .await
+                .is_err(),
+            "terminal join must control when the registry becomes empty"
+        );
+
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
+            .await
+            .expect("terminal join must release the old task identity");
+        assert_eq!(registry.id_for_label("reserved-name").await, None);
+        assert!(!registry.pending_joins.contains(first_id));
+
+        let replacement: TaskRef = TaskFn::arc("reserved-name", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let replacement_id = TaskId::next();
+        assert!(
+            receive_reply(
+                send_add(
+                    &tx,
+                    replacement_id,
+                    TaskSpec::restartable(replacement),
+                    None,
+                ),
+                "replacement add reply",
+            )
+            .await
+            .is_ok(),
+            "the label must be reusable after terminal cleanup"
+        );
+        assert_eq!(
+            registry.id_for_label("reserved-name").await,
+            Some(replacement_id)
+        );
+
         stop_registry(&registry, &token).await;
     }
 
@@ -1367,11 +1637,13 @@ mod tests {
         state.by_label.insert(Arc::clone(&label), id);
         state.tasks.insert(
             id,
-            Handle {
-                join,
-                cancel: CancellationToken::new(),
+            Entry {
                 label: Arc::clone(&label),
-                done: Some(done),
+                state: EntryState::Registered(Handle {
+                    join,
+                    cancel: CancellationToken::new(),
+                    done: Some(done),
+                }),
             },
         );
         drop(state);
@@ -1476,7 +1748,7 @@ mod tests {
     async fn completion_claim_before_remove_emits_one_terminal_event() {
         use crate::{TaskContext, TaskFn, TaskRef};
 
-        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(1));
+        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(5));
         let mut events = bus.subscribe();
         let release = Arc::new(Notify::new());
         let task_release = Arc::clone(&release);
@@ -1503,10 +1775,23 @@ mod tests {
             .completion_tx
             .send(id)
             .expect("completion receiver must be open");
-        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
-            .await
-            .expect("completion branch must claim the handle");
+        assert!(matches!(
+            receive_reply(
+                send_remove(&tx, TaskId::next()),
+                "completion claim barrier reply",
+            )
+            .await,
+            Ok(false)
+        ));
         assert!(registry.pending_joins.contains(id));
+        assert!(registry.contains(id).await);
+        assert_eq!(registry.id_for_label("completion-first").await, Some(id));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), registry.wait_until_empty())
+                .await
+                .is_err(),
+            "completion ownership must retain membership until join"
+        );
         assert!(matches!(
             receive_reply(send_remove(&tx, id), "completion-first remove reply").await,
             Ok(false)
@@ -1522,12 +1807,10 @@ mod tests {
             receive_reply(done_rx, "completion-first outcome").await,
             TaskOutcome::Completed
         ));
-        tokio::time::timeout(
-            Duration::from_secs(2),
-            registry.pending_joins.wait_drained(),
-        )
-        .await
-        .expect("completion-owned join must drain");
+        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
+            .await
+            .expect("completion-owned join must finish registry cleanup");
+        assert!(!registry.pending_joins.contains(id));
 
         assert!(matches!(
             receive_reply(

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -104,9 +104,16 @@ pub(crate) enum RegistryCommand {
     },
     /// Remove a task by runtime identity.
     ///
-    /// The public caller publishes `TaskRemoveRequested` before sending this.
+    /// The identity caller publishes `TaskRemoveRequested` before sending this.
     Remove {
         id: TaskId,
+        reply: oneshot::Sender<RemoveReply>,
+    },
+    /// Resolve a label and claim its current owner in one registry operation.
+    ///
+    /// The registry publishes `TaskRemoveRequested` with the resolved identity before it attempts the state transition.
+    RemoveByLabel {
+        label: Arc<str>,
         reply: oneshot::Sender<RemoveReply>,
     },
 }
@@ -393,6 +400,9 @@ impl Registry {
                         Some(RegistryCommand::Remove { id, reply }) => {
                             me.guarded("registry", me.remove_task(id, reply)).await;
                         }
+                        Some(RegistryCommand::RemoveByLabel { label, reply }) => {
+                            me.guarded("registry", me.remove_task_by_label(label, reply)).await;
+                        }
                         None => break,
                     }
                 }
@@ -413,6 +423,10 @@ impl Registry {
                     }
                     RegistryCommand::Remove { id, reply } => {
                         me.guarded("registry", me.remove_task(id, reply)).await;
+                    }
+                    RegistryCommand::RemoveByLabel { label, reply } => {
+                        me.guarded("registry", me.remove_task_by_label(label, reply))
+                            .await;
                     }
                 }
             }
@@ -644,6 +658,37 @@ impl Registry {
     /// If the task is unknown or cleanup already owns it, replies `Ok(false)` without publishing a terminal event.
     async fn remove_task(&self, id: TaskId, reply: oneshot::Sender<RemoveReply>) {
         if let Some((_label, handle)) = self.claim_task(id).await {
+            handle.cancel.cancel();
+            let _ = reply.send(Ok(true));
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
+        } else {
+            let _ = reply.send(Ok(false));
+        }
+    }
+
+    /// Resolves one label and claims its current owner under the same state lock.
+    ///
+    /// A missing label returns `Ok(false)` without a request event.
+    /// An owner that is already `Removing` keeps its request event but also returns `Ok(false)`.
+    async fn remove_task_by_label(&self, label: Arc<str>, reply: oneshot::Sender<RemoveReply>) {
+        let claimed = {
+            let mut st = self.state.write().await;
+            let Some(id) = st.by_label.get(label.as_ref()).copied() else {
+                drop(st);
+                let _ = reply.send(Ok(false));
+                return;
+            };
+
+            self.bus.publish(
+                Event::new(EventKind::TaskRemoveRequested)
+                    .with_task(Arc::clone(&label))
+                    .with_id(id),
+            );
+            Self::claim_registered(&mut st, &self.pending_joins, id)
+                .map(|(_entry_label, handle)| (id, handle))
+        };
+
+        if let Some((id, handle)) = claimed {
             handle.cancel.cancel();
             let _ = reply.send(Ok(true));
             self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -138,14 +138,14 @@ impl SupervisorCore {
         })
     }
 
-    /// Returns true once shutdown has started and new task admission is closed.
+    /// Returns true once shutdown has started and management admission is closed.
     pub(crate) fn is_shutting_down(&self) -> bool {
         self.shutting_down.load(Ordering::Acquire)
     }
 
     /// Marks the runtime as shutting down.
     ///
-    /// This is idempotent and closes the admission gate for future adds.
+    /// This is idempotent and closes the admission gate for future commands.
     fn mark_shutting_down(&self) {
         self.shutting_down.store(true, Ordering::Release);
     }
@@ -292,28 +292,103 @@ impl SupervisorCore {
         (id, reply_rx)
     }
 
-    /// Queues a remove command by runtime identity.
-    ///
-    /// This is fire-and-forget.
-    /// `Ok(())` means the command was sent, not that the task existed or has already stopped.
-    pub(crate) fn remove(&self, id: TaskId) -> Result<(), RuntimeError> {
+    /// Removes a task after queue capacity and the registry claim decision.
+    pub(crate) async fn remove(&self, id: TaskId) -> Result<bool, RuntimeError> {
+        let reply = self.enqueue_remove_wait(id, None).await?;
+        Self::await_remove_reply(reply).await
+    }
+
+    /// Tries to remove a task without waiting for command queue capacity.
+    pub(crate) async fn try_remove(&self, id: TaskId) -> Result<bool, RuntimeError> {
         let reply = self.enqueue_remove(id, None)?;
-        drop(reply);
-        Ok(())
+        Self::await_remove_reply(reply).await
+    }
+
+    /// Removes the task that owns `label` at the registry ordering point.
+    pub(crate) async fn remove_by_label(&self, label: Arc<str>) -> Result<bool, RuntimeError> {
+        let reply = self.enqueue_remove_by_label_wait(label).await?;
+        Self::await_remove_reply(reply).await
+    }
+
+    /// Resolves one authoritative registry Remove reply.
+    async fn await_remove_reply(reply: RemoveReplyRx) -> Result<bool, RuntimeError> {
+        match reply.await {
+            Ok(result) => result,
+            Err(_) => Err(RuntimeError::ShuttingDown),
+        }
     }
 
     /// Publishes one remove request, queues its command, and returns the authoritative reply.
-    ///
-    /// This is fail-fast while the public management API remains synchronous.
     fn enqueue_remove(
         &self,
         id: TaskId,
         reason: Option<&'static str>,
     ) -> Result<RemoveReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
         let permit = self.cmd_tx.try_reserve().map_err(|error| match error {
             mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
             mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
         })?;
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        }
+        Ok(self.commit_remove(permit, id, reason))
+    }
+
+    /// Waits for bounded queue capacity, then queues one Remove command.
+    async fn enqueue_remove_wait(
+        &self,
+        id: TaskId,
+        reason: Option<&'static str>,
+    ) -> Result<RemoveReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self
+            .cmd_tx
+            .reserve()
+            .await
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        }
+        Ok(self.commit_remove(permit, id, reason))
+    }
+
+    /// Waits for queue capacity, then sends one atomic label Remove command.
+    async fn enqueue_remove_by_label_wait(
+        &self,
+        label: Arc<str>,
+    ) -> Result<RemoveReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self
+            .cmd_tx
+            .reserve()
+            .await
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        }
+
+        let (reply, reply_rx) = oneshot::channel();
+        permit.send(RegistryCommand::RemoveByLabel { label, reply });
+        Ok(reply_rx)
+    }
+
+    /// Publishes one identity request and makes its reserved command visible.
+    fn commit_remove(
+        &self,
+        permit: mpsc::Permit<'_, RegistryCommand>,
+        id: TaskId,
+        reason: Option<&'static str>,
+    ) -> RemoveReplyRx {
         let (reply, reply_rx) = oneshot::channel();
         let mut event = Event::new(EventKind::TaskRemoveRequested).with_id(id);
         if let Some(reason) = reason {
@@ -321,7 +396,7 @@ impl SupervisorCore {
         }
         self.bus.publish(event);
         permit.send(RegistryCommand::Remove { id, reply });
-        Ok(reply_rx)
+        reply_rx
     }
 
     /// Returns registered tasks as `(id, label)` pairs from the registry.
@@ -909,6 +984,154 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn confirmed_remove_waits_for_capacity_and_registry_reply() {
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let filler_id = TaskId::next();
+        let filler_reply = core
+            .enqueue_remove(filler_id, None)
+            .expect("the filler must occupy the only queue slot");
+
+        let remove_id = TaskId::next();
+        let mut remove = Box::pin(core.remove(remove_id));
+        assert_pending_once(remove.as_mut()).await;
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(remove_id) || event.kind != EventKind::TaskRemoveRequested,
+                "a backpressured Remove is not visible before queue admission"
+            );
+        }
+
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), filler_reply)
+                .await
+                .expect("filler reply must resolve"),
+            Ok(Ok(false))
+        ));
+        assert!(
+            !timeout(Duration::from_secs(2), remove)
+                .await
+                .expect("Remove must wake after capacity is released")
+                .expect("the registry must reply for an unknown id")
+        );
+        assert!(std::iter::from_fn(|| events.try_recv().ok()).any(|event| {
+            event.id == Some(remove_id) && event.kind == EventKind::TaskRemoveRequested
+        }));
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn try_remove_waits_for_registry_decision_after_admission() {
+        let core = core(SupervisorConfig::default());
+        let id = TaskId::next();
+        let mut remove = Box::pin(core.try_remove(id));
+        assert_pending_once(remove.as_mut()).await;
+
+        core.start();
+        assert!(
+            !timeout(Duration::from_secs(2), remove)
+                .await
+                .expect("try_remove must wait for registry processing")
+                .expect("an admitted try_remove must receive a reply")
+        );
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remove_by_label_orders_after_an_already_queued_add() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        let mut events = core.bus.subscribe();
+        let release = Arc::new(tokio::sync::Notify::new());
+        let task_release = Arc::clone(&release);
+        let task: TaskRef = TaskFn::arc("ordered-label", move |_ctx: TaskContext| {
+            let release = Arc::clone(&task_release);
+            async move {
+                release.notified().await;
+                Ok(())
+            }
+        });
+        let id = TaskId::next();
+        let (_, add_reply) = core
+            .enqueue_add_task(id, TaskSpec::restartable(task), None)
+            .expect("the Add command must enter the queue first");
+
+        let mut remove = Box::pin(core.remove_by_label(Arc::from("ordered-label")));
+        assert_pending_once(remove.as_mut()).await;
+        core.start();
+
+        assert!(matches!(
+            timeout(Duration::from_secs(2), add_reply)
+                .await
+                .expect("Add reply must resolve"),
+            Ok(Ok(()))
+        ));
+        assert!(
+            timeout(Duration::from_secs(2), remove)
+                .await
+                .expect("label Remove must resolve")
+                .expect("label Remove must receive a registry reply"),
+            "the label lookup must happen after the queued Add is committed"
+        );
+        assert!(std::iter::from_fn(|| events.try_recv().ok()).any(|event| {
+            event.kind == EventKind::TaskRemoveRequested
+                && event.id == Some(id)
+                && event.task.as_deref() == Some("ordered-label")
+        }));
+
+        release.notify_one();
+        timeout(Duration::from_secs(2), core.registry.wait_until_empty())
+            .await
+            .expect("the removed task must finish");
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backpressured_remove_returns_shutting_down_without_request_event() {
+        let cfg = SupervisorConfig {
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the only queue slot");
+        let remove_id = TaskId::next();
+        let mut remove = Box::pin(core.remove(remove_id));
+        assert_pending_once(remove.as_mut()).await;
+
+        core.runtime_token.cancel();
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), remove)
+                .await
+                .expect("closing the queue must wake Remove"),
+            Err(RuntimeError::ShuttingDown)
+        ));
+        let _ = timeout(Duration::from_secs(2), filler_reply)
+            .await
+            .expect("the buffered filler must still resolve");
+        core.registry.join_listener().await;
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(remove_id) || event.kind != EventKind::TaskRemoveRequested,
+                "a Remove rejected before enqueue must not publish TaskRemoveRequested"
+            );
+        }
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn backpressured_add_returns_shutting_down_when_queue_closes() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1135,7 +1358,7 @@ mod tests {
 
         let rejected_remove_id = TaskId::next();
         assert!(matches!(
-            core.remove(rejected_remove_id),
+            core.try_remove(rejected_remove_id).await,
             Err(RuntimeError::CommandQueueFull)
         ));
         while let Ok(event) = events.try_recv() {
@@ -1220,7 +1443,7 @@ mod tests {
 
         let remove_id = TaskId::next();
         assert!(matches!(
-            core.remove(remove_id),
+            core.remove(remove_id).await,
             Err(RuntimeError::ShuttingDown)
         ));
         while let Ok(event) = events.try_recv() {
@@ -1357,7 +1580,7 @@ mod tests {
         let mut lagged_rx = core.subscribe_bus();
         let mut observer = core.subscribe_bus();
 
-        core.remove(id).expect("remove should be accepted");
+        assert!(core.remove(id).await.expect("remove should be accepted"));
 
         let observed = timeout(Duration::from_secs(2), async {
             loop {

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -51,7 +51,7 @@ async fn add_storm_unique_names_all_register_then_drain_to_empty() {
         let mut rjoins = Vec::new();
         for id in ids {
             let h = handle.clone();
-            rjoins.push(tokio::spawn(async move { h.remove(id) }));
+            rjoins.push(tokio::spawn(async move { h.remove(id).await }));
         }
         for j in rjoins {
             let _ = j.await;
@@ -197,7 +197,7 @@ async fn interleaved_add_and_remove_drains_to_empty() {
                     .add(TaskSpec::restartable(make_coop(&format!("t-{i}"))))
                     .await
                     .expect("add");
-                let _ = h.remove(id);
+                let _ = h.remove(id).await;
                 id
             }));
         }
@@ -206,7 +206,7 @@ async fn interleaved_add_and_remove_drains_to_empty() {
             ids.push(j.await.unwrap());
         }
         for id in ids {
-            let _ = handle.remove(id);
+            let _ = handle.remove(id).await;
         }
         assert!(
             poll_until(Duration::from_secs(15), || async {
@@ -217,6 +217,62 @@ async fn interleaved_add_and_remove_drains_to_empty() {
         );
     })
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_remove_same_id_has_exactly_one_claim() {
+    let handle = served(5, 0);
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let task_started = Arc::clone(&started);
+    let task_release = Arc::clone(&release);
+    let task: TaskRef = TaskFn::arc("remove-race", move |_ctx: TaskContext| {
+        let started = Arc::clone(&task_started);
+        let release = Arc::clone(&task_release);
+        async move {
+            started.notify_one();
+            release.notified().await;
+            Ok(())
+        }
+    });
+    let id = handle
+        .add(TaskSpec::restartable(task))
+        .await
+        .expect("register remove-race");
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("remove-race must start");
+
+    const N: usize = 32;
+    let mut joins = Vec::with_capacity(N);
+    for _ in 0..N {
+        let handle = handle.clone();
+        joins.push(tokio::spawn(async move {
+            handle
+                .remove(id)
+                .await
+                .expect("Remove must receive a reply")
+        }));
+    }
+
+    let mut claimed = 0;
+    for join in joins {
+        if join.await.expect("Remove caller must not panic") {
+            claimed += 1;
+        }
+    }
+    assert_eq!(claimed, 1, "exactly one Remove may claim the task");
+    assert_eq!(handle.list().await, vec![(id, Arc::from("remove-race"))]);
+
+    release.notify_one();
+    assert!(
+        poll_until(Duration::from_secs(2), || async {
+            handle.list().await.is_empty()
+        })
+        .await,
+        "terminal cleanup must remove the retained entry"
+    );
+    let _ = handle.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -135,7 +135,10 @@ async fn submit_and_watch_resolves_rejected_when_removed_from_queue() {
             })
             .await
         );
-        handle.remove(victim_id).expect("remove accepted");
+        assert!(
+            !handle.remove(victim_id).await.expect("remove accepted"),
+            "a controller-queued task is not registered yet"
+        );
 
         match waiter.wait().await.expect("waiter errored") {
             TaskOutcome::Rejected { reason } => {
@@ -265,7 +268,10 @@ async fn remove_of_queued_submission_purges_it_before_start() {
             "queued submission must be confirmed before removal"
         );
 
-        handle.remove(victim_id).expect("remove accepted");
+        assert!(
+            !handle.remove(victim_id).await.expect("remove accepted"),
+            "a controller-queued task is not registered yet"
+        );
         assert!(
             poll_until(Duration::from_secs(2), || async {
                 collector

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -165,22 +165,22 @@ async fn remove_by_id_removes_only_that_id() {
             .await
             .expect("add b");
 
-        handle.remove(id_a).expect("remove a");
+        assert!(handle.remove(id_a).await.expect("remove a"));
 
         assert!(
             poll_until(Duration::from_secs(2), || async {
                 let list = handle.list().await;
-                list.len() == 1 && list[0].0 == id_b && !handle.is_alive("a").await
+                list.len() == 1
+                    && list[0].0 == id_b
+                    && !handle.is_alive("a").await
+                    && collector
+                        .by_id(id_a)
+                        .iter()
+                        .any(|event| event.kind == EventKind::TaskRemoved)
             })
             .await
         );
         assert!(handle.is_alive("b").await);
-        assert!(
-            collector
-                .by_id(id_a)
-                .iter()
-                .any(|e| e.kind == EventKind::TaskRemoved)
-        );
         let _ = handle.shutdown().await;
     })
     .await;
@@ -196,7 +196,8 @@ async fn remove_unknown_id_is_noop_without_terminal_event() {
             .expect("add keep");
         let stale = stale_id(&handle).await;
 
-        handle.remove(stale).expect("remove stale ok");
+        assert!(!handle.remove(stale).await.expect("remove stale ok"));
+        assert!(!handle.try_remove(stale).await.expect("try_remove stale ok"));
         handle
             .add(TaskSpec::restartable(make_coop("remove-unknown-barrier")))
             .await
@@ -219,24 +220,43 @@ async fn remove_unknown_id_is_noop_without_terminal_event() {
 async fn remove_by_label_returns_true_then_false() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
-        let _ = handle
-            .add(TaskSpec::restartable(make_coop("svc")))
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let task_started = Arc::clone(&started);
+        let task_release = Arc::clone(&release);
+        let task: TaskRef = TaskFn::arc("svc", move |_ctx: TaskContext| {
+            let started = Arc::clone(&task_started);
+            let release = Arc::clone(&task_release);
+            async move {
+                started.notify_one();
+                release.notified().await;
+                Ok(())
+            }
+        });
+        let id = handle
+            .add(TaskSpec::restartable(task))
             .await
             .expect("add svc");
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("svc must start before removal");
 
         assert!(handle.remove_by_label("svc").await.expect("remove1"));
+        assert!(!handle.remove_by_label("svc").await.expect("remove2"));
+        assert_eq!(handle.list().await, vec![(id, Arc::from("svc"))]);
+
+        release.notify_one();
         assert!(
             poll_until(Duration::from_secs(2), || async {
                 !handle.list().await.iter().any(|(_, l)| &**l == "svc")
             })
             .await
         );
-        assert!(!handle.remove_by_label("svc").await.expect("remove2"));
         assert!(
             !handle
                 .remove_by_label("never-existed")
                 .await
-                .expect("remove3")
+                .expect("remove unknown label")
         );
         let _ = handle.shutdown().await;
     })
@@ -368,7 +388,7 @@ async fn individually_removed_stuck_task_is_force_aborted_after_grace() {
             .await
             .expect("add stuck-runner");
 
-        handle.remove(id).expect("remove");
+        assert!(handle.remove(id).await.expect("remove"));
 
         assert!(
             poll_until(Duration::from_secs(3), || async {
@@ -412,7 +432,7 @@ async fn list_reflects_registered_set_sorted_by_id() {
         assert_eq!(labels, HashSet::from(["x", "y", "z"]));
         assert!(ids.contains(&id_x) && ids.contains(&id_y) && ids.contains(&id_z));
 
-        handle.remove(id_y).expect("remove y");
+        assert!(handle.remove(id_y).await.expect("remove y"));
         assert!(
             poll_until(Duration::from_secs(2), || async {
                 let l = handle.list().await;

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -283,7 +283,7 @@ async fn force_aborted_outcome_for_noncooperative_task() {
         .await
         .expect("add_and_watch should succeed");
 
-    handle.remove(id).expect("remove should be accepted");
+    assert!(handle.remove(id).await.expect("remove should be accepted"));
 
     let outcome = with_timeout(5, waiter.wait())
         .await


### PR DESCRIPTION
## 📝 Description
- Removing tasks in registry state
- Make task removal use registry replies

## 🔄 Related Issues
Resolves #123 #124 

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] `task ci` passes locally
