### PR TITLE
[runtime] re-build shutdown process

### DIFF
--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -279,9 +279,6 @@ impl SupervisorHandle {
 
     /// Initiates graceful shutdown of the supervisor runtime.
     ///
-    /// Shutdown cancels all registered tasks, waits up to the configured grace period, force-aborts tasks that do not stop,
-    /// joins internal listeners, and allows subscriber workers to drain until their separate shutdown timeout.
-    ///
     /// With the `controller` feature enabled, the controller stops through the shared runtime cancellation token.
     ///
     /// # Errors

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -38,11 +38,12 @@
 //! Completion plane:
 //!   Registry ──oneshot outcome──► TaskWaiter
 //!            └─shared terminal──► cancel callers
+//!   SupervisorCore ──shared result──► shutdown callers
 //! ```
 //!
 //! The management plane uses an mpsc command channel. Add, remove, and cancel commands are not delivered through the lossy event bus.
 //! The event plane is best-effort and used for logs, metrics, snapshots, and subscriber integrations. Slow consumers can lag and miss events.
-//! The completion plane provides watched task outcomes and shared terminal completion for cancellation callers.
+//! The completion plane provides watched task outcomes, terminal cancellation completion, and one cached shutdown result.
 //!
 //! ## Main Flow
 //!

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -12,11 +12,13 @@
 //!
 //! ```text
 //! Management plane:
-//!   SupervisorCore                 Registry
-//!        |                            |
-//!        |-- command (bounded mpsc) ->|
-//!        |                            |-- update registry state
-//!        |<-- reply (oneshot) --------|
+//!   SupervisorCore                  Registry
+//!        |                             |
+//!        |-- command (bounded mpsc) -->|
+//!        |                             |-- update registry state
+//!        |<-- reply (oneshot) ---------|
+//!        |-- fence (control channel) ->|  drain committed commands
+//!        |<-- fence reply -------------|
 //!
 //! Completion plane:
 //!   TaskActor -> completion mpsc -> registry cleanup
@@ -63,6 +65,7 @@
 //! - Watched tasks resolve their `TaskOutcome` when the actor join is reported.
 //! - Add/remove command replies report registry decisions, not terminal task outcomes.
 //! - Cancel callers share a lossless completion signal owned by the registry.
+//! - A fence reply means every earlier management command has finished processing.
 //! - Cleanup is idempotent. Duplicate or stale completion signals become no-ops.
 //! - The registry does not clean up on `TaskStopped` or `TaskFailed`.
 //! - Task name is a label and a duplicate-name admission gate; reserved while the task is `Registered` or `Removing`.
@@ -166,6 +169,12 @@ pub(crate) enum RegistryCommand {
         label: Arc<str>,
         reply: oneshot::Sender<CancelReply>,
     },
+}
+
+/// Reliable control messages that must not wait for management queue capacity.
+enum RegistryControl {
+    /// Confirms that every command committed before admission closed has been processed.
+    Fence { reply: oneshot::Sender<()> },
 }
 
 /// Registry-owned actor handle for one registered task.
