### PR TITLE
[core] Make task removal use registry replies

### DIFF
--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -44,7 +44,7 @@
 //! - `sup.serve()`: starts listeners, returns a handle. Non-blocking.
 //! - `handle.add(spec).await`: register a new task dynamically, returns its `TaskId`.
 //! - `handle.remove(id).await`: claim removal by identity (or `remove_by_label(name).await`).
-//! - `handle.cancel(id)`: cancel and wait for confirmation (or `cancel_by_label(name)`).
+//! - `handle.cancel(id).await`: cancel and wait for terminal cleanup (or `cancel_by_label(name).await`).
 //! - `handle.list()`: snapshot of active `(TaskId, name)` pairs.
 //! - `handle.is_alive(name)`: check if a specific task is running.
 //! - `handle.shutdown()`: graceful stop (consumes the handle).

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -233,19 +233,14 @@ impl SupervisorHandle {
         self.core.is_alive(name).await
     }
 
-    /// Requests cancellation of a task and waits for removal confirmation.
+    /// Requests cancellation and waits for registry terminal completion.
     ///
-    /// The task receives cooperative cancellation.
-    /// The method waits up to the configured shutdown grace period for the matching `TaskRemoved` event.
-    ///
-    /// Returns `Ok(true)` when the task was present and removal was confirmed.
-    /// Returns `Ok(false)` when no registered task has this id.
-    ///
-    /// A task that ignores cancellation is force-aborted by the registry after the configured grace period.
+    /// Returns `Ok(true)` only to the caller that claimed removal.
+    /// A caller that joins an existing removal returns `Ok(false)` after the same terminal completion.
+    /// An unknown or terminated id returns `Ok(false)` immediately.
     ///
     /// # Errors
     ///
-    /// - [`RuntimeError::TaskRemoveTimeout`] when removal was not confirmed in time.
     /// - [`RuntimeError::CommandQueueFull`] when the bounded registry queue has no capacity.
     /// - [`RuntimeError::ShuttingDown`] when the runtime no longer accepts commands.
     pub async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
@@ -254,26 +249,20 @@ impl SupervisorHandle {
 
     /// Cancels the task currently holding `name`.
     ///
-    /// Returns `Ok(false)` if no registered task currently has this label.
-    /// Otherwise, behaves like [`cancel`](Self::cancel).
-    ///
     /// # Errors
     ///
     /// Same as [`cancel`](Self::cancel).
     pub async fn cancel_by_label(&self, name: &str) -> Result<bool, RuntimeError> {
-        match self.core.id_for_label(name).await {
-            Some(id) => self.core.cancel(id).await,
-            None => Ok(false),
-        }
+        self.core.cancel_by_label(Arc::from(name)).await
     }
 
     /// Cancels a task with an explicit confirmation window.
     ///
-    /// `wait_for` controls how long this call waits for `TaskRemoved`.
-    /// It does not change the registry's force-abort grace period.
+    /// The registry claim/join decision is not part of `wait_for`.
+    /// The timer starts only while this caller waits for shared terminal completion.
+    /// A timeout does not stop removal or change the registry's force-abort grace period.
     ///
-    /// Returns `Ok(true)` when removal is confirmed within `wait_for`.
-    /// Returns `Ok(false)` when no registered task has this id.
+    /// On completion, the boolean follows the same claimant rules as [`cancel`](Self::cancel).
     ///
     /// # Errors
     ///

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,7 +17,7 @@
 //! | File             | Role                                      |
 //! |------------------|-------------------------------------------|
 //! | `runtime.rs`     | Owns Bus, Registry, subscribers, shutdown |
-//! | `registry.rs`    | Owns active task actors and add/remove    |
+//! | `registry.rs`    | Owns active task actors and lifecycle ops |
 //! | `actor.rs`       | Runs one task with restart/backoff policy |
 //! | `runner.rs`      | Executes one task attempt                 |
 //! | `alive.rs`       | Best-effort live-task snapshot            |
@@ -36,12 +36,13 @@
 //!   runtime components ──broadcast──► subscriber_listener ──► Subscribe impls
 //!
 //! Completion plane:
-//!   Registry ──oneshot──► TaskWaiter
+//!   Registry ──oneshot outcome──► TaskWaiter
+//!            └─shared terminal──► cancel callers
 //! ```
 //!
-//! The management plane uses an mpsc command channel. Add/remove commands are not delivered through the lossy event bus.
+//! The management plane uses an mpsc command channel. Add, remove, and cancel commands are not delivered through the lossy event bus.
 //! The event plane is best-effort and used for logs, metrics, snapshots, and subscriber integrations. Slow consumers can lag and miss events.
-//! The completion plane is used by `add_and_watch` and `submit_and_watch`. It is the authoritative final result for one task run.
+//! The completion plane provides watched task outcomes and shared terminal completion for cancellation callers.
 //!
 //! ## Main Flow
 //!

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -36,23 +36,33 @@
 //!
 //! Remove(id)
 //!   -> change Registered to Removing
+//!   -> create shared terminal completion
 //!   -> cancel actor token
 //!   -> reply claimed
 //!   -> join actor
 //!   -> release id/name indexes
 //!   -> publish TaskRemoved
+//!   -> resolve terminal completion
+//!
+//! Cancel(id or label)
+//!   -> claim Registered or join Removing
+//!   -> reply with the shared terminal completion
+//!   -> wait until registry cleanup is finished
 //!
 //! Actor completion(id)
 //!   -> change Registered to Removing
+//!   -> create shared terminal completion
 //!   -> join actor
 //!   -> release id/name indexes
 //!   -> publish TaskRemoved
+//!   -> resolve terminal completion
 //! ```
 //!
 //! ## Rules
 //!
 //! - Watched tasks resolve their `TaskOutcome` when the actor join is reported.
-//! - Command replies report registry decisions, not terminal task outcomes.
+//! - Add/remove command replies report registry decisions, not terminal task outcomes.
+//! - Cancel callers share a lossless completion signal owned by the registry.
 //! - Cleanup is idempotent. Duplicate or stale completion signals become no-ops.
 //! - The registry does not clean up on `TaskStopped` or `TaskFailed`.
 //! - Task name is a label and a duplicate-name admission gate; reserved while the task is `Registered` or `Removing`.
@@ -93,6 +103,36 @@ pub(crate) type RemoveReply = Result<bool, RuntimeError>;
 /// Receiver for an authoritative registry remove result.
 pub(crate) type RemoveReplyRx = oneshot::Receiver<RemoveReply>;
 
+/// Registry decision returned to one cancellation caller.
+///
+/// `claimed` is true only for the caller that changed `Registered` to `Removing`.
+/// Every caller that observes the same removal waits on the same terminal completion.
+pub(crate) struct CancelDecision {
+    pub(crate) id: TaskId,
+    pub(crate) claimed: bool,
+    completion: RemovalCompletion,
+}
+
+impl CancelDecision {
+    /// Waits until the actor is joined or force-aborted and terminal cleanup is committed.
+    pub(crate) async fn wait(&self) {
+        self.completion.wait().await;
+    }
+
+    /// Returns true when terminal cleanup has already been committed.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.completion.is_complete()
+    }
+}
+
+/// Authoritative result of one registry cancel command.
+///
+/// `Ok(None)` means the task was unknown or already terminated.
+pub(crate) type CancelReply = Result<Option<CancelDecision>, RuntimeError>;
+
+/// Receiver for an authoritative registry cancel decision.
+pub(crate) type CancelReplyRx = oneshot::Receiver<CancelReply>;
+
 /// Command sent to the registry over the management channel.
 pub(crate) enum RegistryCommand {
     /// Register a task under a pre-minted runtime identity.
@@ -116,6 +156,16 @@ pub(crate) enum RegistryCommand {
         label: Arc<str>,
         reply: oneshot::Sender<RemoveReply>,
     },
+    /// Claim or join cancellation by runtime identity.
+    Cancel {
+        id: TaskId,
+        reply: oneshot::Sender<CancelReply>,
+    },
+    /// Resolve a label and claim or join its cancellation atomically.
+    CancelByLabel {
+        label: Arc<str>,
+        reply: oneshot::Sender<CancelReply>,
+    },
 }
 
 /// Registry-owned actor handle for one registered task.