@@ -381,6 +390,8 @@ pub(crate) struct Registry {
     grace: Duration,
     empty_notify: Arc<Notify>,
     cmd_rx: std::sync::Mutex<Option<mpsc::Receiver<RegistryCommand>>>,
+    control_tx: mpsc::UnboundedSender<RegistryControl>,
+    control_rx: std::sync::Mutex<Option<mpsc::UnboundedReceiver<RegistryControl>>>,
     completion_tx: mpsc::UnboundedSender<TaskId>,
     completion_rx: std::sync::Mutex<Option<mpsc::UnboundedReceiver<TaskId>>>,
     pending_joins: Arc<PendingJoins>,
@@ -397,6 +408,7 @@ impl Registry {
         cmd_rx: mpsc::Receiver<RegistryCommand>,
     ) -> Arc<Self> {
         let (completion_tx, completion_rx) = mpsc::unbounded_channel();
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
         Arc::new(Self {
             state: Arc::new(RwLock::new(Inner::default())),
             bus,
@@ -405,6 +417,8 @@ impl Registry {
             grace,
             empty_notify: Arc::new(Notify::new()),
             cmd_rx: std::sync::Mutex::new(Some(cmd_rx)),
+            control_tx,
+            control_rx: std::sync::Mutex::new(Some(control_rx)),
             completion_tx,
             completion_rx: std::sync::Mutex::new(Some(completion_rx)),
             pending_joins: Arc::new(PendingJoins::default()),
@@ -438,14 +452,28 @@ impl Registry {
         }
     }
 
+    /// Waits until every management command committed before this call has been processed.
+    ///
+    /// The control channel is independent of bounded management queue capacity.
+    pub(crate) async fn fence(&self) -> Result<(), RuntimeError> {
+        let (reply, reply_rx) = oneshot::channel();
+        self.control_tx
+            .send(RegistryControl::Fence { reply })
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        reply_rx.await.map_err(|_| RuntimeError::ShuttingDown)
+    }
+
     /// Starts the registry listener task.
     ///
     /// The listener consumes receivers stored during construction.
     /// It listens to:
     /// - management commands from `cmd_rx`,
+    /// - shutdown fences from the independent control channel,
     /// - actor identity signals from the reliable completion channel.
     ///
-    /// On runtime shutdown, it closes the command receiver, drains already buffered commands, cancels remaining actors with zero extra grace, and waits for all join reporters to finish.
+    /// On runtime shutdown, it closes the command receiver, drains commands that
+    /// are already buffered without waiting for uncommitted reservations, cancels
+    /// remaining actors with zero extra grace, and waits for join reporters.
     pub fn spawn_listener(self: Arc<Self>) {
         let mut cmd_rx = self
             .cmd_rx
@@ -455,6 +483,12 @@ impl Registry {
             .expect("spawn_listener called exactly once");
         let mut completion_rx = self
             .completion_rx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+            .expect("spawn_listener called exactly once");
+        let mut control_rx = self
+            .control_rx
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .take()
@@ -475,23 +509,13 @@ impl Registry {
                         None => break,
                     },
 
+                    control = control_rx.recv() => match control {
+                        Some(control) => me.handle_control(control, &mut cmd_rx).await,
+                        None => break,
+                    },
+
                     cmd = cmd_rx.recv() => match cmd {
-                        Some(RegistryCommand::Add { id, spec, outcome, reply }) => {
-                            me.guarded("registry", me.spawn_and_register(id, spec, outcome, reply))
-                            .await;
-                        }
-                        Some(RegistryCommand::Remove { id, reply }) => {
-                            me.guarded("registry", me.remove_task(id, reply)).await;
-                        }
-                        Some(RegistryCommand::RemoveByLabel { label, reply }) => {
-                            me.guarded("registry", me.remove_task_by_label(label, reply)).await;
-                        }
-                        Some(RegistryCommand::Cancel { id, reply }) => {
-                            me.guarded("registry", me.cancel_task(id, reply)).await;
-                        }
-                        Some(RegistryCommand::CancelByLabel { label, reply }) => {
-                            me.guarded("registry", me.cancel_task_by_label(label, reply)).await;
-                        }
+                        Some(command) => me.handle_command(command).await,
                         None => break,
                     }
                 }
@@ -499,32 +523,12 @@ impl Registry {
 
             cmd_rx.close();
             completion_rx.close();
-            while let Some(cmd) = cmd_rx.recv().await {
-                match cmd {
-                    RegistryCommand::Add {
-                        id,
-                        spec,
-                        outcome,
-                        reply,
-                    } => {
-                        me.guarded("registry", me.spawn_and_register(id, spec, outcome, reply))
-                            .await;
-                    }
-                    RegistryCommand::Remove { id, reply } => {
-                        me.guarded("registry", me.remove_task(id, reply)).await;
-                    }
-                    RegistryCommand::RemoveByLabel { label, reply } => {
-                        me.guarded("registry", me.remove_task_by_label(label, reply))
-                            .await;
-                    }
-                    RegistryCommand::Cancel { id, reply } => {
-                        me.guarded("registry", me.cancel_task(id, reply)).await;
-                    }
-                    RegistryCommand::CancelByLabel { label, reply } => {
-                        me.guarded("registry", me.cancel_task_by_label(label, reply))
-                            .await;
-                    }
-                }
+            control_rx.close();
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                me.handle_command(cmd).await;
+            }
+            while let Ok(control) = control_rx.try_recv() {
+                me.handle_control(control, &mut cmd_rx).await;
             }
             me.cancel_all_within(Duration::ZERO).await;
             me.pending_joins.wait_drained().await;
@@ -534,6 +538,54 @@ impl Registry {
             .listener_handle
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(handle);
+    }
+
+    /// Processes one management command to its direct registry decision.
+    async fn handle_command(&self, command: RegistryCommand) {
+        match command {
+            RegistryCommand::Add {
+                id,
+                spec,
+                outcome,
+                reply,
+            } => {
+                self.guarded(
+                    "registry",
+                    self.spawn_and_register(id, spec, outcome, reply),
+                )
+                .await;
+            }
+            RegistryCommand::Remove { id, reply } => {
+                self.guarded("registry", self.remove_task(id, reply)).await;
+            }
+            RegistryCommand::RemoveByLabel { label, reply } => {
+                self.guarded("registry", self.remove_task_by_label(label, reply))
+                    .await;
+            }
+            RegistryCommand::Cancel { id, reply } => {
+                self.guarded("registry", self.cancel_task(id, reply)).await;
+            }
+            RegistryCommand::CancelByLabel { label, reply } => {
+                self.guarded("registry", self.cancel_task_by_label(label, reply))
+                    .await;
+            }
+        }
+    }
+
+    /// Drains commands already visible at the admission ordering point, then replies.
+    async fn handle_control(
+        &self,
+        control: RegistryControl,
+        cmd_rx: &mut mpsc::Receiver<RegistryCommand>,
+    ) {
+        match control {
+            RegistryControl::Fence { reply } => {
+                while let Ok(command) = cmd_rx.try_recv() {
+                    self.handle_command(command).await;
+                }
+                let _ = reply.send(());
+            }
+        }
     }
 
     /// Waits for the registry listener task to finish.

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -58,6 +58,9 @@
 //! - New task admission closes once shutdown begins.
 //! - Shutdown waits for a registry fence before it starts task drain.
 //! - Commands committed before the admission gate closes are processed before that fence.
+//! - Explicit, signal, and natural shutdown paths join one detached operation.
+//! - Every shutdown waiter receives the same cached result after full cleanup.
+//! - The first shutdown trigger controls the result and request events.
 //! - Registry membership is keyed by `TaskId`.
 //! - `run()` is single-shot. A second call returns `RuntimeError::AlreadyRunning`.
 //! - `snapshot` and `is_alive` are best-effort views from the alive tracker.
@@ -66,7 +69,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::Arc, time::Duration};
 use tokio::{
-    sync::{broadcast, mpsc, oneshot},
+    sync::{broadcast, mpsc, oneshot, watch},
     time::timeout,
 };
 use tokio_util::sync::CancellationToken;
@@ -87,6 +90,113 @@ use crate::{
     tasks::TaskSpec,
 };
 
+/// Coordinates one cancellation-safe shutdown operation for every caller.
+struct ShutdownCoordinator {
+    started: CancellationToken,
+    operation: std::sync::Mutex<Option<Arc<ShutdownOperation>>>,
+}
+
+impl ShutdownCoordinator {
+    fn new() -> Self {
+        Self {
+            started: CancellationToken::new(),
+            operation: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+/// Shared, cached result of one detached shutdown owner.
+struct ShutdownOperation {
+    outcome: watch::Receiver<Option<ShutdownOutcome>>,
+}
+
+impl ShutdownOperation {
+    async fn wait(&self) -> ShutdownOutcome {
+        let mut outcome = self.outcome.clone();
+        loop {
+            if let Some(outcome) = outcome.borrow_and_update().clone() {
+                return outcome;
+            }
+            if outcome.changed().await.is_err() {
+                return ShutdownOutcome::ShuttingDown;
+            }
+        }
+    }
+}
+
+/// Keeps a custom I/O error and its source chain alive for repeated delivery.
+#[derive(Debug)]
+struct SharedIoError(Arc<std::io::Error>);
+
+impl std::fmt::Display for SharedIoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.0.as_ref(), f)
+    }
+}
+
+impl std::error::Error for SharedIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let Some(source) = self.0.get_ref() {
+            Some(source)
+        } else {
+            Some(self.0.as_ref())
+        }
+    }
+}
+
+/// Cloneable internal result materialized into one owned public error per caller.
+#[derive(Clone)]
+enum ShutdownOutcome {
+    Completed,
+    GraceExceeded {
+        grace: Duration,
+        stuck: Vec<Arc<str>>,
+    },
+    SignalSetupFailed {
+        source: Arc<std::io::Error>,
+    },
+    ShuttingDown,
+}
+
+impl ShutdownOutcome {
+    fn from_drain_result(result: Result<(), RuntimeError>) -> Self {
+        match result {
+            Ok(()) => Self::Completed,
+            Err(RuntimeError::GraceExceeded { grace, stuck }) => {
+                Self::GraceExceeded { grace, stuck }
+            }
+            Err(_) => Self::ShuttingDown,
+        }
+    }
+
+    fn into_result(self) -> Result<(), RuntimeError> {
+        match self {
+            Self::Completed => Ok(()),
+            Self::GraceExceeded { grace, stuck } => {
+                Err(RuntimeError::GraceExceeded { grace, stuck })
+            }
+            Self::SignalSetupFailed { source } => {
+                let source = if let Some(code) = source.raw_os_error() {
+                    std::io::Error::from_raw_os_error(code)
+                } else {
+                    std::io::Error::new(source.kind(), SharedIoError(source))
+                };
+                Err(RuntimeError::SignalSetupFailed { source })
+            }
+            Self::ShuttingDown => Err(RuntimeError::ShuttingDown),
+        }
+    }
+}
+
+/// Cause that wins ownership of the shared shutdown operation.
+enum ShutdownTrigger {
+    Requested,
+    Natural,
+    SignalSetupFailed(Arc<std::io::Error>),
+    #[cfg(test)]
+    PanicForTest,
+}
+
 /// Runtime implementation behind the public [`Supervisor`](super::supervisor::Supervisor).
 ///
 /// This type is controller-agnostic.
@@ -102,6 +212,7 @@ pub(crate) struct SupervisorCore {
     started: AtomicBool,
     running: AtomicBool,
     shutting_down: AtomicBool,
+    shutdown: ShutdownCoordinator,
     admission_gate: std::sync::Mutex<()>,
     cmd_tx: mpsc::Sender<RegistryCommand>,
     subscriber_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -139,6 +250,7 @@ impl SupervisorCore {
             started: AtomicBool::new(false),
             running: AtomicBool::new(false),
             shutting_down: AtomicBool::new(false),
+            shutdown: ShutdownCoordinator::new(),
             admission_gate: std::sync::Mutex::new(()),
             cmd_tx,
             subscriber_handle: std::sync::Mutex::new(None),
@@ -183,6 +295,63 @@ impl SupervisorCore {
     async fn close_admission_and_fence_registry(&self) -> Result<(), RuntimeError> {
         self.mark_shutting_down();
         self.registry.fence().await
+    }
+
+    /// Returns the shared operation, starting one detached shutdown owner if needed.
+    fn begin_shutdown(self: &Arc<Self>, trigger: ShutdownTrigger) -> Arc<ShutdownOperation> {
+        let mut operation = self
+            .shutdown
+            .operation
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(operation) = operation.as_ref() {
+            return Arc::clone(operation);
+        }
+
+        let (outcome_tx, outcome_rx) = watch::channel(None);
+        let shared = Arc::new(ShutdownOperation {
+            outcome: outcome_rx,
+        });
+
+        self.mark_shutting_down();
+        *operation = Some(Arc::clone(&shared));
+        self.shutdown.started.cancel();
+        drop(operation);
+
+        let core = Arc::clone(self);
+        tokio::spawn(async move {
+            let outcome =
+                match crate::core::panic_guard::guarded(core.perform_shutdown(trigger)).await {
+                    Ok(outcome) => outcome,
+                    Err(panic) => {
+                        core.report_shutdown_panic("owner", panic);
+                        let _ = core.finish_shutdown_cleanup().await;
+                        ShutdownOutcome::ShuttingDown
+                    }
+                };
+            outcome_tx.send_replace(Some(outcome));
+        });
+
+        shared
+    }
+
+    /// Starts or joins the shared shutdown operation.
+    async fn join_shutdown(self: &Arc<Self>, trigger: ShutdownTrigger) -> Result<(), RuntimeError> {
+        self.begin_shutdown(trigger).wait().await.into_result()
+    }
+
+    /// Waits for an operation already started by another runtime entry point.
+    async fn wait_started_shutdown(&self) -> Result<(), RuntimeError> {
+        self.shutdown.started.cancelled().await;
+        let operation = self
+            .shutdown
+            .operation
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .as_ref()
+            .cloned()
+            .expect("started shutdown must publish its shared operation");
+        operation.wait().await.into_result()
     }
 
     /// Adds a task and waits for the registry registration decision.
@@ -513,9 +682,12 @@ impl SupervisorCore {
     /// completion.
     ///
     /// Single-shot: a second or concurrent call returns [`RuntimeError::AlreadyRunning`].
-    pub(crate) async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
+    pub(crate) async fn run(self: &Arc<Self>, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
         if self.running.swap(true, Ordering::AcqRel) {
             return Err(RuntimeError::AlreadyRunning);
+        }
+        if self.is_shutting_down() {
+            return self.wait_started_shutdown().await;
         }
         self.start();
 
@@ -523,14 +695,25 @@ impl SupervisorCore {
             let mut rx = self.bus.subscribe();
             let mut pending_ids = Vec::with_capacity(tasks.len());
             for spec in tasks {
-                let (id, reply) = self
-                    .enqueue_add_task_wait(TaskId::next(), spec, None)
-                    .await
-                    .map_err(|(error, _done)| error)?;
+                let queued = self.enqueue_add_task_wait(TaskId::next(), spec, None).await;
+                let (id, reply) = match queued {
+                    Ok(queued) => queued,
+                    Err((RuntimeError::ShuttingDown, _))
+                        if self.shutdown.started.is_cancelled() =>
+                    {
+                        return self.wait_started_shutdown().await;
+                    }
+                    Err((error, _)) => return Err(error),
+                };
                 drop(reply);
                 pending_ids.push(id);
             }
-            self.wait_tasks_registered(&mut rx, &pending_ids).await;
+            tokio::select! {
+                _ = self.shutdown.started.cancelled() => {
+                    return self.wait_started_shutdown().await;
+                }
+                _ = self.wait_tasks_registered(&mut rx, &pending_ids) => {}
+            }
         }
         self.drive_shutdown().await
     }
@@ -578,16 +761,77 @@ impl SupervisorCore {
 
     /// Initiates explicit graceful shutdown.
     ///
-    /// Publishes `ShutdownRequested`, drains tasks with grace, cancels the runtime token, joins internal listeners,
-    /// and closes subscriber workers within their configured timeout.
-    pub(crate) async fn shutdown(&self) -> Result<(), RuntimeError> {
-        self.bus.publish(Event::new(EventKind::ShutdownRequested));
-        let res = self.drain_with_grace().await;
+    /// Starts or joins one cancellation-safe shutdown operation.
+    pub(crate) async fn shutdown(self: &Arc<Self>) -> Result<(), RuntimeError> {
+        self.join_shutdown(ShutdownTrigger::Requested).await
+    }
+
+    /// Resolves the trigger-specific part of shutdown before common cleanup.
+    async fn resolve_shutdown(&self, trigger: ShutdownTrigger) -> ShutdownOutcome {
+        match trigger {
+            ShutdownTrigger::Requested => {
+                self.bus.publish(Event::new(EventKind::ShutdownRequested));
+                ShutdownOutcome::from_drain_result(self.drain_with_grace().await)
+            }
+            ShutdownTrigger::Natural => {
+                ShutdownOutcome::from_drain_result(self.drain_with_grace().await)
+            }
+            ShutdownTrigger::SignalSetupFailed(source) => {
+                let _ = self.close_admission_and_fence_registry().await;
+                ShutdownOutcome::SignalSetupFailed { source }
+            }
+            #[cfg(test)]
+            ShutdownTrigger::PanicForTest => panic!("injected shutdown panic"),
+        }
+    }
+
+    /// Owns trigger handling and the mandatory cleanup tail.
+    async fn perform_shutdown(&self, trigger: ShutdownTrigger) -> ShutdownOutcome {
+        let outcome = match crate::core::panic_guard::guarded(self.resolve_shutdown(trigger)).await
+        {
+            Ok(outcome) => outcome,
+            Err(panic) => {
+                self.report_shutdown_panic("drain", panic);
+                ShutdownOutcome::ShuttingDown
+            }
+        };
+
+        if self.finish_shutdown_cleanup().await {
+            outcome
+        } else {
+            ShutdownOutcome::ShuttingDown
+        }
+    }
+
+    /// Cancels runtime listeners and closes subscribers, attempting every phase.
+    async fn finish_shutdown_cleanup(&self) -> bool {
+        let mut clean = true;
+
         self.runtime_token.cancel();
-        self.registry.join_listener().await;
-        self.join_subscriber_listener().await;
-        self.subs.close().await;
-        res
+
+        if let Err(panic) = crate::core::panic_guard::guarded(self.registry.join_listener()).await {
+            self.report_shutdown_panic("registry cleanup", panic);
+            clean = false;
+        }
+        if let Err(panic) = crate::core::panic_guard::guarded(self.join_subscriber_listener()).await
+        {
+            self.report_shutdown_panic("subscriber listener cleanup", panic);
+            clean = false;
+        }
+        if let Err(panic) = crate::core::panic_guard::guarded(self.subs.close()).await {
+            self.report_shutdown_panic("subscriber worker cleanup", panic);
+            clean = false;
+        }
+
+        clean
+    }
+
+    /// Reports an internal shutdown panic without interrupting later cleanup phases.
+    fn report_shutdown_panic(&self, phase: &str, panic: String) {
+        self.bus.publish(Event::subscriber_panicked(
+            "shutdown_owner",
+            format!("{phase} panic: {panic}"),
+        ));
     }
 
     /// Returns a best-effort sorted list of task names currently marked alive.
@@ -746,7 +990,11 @@ impl SupervisorCore {
 
     /// Awaits the subscriber listener.
     async fn join_subscriber_listener(&self) {
-        let handle = self.subscriber_handle.lock().unwrap().take();
+        let handle = self
+            .subscriber_handle
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
         if let Some(handle) = handle {
             let _ = handle.await;
         }
@@ -759,31 +1007,27 @@ impl SupervisorCore {
     /// - natural completion when the registry becomes empty.
     ///
     /// Both paths join registry/subscriber listeners and close subscribers before returning.
-    async fn drive_shutdown(&self) -> Result<(), RuntimeError> {
-        let res = tokio::select! {
+    async fn drive_shutdown(self: &Arc<Self>) -> Result<(), RuntimeError> {
+        tokio::select! {
+            _ = self.shutdown.started.cancelled() => self.wait_started_shutdown().await,
             sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
-            _ = self.registry.wait_until_empty() => self.drain_with_grace().await,
-        };
-        self.runtime_token.cancel();
-        self.registry.join_listener().await;
-        self.join_subscriber_listener().await;
-        self.subs.close().await;
-        res
+            _ = self.registry.wait_until_empty() => self.join_shutdown(ShutdownTrigger::Natural).await,
+        }
     }
 
     /// Handles the result of OS shutdown-signal setup/waiting.
     ///
     /// A real signal publishes `ShutdownRequested` and starts graceful drain.
     /// Signal setup errors are returned as [`RuntimeError::SignalSetupFailed`] and are not treated as shutdown requests.
-    async fn on_shutdown_signal(&self, res: std::io::Result<()>) -> Result<(), RuntimeError> {
+    async fn on_shutdown_signal(
+        self: &Arc<Self>,
+        res: std::io::Result<()>,
+    ) -> Result<(), RuntimeError> {
         match res {
-            Ok(()) => {
-                self.bus.publish(Event::new(EventKind::ShutdownRequested));
-                self.drain_with_grace().await
-            }
-            Err(e) => {
-                let _ = self.close_admission_and_fence_registry().await;
-                Err(RuntimeError::SignalSetupFailed { source: e })
+            Ok(()) => self.join_shutdown(ShutdownTrigger::Requested).await,
+            Err(source) => {
+                self.join_shutdown(ShutdownTrigger::SignalSetupFailed(Arc::new(source)))
+                    .await
             }
         }
     }
@@ -797,9 +1041,10 @@ impl SupervisorCore {
     async fn drain_with_grace(&self) -> Result<(), RuntimeError> {
         self.close_admission_and_fence_registry().await?;
         let grace = self.cfg.grace;
-        let deadline = tokio::time::Instant::now() + grace;
-        let mut stuck = self.registry.cancel_all_within(grace).await;
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let effective_grace = grace.min(Duration::from_secs(60 * 60 * 24 * 365 * 30));
+        let started = tokio::time::Instant::now();
+        let mut stuck = self.registry.cancel_all_within(effective_grace).await;
+        let remaining = effective_grace.saturating_sub(started.elapsed());
         stuck.extend(self.registry.wait_joins_within(remaining).await);
         if stuck.is_empty() {
             self.bus
@@ -971,6 +1216,42 @@ mod tests {
         assert!(
             matches!(second, Err(RuntimeError::AlreadyRunning)),
             "second run() must return AlreadyRunning, got {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_panic_still_runs_cleanup_before_caching_result() {
+        let (recorder, seen) = RecordingSub::new();
+        let core = core_with_subs(SupervisorConfig::default(), vec![recorder]);
+        core.start();
+
+        let result = core.join_shutdown(ShutdownTrigger::PanicForTest).await;
+        assert!(
+            matches!(result, Err(RuntimeError::ShuttingDown)),
+            "a shutdown panic must become the shared fallback result: {result:?}"
+        );
+        assert!(core.runtime_token.is_cancelled());
+        assert!(
+            core.subscriber_handle
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .is_none(),
+            "the subscriber listener must be joined before publishing the result"
+        );
+
+        let delivered_before_probe = seen.lock().unwrap().len();
+        core.subs.emit_arc(Arc::new(
+            Event::new(EventKind::TaskStarting).with_task("closed-probe"),
+        ));
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            delivered_before_probe,
+            "subscriber channels must be closed before publishing the result"
+        );
+        assert!(
+            matches!(core.shutdown().await, Err(RuntimeError::ShuttingDown)),
+            "late callers must receive the cached fallback result"
         );
     }
 
@@ -1758,6 +2039,73 @@ mod tests {
             !saw_shutdown,
             "a signal-setup error must NOT masquerade as a shutdown request"
         );
+    }
+
+    #[tokio::test]
+    async fn signal_setup_error_keeps_custom_source_for_late_callers() {
+        #[derive(Debug)]
+        struct Marker;
+
+        impl std::fmt::Display for Marker {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("custom signal marker")
+            }
+        }
+
+        impl std::error::Error for Marker {}
+
+        fn signal_source(result: Result<(), RuntimeError>) -> std::io::Error {
+            match result {
+                Err(RuntimeError::SignalSetupFailed { source }) => source,
+                other => panic!("expected SignalSetupFailed, got {other:?}"),
+            }
+        }
+
+        fn contains_marker(error: &(dyn std::error::Error + 'static)) -> bool {
+            let mut current = Some(error);
+            while let Some(error) = current {
+                if error.downcast_ref::<Marker>().is_some() {
+                    return true;
+                }
+                current = error.source();
+            }
+            false
+        }
+
+        let core = core(SupervisorConfig::default());
+        core.start();
+        let original = std::io::Error::new(std::io::ErrorKind::PermissionDenied, Marker);
+
+        let first = signal_source(core.on_shutdown_signal(Err(original)).await);
+        let late = signal_source(core.shutdown().await);
+
+        for source in [&first, &late] {
+            assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            assert_eq!(source.to_string(), "custom signal marker");
+            assert!(
+                contains_marker(source),
+                "the original custom source must remain in the error chain"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn signal_setup_error_keeps_raw_os_code_for_late_callers() {
+        fn signal_source(result: Result<(), RuntimeError>) -> std::io::Error {
+            match result {
+                Err(RuntimeError::SignalSetupFailed { source }) => source,
+                other => panic!("expected SignalSetupFailed, got {other:?}"),
+            }
+        }
+
+        let core = core(SupervisorConfig::default());
+        core.start();
+        let original = std::io::Error::from_raw_os_error(2);
+
+        let first = signal_source(core.on_shutdown_signal(Err(original)).await);
+        let late = signal_source(core.shutdown().await);
+        assert_eq!(first.raw_os_error(), Some(2));
+        assert_eq!(late.raw_os_error(), Some(2));
     }
 
     #[tokio::test]

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -56,6 +56,8 @@
 //! ## Rules
 //!
 //! - New task admission closes once shutdown begins.
+//! - Shutdown waits for a registry fence before it starts task drain.
+//! - Commands committed before the admission gate closes are processed before that fence.
 //! - Registry membership is keyed by `TaskId`.
 //! - `run()` is single-shot. A second call returns `RuntimeError::AlreadyRunning`.
 //! - `snapshot` and `is_alive` are best-effort views from the alive tracker.
@@ -100,6 +102,7 @@ pub(crate) struct SupervisorCore {
     started: AtomicBool,
     running: AtomicBool,
     shutting_down: AtomicBool,
+    admission_gate: std::sync::Mutex<()>,
     cmd_tx: mpsc::Sender<RegistryCommand>,
     subscriber_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -136,6 +139,7 @@ impl SupervisorCore {
             started: AtomicBool::new(false),
             running: AtomicBool::new(false),
             shutting_down: AtomicBool::new(false),
+            admission_gate: std::sync::Mutex::new(()),
             cmd_tx,
             subscriber_handle: std::sync::Mutex::new(None),
         })
@@ -148,9 +152,37 @@ impl SupervisorCore {
 
     /// Marks the runtime as shutting down.
     ///
-    /// This is idempotent and closes the admission gate for future commands.
+    /// The gate lock waits for every command that already passed its final
+    /// admission check to become visible in the registry queue.
     fn mark_shutting_down(&self) {
+        let _gate = self
+            .admission_gate
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         self.shutting_down.store(true, Ordering::Release);
+    }
+
+    /// Holds the admission gate across a command's final check and queue commit.
+    fn command_admission(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        let gate = self
+            .admission_gate
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if self.is_shutting_down() {
+            None
+        } else {
+            Some(gate)
+        }
+    }
+
+    /// Closes command admission and waits until the registry reaches that ordering point.
+    ///
+    /// Every command committed before the gate closes is ahead of this fence.
+    /// Backpressured callers re-check the gate after receiving capacity and are
+    /// rejected instead of appearing behind the fence.
+    async fn close_admission_and_fence_registry(&self) -> Result<(), RuntimeError> {
+        self.mark_shutting_down();
+        self.registry.fence().await
     }
 
     /// Adds a task and waits for the registry registration decision.
@@ -231,6 +263,7 @@ impl SupervisorCore {
         if self.is_shutting_down() {
             return Err((RuntimeError::ShuttingDown, done));
         }
+        let label: Arc<str> = Arc::from(spec.task().name());
         let permit = match self.cmd_tx.try_reserve() {
             Ok(permit) => permit,
             Err(mpsc::error::TrySendError::Full(())) => {
@@ -240,11 +273,11 @@ impl SupervisorCore {
                 return Err((RuntimeError::ShuttingDown, done));
             }
         };
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err((RuntimeError::ShuttingDown, done));
-        }
-        Ok(self.commit_add(permit, id, spec, done))
+        };
+        Ok(self.commit_add(permit, id, label, spec, done))
     }
 
     /// Waits for bounded queue capacity, then queues one Add command.
@@ -257,15 +290,16 @@ impl SupervisorCore {
         if self.is_shutting_down() {
             return Err((RuntimeError::ShuttingDown, done));
         }
+        let label: Arc<str> = Arc::from(spec.task().name());
         let permit = match self.cmd_tx.reserve().await {
             Ok(permit) => permit,
             Err(_) => return Err((RuntimeError::ShuttingDown, done)),
         };
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err((RuntimeError::ShuttingDown, done));
-        }
-        Ok(self.commit_add(permit, id, spec, done))
+        };
+        Ok(self.commit_add(permit, id, label, spec, done))
     }
 
     /// Publishes the request event and makes an already-reserved Add visible.
@@ -276,10 +310,10 @@ impl SupervisorCore {
         &self,
         permit: mpsc::Permit<'_, RegistryCommand>,
         id: TaskId,
+        label: Arc<str>,
         spec: TaskSpec,
         done: Option<OutcomeTx>,
     ) -> (TaskId, AddReplyRx) {
-        let label: Arc<str> = Arc::from(spec.task().name());
         let (reply, reply_rx) = oneshot::channel();
         self.bus.publish(
             Event::new(EventKind::TaskAddRequested)
@@ -334,10 +368,10 @@ impl SupervisorCore {
             mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
             mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
         })?;
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err(RuntimeError::ShuttingDown);
-        }
+        };
         Ok(self.commit_remove(permit, id, reason))
     }
 
@@ -355,10 +389,10 @@ impl SupervisorCore {
             .reserve()
             .await
             .map_err(|_| RuntimeError::ShuttingDown)?;
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err(RuntimeError::ShuttingDown);
-        }
+        };
         Ok(self.commit_remove(permit, id, reason))
     }
 
@@ -375,10 +409,10 @@ impl SupervisorCore {
             .reserve()
             .await
             .map_err(|_| RuntimeError::ShuttingDown)?;
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err(RuntimeError::ShuttingDown);
-        }
+        };
 
         let (reply, reply_rx) = oneshot::channel();
         permit.send(RegistryCommand::RemoveByLabel { label, reply });
@@ -411,10 +445,10 @@ impl SupervisorCore {
             mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
             mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
         })?;
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err(RuntimeError::ShuttingDown);
-        }
+        };
 
         let (reply, reply_rx) = oneshot::channel();
         permit.send(RegistryCommand::Cancel { id, reply });
@@ -430,10 +464,10 @@ impl SupervisorCore {
             mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
             mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
         })?;
-        if self.is_shutting_down() {
+        let Some(_admission) = self.command_admission() else {
             drop(permit);
             return Err(RuntimeError::ShuttingDown);
-        }
+        };
 
         let (reply, reply_rx) = oneshot::channel();
         permit.send(RegistryCommand::CancelByLabel { label, reply });
@@ -728,19 +762,8 @@ impl SupervisorCore {
     async fn drive_shutdown(&self) -> Result<(), RuntimeError> {
         let res = tokio::select! {
             sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
-            _ = self.registry.wait_until_empty() => {
-                let stuck = self.registry.wait_joins_within(self.cfg.grace).await;
-                if stuck.is_empty() {
-                    self.bus
-                        .publish(Event::new(EventKind::AllStoppedWithinGrace));
-                    Ok(())
-                } else {
-                    self.bus.publish(Event::new(EventKind::GraceExceeded));
-                    Err(RuntimeError::GraceExceeded { grace: self.cfg.grace, stuck })
-                }
-            }
+            _ = self.registry.wait_until_empty() => self.drain_with_grace().await,
         };
-        self.mark_shutting_down();
         self.runtime_token.cancel();
         self.registry.join_listener().await;
         self.join_subscriber_listener().await;
@@ -758,16 +781,21 @@ impl SupervisorCore {
                 self.bus.publish(Event::new(EventKind::ShutdownRequested));
                 self.drain_with_grace().await
             }
-            Err(e) => Err(RuntimeError::SignalSetupFailed { source: e }),
+            Err(e) => {
+                let _ = self.close_admission_and_fence_registry().await;
+                Err(RuntimeError::SignalSetupFailed { source: e })
+            }
         }
     }
 
     /// Cancels tasks and waits for them within the configured grace window.
     ///
-    /// This drains registered tasks first, then waits for detached join reporters using the remaining grace.
+    /// Admission closes first. The registry processes every command accepted
+    /// before that point, then this drains registered tasks and waits for
+    /// detached join reporters using the remaining grace.
     /// Tasks/joiners that do not finish are returned as `GraceExceeded` stuck labels.
     async fn drain_with_grace(&self) -> Result<(), RuntimeError> {
-        self.mark_shutting_down();
+        self.close_admission_and_fence_registry().await?;
         let grace = self.cfg.grace;
         let deadline = tokio::time::Instant::now() + grace;
         let mut stuck = self.registry.cancel_all_within(grace).await;
@@ -972,6 +1000,124 @@ mod tests {
         );
 
         let _ = core.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_fence_processes_committed_add_before_drain() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskError, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            grace: Duration::from_secs(1),
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let accepted_id = TaskId::next();
+        let accepted: TaskRef =
+            TaskFn::arc("accepted-before-shutdown", |ctx: TaskContext| async move {
+                ctx.cancelled().await;
+                Err(TaskError::Canceled)
+            });
+        let (outcome, outcome_rx) = oneshot::channel();
+        let (_, add_reply) = core
+            .enqueue_add_task(accepted_id, TaskSpec::restartable(accepted), Some(outcome))
+            .expect("the Add command must be committed before shutdown starts");
+
+        let mut shutdown = Box::pin(core.shutdown());
+        assert_pending_once(shutdown.as_mut()).await;
+        assert!(core.is_shutting_down());
+
+        let late_runs = Arc::new(AtomicUsize::new(0));
+        let late_runs_by_task = Arc::clone(&late_runs);
+        let late: TaskRef = TaskFn::arc("rejected-after-shutdown", move |_ctx: TaskContext| {
+            late_runs_by_task.fetch_add(1, Ordering::SeqCst);
+            async { Ok(()) }
+        });
+        assert!(matches!(
+            core.add_task(TaskSpec::once(late)).await,
+            Err(RuntimeError::ShuttingDown)
+        ));
+
+        core.start();
+        assert!(matches!(
+            timeout(Duration::from_secs(2), add_reply)
+                .await
+                .expect("the accepted Add must receive its registry reply"),
+            Ok(Ok(()))
+        ));
+        timeout(Duration::from_secs(2), shutdown)
+            .await
+            .expect("shutdown must pass the fence and finish")
+            .expect("the accepted cooperative task must drain cleanly");
+        timeout(Duration::from_secs(2), outcome_rx)
+            .await
+            .expect("the accepted watched task must receive a terminal outcome")
+            .expect("the registry must keep the watched outcome sender");
+
+        assert!(!core.contains_id(accepted_id).await);
+        assert_eq!(late_runs.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unpolled_backpressured_add_does_not_block_shutdown_fence() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            grace: Duration::from_secs(1),
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the command queue");
+
+        let rejected_id = TaskId::next();
+        let runs = Arc::new(AtomicUsize::new(0));
+        let runs_by_task = Arc::clone(&runs);
+        let rejected: TaskRef =
+            TaskFn::arc("backpressured-at-shutdown", move |_ctx: TaskContext| {
+                runs_by_task.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+        let mut add =
+            Box::pin(core.enqueue_add_task_wait(rejected_id, TaskSpec::once(rejected), None));
+        assert_pending_once(add.as_mut()).await;
+
+        let mut shutdown = Box::pin(core.shutdown());
+        assert_pending_once(shutdown.as_mut()).await;
+        assert!(core.is_shutting_down());
+
+        core.start();
+        timeout(Duration::from_secs(2), shutdown)
+            .await
+            .expect("the control fence must not wait for the backpressured Add")
+            .expect("an empty registry must shut down cleanly");
+        assert!(matches!(
+            timeout(Duration::from_secs(2), filler_reply)
+                .await
+                .expect("the filler must receive its registry reply"),
+            Ok(Ok(false))
+        ));
+        assert!(matches!(
+            timeout(Duration::from_secs(2), add)
+                .await
+                .expect("the backpressured Add must wake after admission closes"),
+            Err((RuntimeError::ShuttingDown, None))
+        ));
+
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.id != Some(rejected_id) || event.kind != EventKind::TaskAddRequested,
+                "an Add rejected behind the admission gate must stay silent"
+            );
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1591,6 +1737,7 @@ mod tests {
     #[tokio::test]
     async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
         let core = core(SupervisorConfig::default());
+        core.start();
         let mut rx = core.bus.subscribe();
 
         let err = std::io::Error::other("signal registration failed");
@@ -1616,6 +1763,7 @@ mod tests {
     #[tokio::test]
     async fn real_signal_publishes_shutdown_requested() {
         let core = core(SupervisorConfig::default());
+        core.start();
         let mut rx = core.bus.subscribe();
 
         let out = core.on_shutdown_signal(Ok(())).await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ pub enum RuntimeError {
     /// OS signal listener setup failed.
     ///
     /// Signal-based shutdown is unavailable.
-    /// The original [`std::io::Error`] is preserved as the source.
+    /// The I/O error kind, message, and source chain are preserved for every caller that joins the shared shutdown operation.
     #[error("failed to install shutdown signal handlers: {source}")]
     SignalSetupFailed {
         /// I/O error returned by signal registration.

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -2,7 +2,10 @@
 
 mod common;
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Condvar, Mutex};
+use std::task::Poll;
 use std::time::Duration;
 
 use common::*;
@@ -14,6 +17,34 @@ fn make_stubborn(name: &str) -> TaskRef {
         tokio::time::sleep(Duration::from_secs(30)).await;
         Ok(())
     })
+}
+
+fn make_gated_cancel(
+    name: &str,
+    started: Arc<tokio::sync::Notify>,
+    cancellation_seen: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+) -> TaskRef {
+    TaskFn::arc(name, move |ctx: TaskContext| {
+        let started = Arc::clone(&started);
+        let cancellation_seen = Arc::clone(&cancellation_seen);
+        let release = Arc::clone(&release);
+        async move {
+            started.notify_one();
+            ctx.cancelled().await;
+            cancellation_seen.notify_one();
+            release.notified().await;
+            Err(TaskError::Canceled)
+        }
+    })
+}
+
+async fn assert_pending_once<F: Future>(mut future: Pin<&mut F>) {
+    std::future::poll_fn(|cx| match future.as_mut().poll(cx) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!("future completed before the expected ordering point"),
+    })
+    .await;
 }
 
 #[derive(Default)]
@@ -254,6 +285,297 @@ async fn shutdown_cooperative_returns_ok_emits_all_stopped_within_grace() {
         requested.seq < all_stopped.seq,
         "ShutdownRequested must precede AllStopped"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_shutdown_waiters_share_clean_result() {
+    let (handle, collector) = served(Duration::from_secs(5));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let id = handle
+        .add(TaskSpec::restartable(make_gated_cancel(
+            "shared-clean",
+            Arc::clone(&started),
+            Arc::clone(&cancellation_seen),
+            Arc::clone(&release),
+        )))
+        .await
+        .expect("the gated task must register");
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("the gated task must start");
+
+    let late = handle.clone();
+    let mut first = Box::pin(handle.clone().shutdown());
+    let mut second = Box::pin(handle.shutdown());
+    tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::select! {
+            result = &mut first => panic!("first shutdown returned before task release: {result:?}"),
+            result = &mut second => panic!("second shutdown returned before task release: {result:?}"),
+            _ = cancellation_seen.notified() => {}
+        }
+    })
+    .await
+    .expect("the shared owner must cancel the task");
+    assert_pending_once(first.as_mut()).await;
+    assert_pending_once(second.as_mut()).await;
+
+    release.notify_one();
+    let (first_result, second_result) = tokio::join!(first, second);
+    assert!(first_result.is_ok(), "first result: {first_result:?}");
+    assert!(second_result.is_ok(), "second result: {second_result:?}");
+    assert!(
+        late.shutdown().await.is_ok(),
+        "a late caller must receive the cached clean result"
+    );
+
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 1);
+    assert_eq!(collector.count(EventKind::GraceExceeded), 0);
+    assert_eq!(
+        collector
+            .by_id(id)
+            .into_iter()
+            .filter(|event| event.kind == EventKind::TaskRemoved)
+            .count(),
+        1
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_shutdown_waiters_share_subscriber_drain() {
+    let (subscriber, gate) = blocking_subscriber();
+    let watchdog = spawn_callback_watchdog(Arc::clone(&gate));
+    let supervisor = Supervisor::builder(SupervisorConfig {
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    })
+    .with_subscriber_shutdown_timeout(Duration::from_secs(5))
+    .with_subscribers(vec![subscriber as Arc<dyn Subscribe>])
+    .build();
+    let handle = supervisor.serve();
+    handle
+        .add(TaskSpec::restartable(make_coop("shared-subscriber-drain")))
+        .await
+        .expect("the cooperative task must register");
+    assert!(
+        wait_for_callback(&gate, |state| state.entered).await,
+        "the blocking callback must start"
+    );
+
+    let mut first = Box::pin(handle.clone().shutdown());
+    let mut second = Box::pin(handle.shutdown());
+    assert_pending_once(first.as_mut()).await;
+    assert_pending_once(second.as_mut()).await;
+
+    release_callback(&gate);
+    let (first_result, second_result) = tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::join!(first, second)
+    })
+    .await
+    .expect("both callers must finish after subscriber drain");
+    assert!(first_result.is_ok(), "first result: {first_result:?}");
+    assert!(second_result.is_ok(), "second result: {second_result:?}");
+    assert!(
+        wait_for_callback(&gate, |state| state.finished).await,
+        "the callback must finish before the shared result is returned"
+    );
+
+    watchdog.join().expect("watchdog thread must not panic");
+    assert!(
+        !gate
+            .0
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .watchdog_fired,
+        "the test must beat its safety watchdog"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_shutdown_waiters_share_grace_exceeded() {
+    let grace = Duration::from_millis(50);
+    let (handle, collector) = served(grace);
+    handle
+        .add(TaskSpec::once(make_stubborn("shared-stuck-a")))
+        .await
+        .expect("first stubborn task must register");
+    handle
+        .add(TaskSpec::once(make_stubborn("shared-stuck-b")))
+        .await
+        .expect("second stubborn task must register");
+
+    let late = handle.clone();
+    let first = handle.clone();
+    let second = handle;
+    let (first_result, second_result) = with_timeout(5, async move {
+        tokio::join!(first.shutdown(), second.shutdown())
+    })
+    .await;
+
+    let (first_grace, first_stuck) = match first_result {
+        Err(RuntimeError::GraceExceeded { grace, stuck }) => (grace, stuck),
+        other => panic!("first caller must receive GraceExceeded, got {other:?}"),
+    };
+    let (second_grace, second_stuck) = match second_result {
+        Err(RuntimeError::GraceExceeded { grace, stuck }) => (grace, stuck),
+        other => panic!("second caller must receive GraceExceeded, got {other:?}"),
+    };
+    assert_eq!(first_grace, grace);
+    assert_eq!(second_grace, grace);
+    assert_eq!(first_stuck, second_stuck, "callers need the same snapshot");
+    let (late_grace, late_stuck) = match late.shutdown().await {
+        Err(RuntimeError::GraceExceeded { grace, stuck }) => (grace, stuck),
+        other => panic!("late caller must receive GraceExceeded, got {other:?}"),
+    };
+    assert_eq!(late_grace, grace);
+    assert_eq!(
+        late_stuck, first_stuck,
+        "late caller needs the cached snapshot"
+    );
+
+    let mut names: Vec<_> = first_stuck.iter().map(|name| name.as_ref()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["shared-stuck-a", "shared-stuck-b"]);
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::GraceExceeded), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn dropping_first_shutdown_waiter_does_not_cancel_owner() {
+    let (handle, collector) = served(Duration::from_secs(5));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    handle
+        .add(TaskSpec::restartable(make_gated_cancel(
+            "dropped-shutdown-waiter",
+            Arc::clone(&started),
+            Arc::clone(&cancellation_seen),
+            Arc::clone(&release),
+        )))
+        .await
+        .expect("the gated task must register");
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("the gated task must start");
+
+    let first_handle = handle.clone();
+    let first_waiter = tokio::spawn(async move { first_handle.shutdown().await });
+    tokio::time::timeout(Duration::from_secs(2), cancellation_seen.notified())
+        .await
+        .expect("the detached owner must start task cancellation");
+    first_waiter.abort();
+    let _ = first_waiter.await;
+
+    let mut second = Box::pin(handle.shutdown());
+    assert_pending_once(second.as_mut()).await;
+    release.notify_one();
+    let result = tokio::time::timeout(Duration::from_secs(2), second)
+        .await
+        .expect("the second waiter must observe owner completion");
+    assert!(result.is_ok(), "joined shutdown result: {result:?}");
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 1);
+    assert_eq!(collector.count(EventKind::GraceExceeded), 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_and_handle_shutdown_share_one_operation() {
+    let collector = EventCollector::new();
+    let supervisor = Supervisor::builder(SupervisorConfig {
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    })
+    .with_subscribers(vec![collector.clone() as Arc<dyn Subscribe>])
+    .build();
+    let handle = supervisor.serve();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let task = make_gated_cancel(
+        "run-shutdown-owner",
+        Arc::clone(&started),
+        Arc::clone(&cancellation_seen),
+        Arc::clone(&release),
+    );
+
+    let run_supervisor = Arc::clone(&supervisor);
+    let run =
+        tokio::spawn(async move { run_supervisor.run(vec![TaskSpec::restartable(task)]).await });
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("the static task must start");
+
+    let mut shutdown = Box::pin(handle.shutdown());
+    tokio::select! {
+        result = &mut shutdown => panic!("shutdown returned before task release: {result:?}"),
+        _ = cancellation_seen.notified() => {}
+    }
+    release.notify_one();
+
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(2), shutdown)
+        .await
+        .expect("handle shutdown must finish");
+    let run_result = tokio::time::timeout(Duration::from_secs(2), run)
+        .await
+        .expect("run must join shared shutdown")
+        .expect("run task must not panic");
+    assert!(shutdown_result.is_ok(), "shutdown: {shutdown_result:?}");
+    assert!(run_result.is_ok(), "run: {run_result:?}");
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 1);
+    assert_eq!(collector.count(EventKind::GraceExceeded), 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_joins_shutdown_that_started_first() {
+    let collector = EventCollector::new();
+    let supervisor = Supervisor::builder(SupervisorConfig {
+        grace: Duration::from_secs(5),
+        ..Default::default()
+    })
+    .with_subscribers(vec![collector.clone() as Arc<dyn Subscribe>])
+    .build();
+    let handle = supervisor.serve();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let cancellation_seen = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    handle
+        .add(TaskSpec::restartable(make_gated_cancel(
+            "shutdown-before-run",
+            Arc::clone(&started),
+            Arc::clone(&cancellation_seen),
+            Arc::clone(&release),
+        )))
+        .await
+        .expect("the gated task must register");
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("the gated task must start");
+
+    let mut shutdown = Box::pin(handle.shutdown());
+    tokio::select! {
+        result = &mut shutdown => panic!("shutdown returned before task release: {result:?}"),
+        _ = cancellation_seen.notified() => {}
+    }
+
+    let mut run = Box::pin(supervisor.run(vec![]));
+    assert_pending_once(run.as_mut()).await;
+    release.notify_one();
+    let (shutdown_result, run_result) = tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::join!(shutdown, run)
+    })
+    .await
+    .expect("run and shutdown must finish together");
+
+    assert!(shutdown_result.is_ok(), "shutdown: {shutdown_result:?}");
+    assert!(run_result.is_ok(), "run: {run_result:?}");
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 1);
+    assert_eq!(collector.count(EventKind::GraceExceeded), 0);
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## 📝 Description
- Make shutdown one shared operation
- Order task add and shutdown in the registry

## 🔄 Related Issues
Resolves #126 #127

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] `task ci` passes locally