@@ -125,12 +175,38 @@ struct Handle {
     done: Option<OutcomeTx>,
 }
 
+/// Shared terminal signal for all callers waiting on one removal.
+#[derive(Clone)]
+struct RemovalCompletion {
+    token: CancellationToken,
+}
+
+impl RemovalCompletion {
+    fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+        }
+    }
+
+    async fn wait(&self) {
+        self.token.cancelled().await;
+    }
+
+    fn is_complete(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    fn complete(&self) {
+        self.token.cancel();
+    }
+}
+
 /// Lifecycle phase of one authoritative registry entry.
 enum EntryState {
     /// The actor can still be claimed by remove, completion, or shutdown.
     Registered(Handle),
     /// One owner has the actor handle and is waiting for its terminal join.
-    Removing,
+    Removing { completion: RemovalCompletion },
 }
 
 /// Authoritative membership record kept until terminal join cleanup finishes.
@@ -143,6 +219,20 @@ struct Entry {
 enum JoinCompletion {
     Joined(Result<ActorExitReason, JoinError>),
     ForceAborted,
+}
+
+/// Data needed to commit one actor's terminal registry cleanup.
+struct RemovalReport {
+    id: TaskId,
+    outcome: Option<OutcomeTx>,
+    join: JoinCompletion,
+    completion: RemovalCompletion,
+}
+
+/// Registry-side work selected for one cancel command.
+struct CancelAction {
+    decision: CancelDecision,
+    handle: Option<Handle>,
 }
 
 /// Sends one completion signal when an actor task returns, panics, or is aborted.
@@ -225,6 +315,7 @@ impl PendingJoins {
     }
 
     /// Returns `true` if a join for `id` is still in flight.
+    #[cfg(test)]
     fn contains(&self, id: TaskId) -> bool {
         self.inner
             .lock()
@@ -261,6 +352,8 @@ impl PendingJoins {
     async fn wait_drained(&self) {
         loop {
             let notified = self.drained.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if self.is_empty() {
                 return;
             }
@@ -317,16 +410,6 @@ impl Registry {
             pending_joins: Arc::new(PendingJoins::default()),
             listener_handle: std::sync::Mutex::new(None),
         })
-    }
-
-    /// Returns true when `id` has no registry entry and no join in flight.
-    ///
-    /// Used as a fallback when a `TaskRemoved` event may have been missed because of broadcast lag.
-    pub async fn is_terminated(&self, id: TaskId) -> bool {
-        if self.state.read().await.tasks.contains_key(&id) {
-            return false;
-        }
-        !self.pending_joins.contains(id)
     }
 
     /// Waits for detached join reporters to finish.
@@ -403,6 +486,12 @@ impl Registry {
                         Some(RegistryCommand::RemoveByLabel { label, reply }) => {
                             me.guarded("registry", me.remove_task_by_label(label, reply)).await;
                         }
+                        Some(RegistryCommand::Cancel { id, reply }) => {
+                            me.guarded("registry", me.cancel_task(id, reply)).await;
+                        }
+                        Some(RegistryCommand::CancelByLabel { label, reply }) => {
+                            me.guarded("registry", me.cancel_task_by_label(label, reply)).await;
+                        }
                         None => break,
                     }
                 }
@@ -426,6 +515,13 @@ impl Registry {
                     }
                     RegistryCommand::RemoveByLabel { label, reply } => {
                         me.guarded("registry", me.remove_task_by_label(label, reply))
+                            .await;
+                    }
+                    RegistryCommand::Cancel { id, reply } => {
+                        me.guarded("registry", me.cancel_task(id, reply)).await;
+                    }
+                    RegistryCommand::CancelByLabel { label, reply } => {
+                        me.guarded("registry", me.cancel_task_by_label(label, reply))
                             .await;
                     }
                 }
@@ -485,6 +581,7 @@ impl Registry {
     }
 
     /// Resolves a label to the identity currently holding it (if any).
+    #[cfg(test)]
     pub async fn id_for_label(&self, name: &str) -> Option<TaskId> {
         self.state.read().await.by_label.get(name).copied()
     }
@@ -506,24 +603,24 @@ impl Registry {
     /// Returns labels of tasks that were force-aborted.
     pub async fn cancel_all_within(&self, grace: Duration) -> Vec<Arc<str>> {
         let grace = grace.min(Duration::from_secs(60 * 60 * 24 * 365 * 30));
-        let handles: Vec<(TaskId, Arc<str>, Handle)> = {
+        let handles: Vec<(TaskId, Arc<str>, Handle, RemovalCompletion)> = {
             let mut st = self.state.write().await;
             let ids: Vec<TaskId> = st.tasks.keys().copied().collect();
             ids.into_iter()
                 .filter_map(|id| {
                     Self::claim_registered(&mut st, &self.pending_joins, id)
-                        .map(|(label, handle)| (id, label, handle))
+                        .map(|(label, handle, completion)| (id, label, handle, completion))
                 })
                 .collect()
         };
-        for (_, _, h) in &handles {
+        for (_, _, h, _) in &handles {
             h.cancel.cancel();
         }
 
         let deadline = tokio::time::Instant::now() + grace;
         let mut stuck = Vec::new();
 
-        for (id, label, h) in handles {
+        for (id, label, h, removal_completion) in handles {
             let mut join = h.join;
             match tokio::time::timeout_at(deadline, &mut join).await {
                 Ok(res) => {
@@ -532,9 +629,12 @@ impl Registry {
                         &self.empty_notify,
                         &self.pending_joins,
                         &self.bus,
-                        id,
-                        h.done,
-                        JoinCompletion::Joined(res),
+                        RemovalReport {
+                            id,
+                            outcome: h.done,
+                            join: JoinCompletion::Joined(res),
+                            completion: removal_completion,
+                        },
                     )
                     .await;
                 }
@@ -547,9 +647,12 @@ impl Registry {
                         &self.empty_notify,
                         &self.pending_joins,
                         &self.bus,
-                        id,
-                        h.done,
-                        JoinCompletion::ForceAborted,
+                        RemovalReport {
+                            id,
+                            outcome: h.done,
+                            join: JoinCompletion::ForceAborted,
+                            completion: removal_completion,
+                        },
                     )
                     .await;
                 }
@@ -657,10 +760,10 @@ impl Registry {
     ///
     /// If the task is unknown or cleanup already owns it, replies `Ok(false)` without publishing a terminal event.
     async fn remove_task(&self, id: TaskId, reply: oneshot::Sender<RemoveReply>) {
-        if let Some((_label, handle)) = self.claim_task(id).await {
+        if let Some((_label, handle, completion)) = self.claim_task(id).await {
             handle.cancel.cancel();
             let _ = reply.send(Ok(true));
-            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done, completion);
         } else {
             let _ = reply.send(Ok(false));
         }
@@ -685,15 +788,112 @@ impl Registry {
                     .with_id(id),
             );
             Self::claim_registered(&mut st, &self.pending_joins, id)
-                .map(|(_entry_label, handle)| (id, handle))
+                .map(|(_entry_label, handle, completion)| (id, handle, completion))
         };
 
-        if let Some((id, handle)) = claimed {
+        if let Some((id, handle, completion)) = claimed {
             handle.cancel.cancel();
             let _ = reply.send(Ok(true));
-            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done, completion);
         } else {
             let _ = reply.send(Ok(false));
+        }
+    }
+
+    /// Claims or joins cancellation by identity and returns a shared terminal decision.
+    async fn cancel_task(&self, id: TaskId, reply: oneshot::Sender<CancelReply>) {
+        let action = {
+            let mut st = self.state.write().await;
+            if !st.tasks.contains_key(&id) {
+                None
+            } else {
+                self.bus.publish(
+                    Event::new(EventKind::TaskRemoveRequested)
+                        .with_id(id)
+                        .with_reason("manual_cancel"),
+                );
+                Self::cancel_action(&mut st, &self.pending_joins, id)
+            }
+        };
+        self.resolve_cancel_action(action, reply);
+    }
+
+    /// Resolves a label and claims or joins cancellation under the same state lock.
+    async fn cancel_task_by_label(&self, label: Arc<str>, reply: oneshot::Sender<CancelReply>) {
+        let action = {
+            let mut st = self.state.write().await;
+            let Some(id) = st.by_label.get(label.as_ref()).copied() else {
+                drop(st);
+                let _ = reply.send(Ok(None));
+                return;
+            };
+
+            self.bus.publish(
+                Event::new(EventKind::TaskRemoveRequested)
+                    .with_task(label)
+                    .with_id(id)
+                    .with_reason("manual_cancel"),
+            );
+            Self::cancel_action(&mut st, &self.pending_joins, id)
+        };
+        self.resolve_cancel_action(action, reply);
+    }
+
+    /// Selects one cancel action while registry state is locked.
+    fn cancel_action(
+        st: &mut Inner,
+        pending_joins: &PendingJoins,
+        id: TaskId,
+    ) -> Option<CancelAction> {
+        let existing_completion = {
+            let entry = st.tasks.get(&id)?;
+            match &entry.state {
+                EntryState::Registered(_) => None,
+                EntryState::Removing { completion } => Some(completion.clone()),
+            }
+        };
+        if let Some(completion) = existing_completion {
+            return Some(CancelAction {
+                decision: CancelDecision {
+                    id,
+                    claimed: false,
+                    completion,
+                },
+                handle: None,
+            });
+        }
+
+        let (_label, handle, completion) = Self::claim_registered(st, pending_joins, id)
+            .expect("a registered entry must be claimable while state is locked");
+        Some(CancelAction {
+            decision: CancelDecision {
+                id,
+                claimed: true,
+                completion,
+            },
+            handle: Some(handle),
+        })
+    }
+
+    /// Sends one cancel decision and starts the join owner when this command claimed it.
+    fn resolve_cancel_action(
+        &self,
+        action: Option<CancelAction>,
+        reply: oneshot::Sender<CancelReply>,
+    ) {
+        let Some(CancelAction { decision, handle }) = action else {
+            let _ = reply.send(Ok(None));
+            return;
+        };
+
+        if let Some(handle) = handle {
+            handle.cancel.cancel();
+            let completion = decision.completion.clone();
+            let id = decision.id;
+            let _ = reply.send(Ok(Some(decision)));
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done, completion);
+        } else {
+            let _ = reply.send(Ok(Some(decision)));
         }
     }
 
@@ -702,8 +902,8 @@ impl Registry {
     /// Called after the actor's reliable completion signal is received.
     /// Duplicate or stale completion signals are no-ops.
     async fn cleanup_task(&self, id: TaskId) {
-        if let Some((_label, handle)) = self.claim_task(id).await {
-            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done);
+        if let Some((_label, handle, completion)) = self.claim_task(id).await {
+            self.spawn_join_report(id, handle.join, Some(self.grace), handle.done, completion);
         }
     }
 
@@ -711,7 +911,7 @@ impl Registry {
     ///
     /// The winning caller gets the only actor handle.
     /// Identity and label indexes stay in the registry until that caller finishes the join.
-    async fn claim_task(&self, id: TaskId) -> Option<(Arc<str>, Handle)> {
+    async fn claim_task(&self, id: TaskId) -> Option<(Arc<str>, Handle, RemovalCompletion)> {
         let mut st = self.state.write().await;
         Self::claim_registered(&mut st, &self.pending_joins, id)
     }
@@ -721,21 +921,25 @@ impl Registry {
         st: &mut Inner,
         pending_joins: &PendingJoins,
         id: TaskId,
-    ) -> Option<(Arc<str>, Handle)> {
+    ) -> Option<(Arc<str>, Handle, RemovalCompletion)> {
         let entry = st.tasks.get_mut(&id)?;
-        if matches!(&entry.state, EntryState::Removing) {
+        if matches!(&entry.state, EntryState::Removing { .. }) {
             return None;
         }
 
-        let EntryState::Registered(handle) =
-            std::mem::replace(&mut entry.state, EntryState::Removing)
-        else {
+        let completion = RemovalCompletion::new();
+        let EntryState::Registered(handle) = std::mem::replace(
+            &mut entry.state,
+            EntryState::Removing {
+                completion: completion.clone(),
+            },
+        ) else {
             unreachable!("a removing entry was checked above")
         };
         let label = Arc::clone(&entry.label);
         pending_joins.inc(id);
         pending_joins.label(id, Arc::clone(&label));
-        Some((label, handle))
+        Some((label, handle, completion))
     }
 
     /// Joins an actor in a detached task and reports its final result.
@@ -750,6 +954,7 @@ impl Registry {
         join: JoinHandle<ActorExitReason>,
         force_after: Option<Duration>,
         done: Option<OutcomeTx>,
+        removal_completion: RemovalCompletion,
     ) {
         let bus = self.bus.clone();
         let state = Arc::clone(&self.state);
@@ -769,7 +974,19 @@ impl Registry {
                 None => JoinCompletion::Joined(join.await),
             };
 
-            Self::finish_removal(&state, &empty_notify, &pending, &bus, id, done, completion).await;
+            Self::finish_removal(
+                &state,
+                &empty_notify,
+                &pending,
+                &bus,
+                RemovalReport {
+                    id,
+                    outcome: done,
+                    join: completion,
+                    completion: removal_completion,
+                },
+            )
+            .await;
         });
     }
 
@@ -781,18 +998,23 @@ impl Registry {
         empty_notify: &Notify,
         pending_joins: &PendingJoins,
         bus: &Bus,
-        id: TaskId,
-        done: Option<OutcomeTx>,
-        completion: JoinCompletion,
+        report: RemovalReport,
     ) {
+        let RemovalReport {
+            id,
+            outcome,
+            join,
+            completion: removal_completion,
+        } = report;
         let mut st = state.write().await;
         let is_removing = st
             .tasks
             .get(&id)
-            .is_some_and(|entry| matches!(&entry.state, EntryState::Removing));
+            .is_some_and(|entry| matches!(&entry.state, EntryState::Removing { .. }));
         if !is_removing {
             drop(st);
             pending_joins.dec(id);
+            removal_completion.complete();
             return;
         }
 
@@ -800,16 +1022,22 @@ impl Registry {
             .tasks
             .remove(&id)
             .expect("the removing entry was checked above");
+        let EntryState::Removing {
+            completion: state_completion,
+        } = entry.state
+        else {
+            unreachable!("the removing entry was checked above")
+        };
         if st.by_label.get(entry.label.as_ref()) == Some(&id) {
             st.by_label.remove(entry.label.as_ref());
         }
 
-        match completion {
+        match join {
             JoinCompletion::Joined(res) => {
-                Self::report_join(bus, id, &entry.label, res, done);
+                Self::report_join(bus, id, &entry.label, res, outcome);
             }
             JoinCompletion::ForceAborted => {
-                if let Some(done) = done {
+                if let Some(done) = outcome {
                     let _ = done.send(TaskOutcome::ForceAborted);
                 }
                 bus.publish(
@@ -821,6 +1049,8 @@ impl Registry {
             }
         }
         pending_joins.dec(id);
+        state_completion.complete();
+        removal_completion.complete();
 
         let is_empty = st.tasks.is_empty();
         drop(st);
@@ -936,13 +1166,16 @@ mod tests {
         let registry = registry();
         let id = TaskId::next();
         let label: Arc<str> = Arc::from("empty-waiters");
+        let completion = RemovalCompletion::new();
         let mut state = registry.state.write().await;
         state.by_label.insert(Arc::clone(&label), id);
         state.tasks.insert(
             id,
             Entry {
                 label: Arc::clone(&label),
-                state: EntryState::Removing,
+                state: EntryState::Removing {
+                    completion: completion.clone(),
+                },
             },
         );
         registry.pending_joins.inc(id);
@@ -976,9 +1209,12 @@ mod tests {
             &registry.empty_notify,
             &registry.pending_joins,
             &registry.bus,
-            id,
-            None,
-            JoinCompletion::Joined(Ok(ActorExitReason::Completed)),
+            RemovalReport {
+                id,
+                outcome: None,
+                join: JoinCompletion::Joined(Ok(ActorExitReason::Completed)),
+                completion,
+            },
         )
         .await;
 
@@ -1032,6 +1268,13 @@ mod tests {
     fn send_remove(tx: &mpsc::Sender<RegistryCommand>, id: TaskId) -> RemoveReplyRx {
         let (reply, reply_rx) = oneshot::channel();
         tx.try_send(RegistryCommand::Remove { id, reply })
+            .expect("registry command channel must stay open");
+        reply_rx
+    }
+
+    fn send_cancel(tx: &mpsc::Sender<RegistryCommand>, id: TaskId) -> CancelReplyRx {
+        let (reply, reply_rx) = oneshot::channel();
+        tx.try_send(RegistryCommand::Cancel { id, reply })
             .expect("registry command channel must stay open");
         reply_rx
     }
@@ -1231,7 +1474,23 @@ mod tests {
             "a second remove cannot claim the same task"
         );
 
+        let joined_cancel = receive_reply(send_cancel(&tx, id), "joined cancel reply")
+            .await
+            .expect("the cancel command must succeed")
+            .expect("the removing task must expose its completion");
+        assert!(
+            !joined_cancel.claimed,
+            "cancel must join an existing Remove instead of claiming again"
+        );
+        assert!(
+            !joined_cancel.is_complete(),
+            "joining cancellation cannot complete before the actor join"
+        );
+
         release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), joined_cancel.wait())
+            .await
+            .expect("joined cancellation must finish with the Remove owner");
         tokio::time::timeout(
             Duration::from_secs(2),
             registry.pending_joins.wait_drained(),
@@ -1240,6 +1499,85 @@ mod tests {
         .expect("the released task must finish its join");
         assert!(!registry.contains(id).await);
         assert_eq!(registry.id_for_label("remove-once").await, None);
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn concurrent_cancel_commands_share_one_terminal_completion() {
+        use crate::{TaskContext, TaskError, TaskFn, TaskRef};
+
+        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(5));
+        let mut events = bus.subscribe();
+        let cancellation_seen = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let seen_by_task = Arc::clone(&cancellation_seen);
+        let task_release = Arc::clone(&release);
+        let task: TaskRef = TaskFn::arc("shared-cancel", move |ctx: TaskContext| {
+            let seen = Arc::clone(&seen_by_task);
+            let release = Arc::clone(&task_release);
+            async move {
+                ctx.cancelled().await;
+                seen.notify_one();
+                release.notified().await;
+                Err(TaskError::Canceled)
+            }
+        });
+        let id = TaskId::next();
+        assert!(
+            receive_reply(
+                send_add(&tx, id, TaskSpec::restartable(task), None),
+                "shared cancel add reply",
+            )
+            .await
+            .is_ok()
+        );
+        while events.try_recv().is_ok() {}
+
+        const CALLERS: usize = 8;
+        let replies: Vec<_> = (0..CALLERS).map(|_| send_cancel(&tx, id)).collect();
+        let mut decisions = Vec::with_capacity(CALLERS);
+        for reply in replies {
+            decisions.push(
+                receive_reply(reply, "concurrent cancel reply")
+                    .await
+                    .expect("cancel command must succeed")
+                    .expect("the task must still be removing"),
+            );
+        }
+        tokio::time::timeout(Duration::from_secs(2), cancellation_seen.notified())
+            .await
+            .expect("the task must observe one cancellation");
+
+        assert_eq!(
+            decisions.iter().filter(|decision| decision.claimed).count(),
+            1,
+            "exactly one cancellation command may claim the task"
+        );
+        assert!(decisions.iter().all(|decision| !decision.is_complete()));
+        assert!(registry.contains(id).await);
+        assert!(
+            std::iter::from_fn(|| events.try_recv().ok())
+                .all(|event| event.id != Some(id) || event.kind != EventKind::TaskRemoved),
+            "terminal cleanup cannot happen before the task is released"
+        );
+
+        release.notify_one();
+        for decision in &decisions {
+            tokio::time::timeout(Duration::from_secs(2), decision.wait())
+                .await
+                .expect("all cancel callers must share terminal completion");
+        }
+        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
+            .await
+            .expect("terminal cleanup must remove the task");
+        let removed = std::iter::from_fn(|| events.try_recv().ok())
+            .filter(|event| event.id == Some(id) && event.kind == EventKind::TaskRemoved)
+            .count();
+        assert_eq!(
+            removed, 1,
+            "shared cancellation must publish one terminal event"
+        );
+
         stop_registry(&registry, &token).await;
     }
 
@@ -1805,7 +2143,7 @@ mod tests {
             }
         });
         let id = TaskId::next();
-        let (done, done_rx) = oneshot::channel();
+        let (done, mut done_rx) = oneshot::channel();
         assert!(
             receive_reply(
                 send_add(&tx, id, TaskSpec::once(task), Some(done)),
@@ -1841,6 +2179,15 @@ mod tests {
             receive_reply(send_remove(&tx, id), "completion-first remove reply").await,
             Ok(false)
         ));
+        let joined_cancel = receive_reply(send_cancel(&tx, id), "completion-first cancel reply")
+            .await
+            .expect("the cancel command must succeed")
+            .expect("the completion-owned removal must still exist");
+        assert!(
+            !joined_cancel.claimed,
+            "cancel must join the completion-plane owner"
+        );
+        assert!(!joined_cancel.is_complete());
         assert!(
             std::iter::from_fn(|| events.try_recv().ok())
                 .all(|event| event.id != Some(id) || event.kind != EventKind::TaskRemoved),
@@ -1848,10 +2195,13 @@ mod tests {
         );
 
         release.notify_one();
-        assert!(matches!(
-            receive_reply(done_rx, "completion-first outcome").await,
-            TaskOutcome::Completed
-        ));
+        tokio::time::timeout(Duration::from_secs(2), joined_cancel.wait())
+            .await
+            .expect("cancel must finish with the completion-plane owner");
+        assert!(
+            matches!(done_rx.try_recv(), Ok(TaskOutcome::Completed)),
+            "watched outcome must be ready before terminal completion is signalled"
+        );
         tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
             .await
             .expect("completion-owned join must finish registry cleanup");

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -28,7 +28,7 @@
 //!                               -> close subscribers
 //! ```
 //!
-//! Add/remove commands use the management plane.
+//! Add, remove, and cancel commands use the management plane.
 //! They are not delivered through the lossy event bus.
 //!
 //! Events are used for observability, alive snapshots, and subscriber delivery.
@@ -71,7 +71,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::core::{
     alive::AliveTracker,
-    registry::{AddReplyRx, OutcomeTx, Registry, RegistryCommand, RemoveReplyRx},
+    registry::{
+        AddReplyRx, CancelDecision, CancelReplyRx, OutcomeTx, Registry, RegistryCommand,
+        RemoveReplyRx,
+    },
 };
 use crate::{
     core::SupervisorConfig,
@@ -399,6 +402,44 @@ impl SupervisorCore {
         reply_rx
     }
 
+    /// Queues one fail-fast Cancel command by identity.
+    fn enqueue_cancel(&self, id: TaskId) -> Result<CancelReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self.cmd_tx.try_reserve().map_err(|error| match error {
+            mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
+            mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
+        })?;
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        }
+
+        let (reply, reply_rx) = oneshot::channel();
+        permit.send(RegistryCommand::Cancel { id, reply });
+        Ok(reply_rx)
+    }
+
+    /// Queues one fail-fast atomic Cancel command by label.
+    fn enqueue_cancel_by_label(&self, label: Arc<str>) -> Result<CancelReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self.cmd_tx.try_reserve().map_err(|error| match error {
+            mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
+            mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
+        })?;
+        if self.is_shutting_down() {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        }
+
+        let (reply, reply_rx) = oneshot::channel();
+        permit.send(RegistryCommand::CancelByLabel { label, reply });
+        Ok(reply_rx)
+    }
+
     /// Returns registered tasks as `(id, label)` pairs from the registry.
     pub(crate) async fn list_tasks(&self) -> Vec<(TaskId, Arc<str>)> {
         self.registry.list().await
@@ -411,14 +452,9 @@ impl SupervisorCore {
     }
 
     /// Resolves a label to the identity currently holding it (if any).
+    #[cfg(test)]
     pub(crate) async fn id_for_label(&self, name: &str) -> Option<TaskId> {
         self.registry.id_for_label(name).await
-    }
-
-    /// Returns a new bus receiver for event subscription.
-    #[cfg(test)]
-    pub(crate) fn subscribe_bus(&self) -> broadcast::Receiver<Arc<Event>> {
-        self.bus.subscribe()
     }
 
     /// Starts runtime listeners without blocking.
@@ -532,28 +568,64 @@ impl SupervisorCore {
         self.alive.is_alive(name).await
     }
 
-    /// Cancels a task by identity and waits for `TaskRemoved`.
+    /// Cancels a task by identity and waits for registry terminal completion.
     pub(crate) async fn cancel(&self, id: TaskId) -> Result<bool, RuntimeError> {
-        self.cancel_with_timeout(id, self.cfg.grace).await
+        let decision = Self::await_cancel_reply(self.enqueue_cancel(id)?).await?;
+        Self::wait_cancel_decision(decision, None).await
     }
 
     /// Cancels a task with an explicit confirmation window.
     ///
-    /// `wait_for` controls how long this call waits for `TaskRemoved`.
-    /// It does not change the registry's force-abort grace period.
+    /// The registry decision is not part of `wait_for`. The timeout only bounds
+    /// this caller's wait for shared terminal completion and does not stop removal.
     pub(crate) async fn cancel_with_timeout(
         &self,
         id: TaskId,
         wait_for: Duration,
     ) -> Result<bool, RuntimeError> {
-        let mut rx = self.bus.subscribe();
-        if !self.registry.contains(id).await {
+        let decision = Self::await_cancel_reply(self.enqueue_cancel(id)?).await?;
+        Self::wait_cancel_decision(decision, Some(wait_for)).await
+    }
+
+    /// Cancels the task that owns `label` at the registry ordering point.
+    pub(crate) async fn cancel_by_label(&self, label: Arc<str>) -> Result<bool, RuntimeError> {
+        let decision = Self::await_cancel_reply(self.enqueue_cancel_by_label(label)?).await?;
+        Self::wait_cancel_decision(decision, None).await
+    }
+
+    /// Resolves one authoritative registry cancellation decision.
+    async fn await_cancel_reply(
+        reply: CancelReplyRx,
+    ) -> Result<Option<CancelDecision>, RuntimeError> {
+        match reply.await {
+            Ok(result) => result,
+            Err(_) => Err(RuntimeError::ShuttingDown),
+        }
+    }
+
+    /// Waits for one shared terminal completion and preserves its claim result.
+    async fn wait_cancel_decision(
+        decision: Option<CancelDecision>,
+        wait_for: Option<Duration>,
+    ) -> Result<bool, RuntimeError> {
+        let Some(decision) = decision else {
             return Ok(false);
+        };
+        let id = decision.id;
+        let claimed = decision.claimed;
+
+        if let Some(wait_for) = wait_for {
+            if timeout(wait_for, decision.wait()).await.is_err() && !decision.is_complete() {
+                return Err(RuntimeError::TaskRemoveTimeout {
+                    id,
+                    timeout: wait_for,
+                });
+            }
+        } else {
+            decision.wait().await;
         }
 
-        let reply = self.enqueue_remove(id, Some("manual_cancel"))?;
-        drop(reply);
-        self.wait_task_removed(&mut rx, id, wait_for).await
+        Ok(claimed)
     }
 
     /// Applies one event to alive tracking and subscriber fan-out.
@@ -708,50 +780,6 @@ impl SupervisorCore {
         } else {
             self.bus.publish(Event::new(EventKind::GraceExceeded));
             Err(RuntimeError::GraceExceeded { grace, stuck })
-        }
-    }
-
-    /// Waits for a task to terminate.
-    ///
-    /// Success is normally observed through `TaskRemoved`.
-    /// If the bus receiver lags or closes, falls back to registry termination state.
-    async fn wait_task_removed(
-        &self,
-        rx: &mut broadcast::Receiver<Arc<Event>>,
-        id: TaskId,
-        wait_for: Duration,
-    ) -> Result<bool, RuntimeError> {
-        let wait_for_event = async {
-            loop {
-                match rx.recv().await {
-                    Ok(ev) if matches!(ev.kind, EventKind::TaskRemoved) && ev.id == Some(id) => {
-                        return true;
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if self.registry.is_terminated(id).await {
-                            return true;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        return self.registry.is_terminated(id).await;
-                    }
-                }
-            }
-        };
-
-        match timeout(wait_for, wait_for_event).await {
-            Ok(true) => Ok(true),
-            Ok(false) | Err(_) => {
-                if self.registry.is_terminated(id).await {
-                    Ok(true)
-                } else {
-                    Err(RuntimeError::TaskRemoveTimeout {
-                        id,
-                        timeout: wait_for,
-                    })
-                }
-            }
         }
     }
 }
@@ -1095,6 +1123,49 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn cancel_by_label_orders_after_an_already_queued_add() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        let mut events = core.bus.subscribe();
+        let task: TaskRef = TaskFn::arc("ordered-cancel-label", |ctx: TaskContext| async move {
+            ctx.cancelled().await;
+            Ok(())
+        });
+        let id = TaskId::next();
+        let (_, add_reply) = core
+            .enqueue_add_task(id, TaskSpec::restartable(task), None)
+            .expect("the Add command must enter the queue first");
+
+        let mut cancel = Box::pin(core.cancel_by_label(Arc::from("ordered-cancel-label")));
+        assert_pending_once(cancel.as_mut()).await;
+        core.start();
+
+        assert!(matches!(
+            timeout(Duration::from_secs(2), add_reply)
+                .await
+                .expect("Add reply must resolve"),
+            Ok(Ok(()))
+        ));
+        assert!(
+            timeout(Duration::from_secs(2), cancel)
+                .await
+                .expect("label Cancel must resolve after terminal cleanup")
+                .expect("label Cancel must receive a registry reply"),
+            "the label lookup must happen after the queued Add is committed"
+        );
+        assert!(std::iter::from_fn(|| events.try_recv().ok()).any(|event| {
+            event.kind == EventKind::TaskRemoveRequested
+                && event.id == Some(id)
+                && event.task.as_deref() == Some("ordered-cancel-label")
+                && event.reason.as_deref() == Some("manual_cancel")
+        }));
+        assert!(!core.contains_id(id).await);
+
+        let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn backpressured_remove_returns_shutting_down_without_request_event() {
         let cfg = SupervisorConfig {
             registry_queue_capacity: 1,
@@ -1369,6 +1440,19 @@ mod tests {
             );
         }
 
+        let rejected_cancel_id = TaskId::next();
+        assert!(matches!(
+            core.cancel(rejected_cancel_id).await,
+            Err(RuntimeError::CommandQueueFull)
+        ));
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(rejected_cancel_id)
+                    || event.kind != EventKind::TaskRemoveRequested,
+                "a Cancel rejected before enqueue must not publish TaskRemoveRequested"
+            );
+        }
+
         core.start();
         assert!(matches!(
             timeout(Duration::from_secs(2), filler_reply)
@@ -1547,69 +1631,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_task_removed_survives_bus_lag() {
+    async fn cancel_uses_registry_completion_when_event_bus_lags() {
         use crate::{TaskContext, TaskFn, TaskRef};
+        use tokio::sync::broadcast::error::TryRecvError;
 
         let cfg = SupervisorConfig {
-            bus_capacity: 8,
+            bus_capacity: 1,
             ..Default::default()
         };
         let core = core(cfg);
         core.start();
 
-        let t: TaskRef = TaskFn::arc("laggy", |ctx: TaskContext| async move {
-            ctx.cancelled().await;
-            Ok(())
+        let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let seen_by_task = Arc::clone(&cancellation_seen);
+        let task_release = Arc::clone(&release);
+        let task: TaskRef = TaskFn::arc("laggy-cancel", move |ctx: TaskContext| {
+            let seen = Arc::clone(&seen_by_task);
+            let release = Arc::clone(&task_release);
+            async move {
+                ctx.cancelled().await;
+                seen.notify_one();
+                release.notified().await;
+                Ok(())
+            }
         });
         let id = core
-            .add_task(TaskSpec::restartable(t))
+            .add_task(TaskSpec::restartable(task))
             .await
             .expect("add accepted");
 
-        let registered = timeout(Duration::from_secs(2), async {
-            loop {
-                if core.contains_id(id).await {
-                    return;
-                }
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-        })
-        .await;
-        registered.expect("task must register");
+        let mut stale_events = core.bus.subscribe();
+        let receiver_count = core.bus.receiver_count();
+        let mut cancel = Box::pin(core.cancel(id));
+        tokio::select! {
+            result = &mut cancel => panic!("cancel returned before actor termination: {result:?}"),
+            _ = cancellation_seen.notified() => {}
+        }
+        assert_eq!(
+            core.bus.receiver_count(),
+            receiver_count,
+            "cancel must not create a correctness receiver on the event bus"
+        );
+        assert_pending_once(cancel.as_mut()).await;
 
-        let mut lagged_rx = core.subscribe_bus();
-        let mut observer = core.subscribe_bus();
-
-        assert!(core.remove(id).await.expect("remove should be accepted"));
-
-        let observed = timeout(Duration::from_secs(2), async {
-            loop {
-                if let Ok(ev) = observer.recv().await
-                    && ev.kind == EventKind::TaskRemoved
-                    && ev.id == Some(id)
-                {
-                    return;
-                }
-            }
-        })
-        .await;
-        observed.expect("TaskRemoved must be observed by a healthy receiver");
-
-        for _ in 0..32 {
+        for _ in 0..16 {
             core.bus
                 .publish(Event::new(EventKind::TaskStarting).with_task("noise"));
         }
-
-        let res = timeout(
-            Duration::from_secs(1),
-            core.wait_task_removed(&mut lagged_rx, id, Duration::from_millis(300)),
-        )
-        .await
-        .expect("wait_task_removed must not hang");
         assert!(
-            matches!(res, Ok(true)),
-            "a lagged receiver must fall back to runtime state instead of reporting \
-             a spurious TaskRemoveTimeout, got {res:?}"
+            matches!(stale_events.try_recv(), Err(TryRecvError::Lagged(_))),
+            "the observer must lag in this regression setup"
+        );
+
+        release.notify_one();
+        assert!(
+            timeout(Duration::from_secs(2), cancel)
+                .await
+                .expect("cancel must finish after terminal cleanup")
+                .expect("cancel must receive a registry result")
+        );
+        assert!(
+            !core.contains_id(id).await,
+            "terminal completion must follow registry state cleanup"
         );
 
         let _ = core.shutdown().await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,10 +51,10 @@ pub enum RuntimeError {
     #[error("registry command queue is full")]
     CommandQueueFull,
 
-    /// Timed out while waiting for removal confirmation.
+    /// Timed out while waiting for registry terminal completion.
     #[error("timeout waiting for task {id} removal after {timeout:?}")]
     TaskRemoveTimeout {
-        /// Task id that did not report removal in time.
+        /// Task id whose terminal cleanup did not finish in time.
         id: TaskId,
         /// Wait duration before timing out.
         timeout: Duration,

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -314,7 +314,7 @@ async fn cancel_storm_by_id_returns_true_and_drains() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn double_cancel_same_id_concurrent_at_most_one_true() {
+async fn concurrent_cancel_same_id_returns_exactly_one_true() {
     let handle = served(5, 0);
     const K: usize = 16;
     with_timeout(20, async {
@@ -336,9 +336,9 @@ async fn double_cancel_same_id_concurrent_at_most_one_true() {
                 trues += 1;
             }
         }
-        assert!(
-            trues >= 1,
-            "at least one concurrent cancel must observe the task"
+        assert_eq!(
+            trues, 1,
+            "exactly one concurrent cancel must claim the task"
         );
         assert!(
             poll_until(Duration::from_secs(5), || async {

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -334,34 +334,71 @@ async fn cancel_with_timeout_true_for_cooperative_task() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn cancel_with_timeout_errors_on_stuck_task() {
+async fn cancel_timeout_does_not_stop_shared_removal() {
     let (handle, _c) = served_with_collector(5);
     with_timeout(10, async {
-        let task = TaskFn::arc("stubborn", |_ctx: TaskContext| async move {
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            Ok(())
+        let started = Arc::new(tokio::sync::Notify::new());
+        let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let started_by_task = Arc::clone(&started);
+        let seen_by_task = Arc::clone(&cancellation_seen);
+        let release_by_task = Arc::clone(&release);
+        let task = TaskFn::arc("timeout-shared", move |ctx: TaskContext| {
+            let started = Arc::clone(&started_by_task);
+            let seen = Arc::clone(&seen_by_task);
+            let release = Arc::clone(&release_by_task);
+            async move {
+                started.notify_one();
+                ctx.cancelled().await;
+                seen.notify_one();
+                release.notified().await;
+                Ok(())
+            }
         });
         let id = handle
             .add(TaskSpec::restartable(task))
             .await
-            .expect("add stubborn");
-
-        match handle
-            .cancel_with_timeout(id, Duration::from_millis(150))
+            .expect("add timeout-shared");
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
             .await
-        {
+            .expect("task must start before cancellation");
+
+        match handle.cancel_with_timeout(id, Duration::ZERO).await {
             Err(RuntimeError::TaskRemoveTimeout {
                 id: timed_id,
                 timeout,
             }) => {
                 assert_eq!(timed_id, id);
-                assert_eq!(timeout, Duration::from_millis(150));
+                assert_eq!(timeout, Duration::ZERO);
             }
             other => panic!(
-                "expected TaskRemoveTimeout for a task that ignores cancellation, got {other:?}"
+                "expected TaskRemoveTimeout while terminal completion is blocked, got {other:?}"
             ),
         }
-        let _ = with_timeout(5, handle.shutdown()).await;
+        tokio::time::timeout(Duration::from_secs(2), cancellation_seen.notified())
+            .await
+            .expect("timed-out caller must leave cancellation running");
+        assert_eq!(handle.list().await, vec![(id, Arc::from("timeout-shared"))]);
+
+        let mut joined_cancel = Box::pin(handle.cancel(id));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut joined_cancel)
+                .await
+                .is_err(),
+            "a later cancel must join the same blocked terminal completion"
+        );
+
+        release.notify_one();
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(2), joined_cancel)
+                .await
+                .expect("joined cancel must finish after release")
+                .expect("joined cancel must not fail"),
+            "the caller that joins an existing removal returns false"
+        );
+        assert!(handle.list().await.is_empty());
+
+        let _ = handle.shutdown().await;
     })
     .await;
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -283,7 +283,10 @@ async fn force_aborted_outcome_for_noncooperative_task() {
         .await
         .expect("add_and_watch should succeed");
 
-    assert!(handle.remove(id).await.expect("remove should be accepted"));
+    assert!(
+        handle.cancel(id).await.expect("cancel should be accepted"),
+        "plain cancel must wait through registry force-abort without a caller timeout"
+    );
 
     let outcome = with_timeout(5, waiter.wait())
         .await


### PR DESCRIPTION
## 📝 Description
- Task removal use registry replies

## 🔄 Related Issues
Resolves #124 #125

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] `task ci` passes locally
