### PR TITLE
[core] Register static run tasks as one batch

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -51,8 +51,8 @@
 //! Supervisor::run(tasks)
 //!   ├─ start subscriber listener
 //!   ├─ start registry listener
-//!   ├─ send initial Add commands
-//!   ├─ wait until initial tasks are accepted/rejected
+//!   ├─ send one initial AddBatch command
+//!   ├─ wait for the direct registry decision
 //!   └─ wait for OS shutdown signal or natural completion
 //!
 //! Supervisor::serve()

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -66,6 +66,8 @@
 //! - Add/remove command replies report registry decisions, not terminal task outcomes.
 //! - Cancel callers share a lossless completion signal owned by the registry.
 //! - A fence reply means every earlier management command has finished processing.
+//! - A static AddBatch validates every label before it starts any task body.
+//! - AddBatch either registers every item or leaves registry state unchanged.
 //! - Cleanup is idempotent. Duplicate or stale completion signals become no-ops.
 //! - The registry does not clean up on `TaskStopped` or `TaskFailed`.
 //! - Task name is a label and a duplicate-name admission gate; reserved while the task is `Registered` or `Removing`.
@@ -74,9 +76,14 @@
 //! - `TaskRemoved` means the registry has finished cleanup for that identity.
 //! - `TaskId` is the canonical identity.
 
-use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
-use tokio::sync::{Notify, RwLock, Semaphore, mpsc, oneshot};
+use tokio::sync::{Notify, RwLock, Semaphore, mpsc, oneshot, watch};
 use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
@@ -91,11 +98,18 @@ use crate::tasks::TaskSpec;
 /// Sender used to resolve a watched task with its final [`TaskOutcome`].
 pub(crate) type OutcomeTx = oneshot::Sender<TaskOutcome>;
 
-/// Authoritative result of one registry add command.
+/// Authoritative result of one single-task or batch registry add command.
 pub(crate) type AddReply = Result<(), RuntimeError>;
 
 /// Receiver for an authoritative registry add result.
 pub(crate) type AddReplyRx = oneshot::Receiver<AddReply>;
+
+/// One task owned by the atomic static-run registration command.
+pub(crate) struct AddBatchItem {
+    pub(crate) id: TaskId,
+    pub(crate) label: Arc<str>,
+    pub(crate) spec: TaskSpec,
+}
 
 /// Authoritative result of one registry remove command.
 ///
@@ -143,6 +157,11 @@ pub(crate) enum RegistryCommand {
         id: TaskId,
         spec: TaskSpec,
         outcome: Option<OutcomeTx>,
+        reply: oneshot::Sender<AddReply>,
+    },
+    /// Validate and register every static-run task as one operation.
+    AddBatch {
+        items: Vec<AddBatchItem>,
         reply: oneshot::Sender<AddReply>,
     },
     /// Remove a task by runtime identity.
@@ -555,6 +574,10 @@ impl Registry {
                 )
                 .await;
             }
+            RegistryCommand::AddBatch { items, reply } => {
+                self.guarded("registry", self.spawn_and_register_batch(items, reply))
+                    .await;
+            }
             RegistryCommand::Remove { id, reply } => {
                 self.guarded("registry", self.remove_task(id, reply)).await;
             }
@@ -628,6 +651,7 @@ impl Registry {
     }
 
     /// Returns true if `id` is registered or removing.
+    #[cfg(any(test, feature = "controller"))]
     pub async fn contains(&self, id: TaskId) -> bool {
         self.state.read().await.tasks.contains_key(&id)
     }
@@ -730,6 +754,125 @@ impl Registry {
         })
     }
 
+    /// Spawns one registered actor, optionally held behind a batch start gate.
+    fn spawn_entry(
+        &self,
+        id: TaskId,
+        label: Arc<str>,
+        spec: TaskSpec,
+        done: Option<OutcomeTx>,
+        start: Option<watch::Receiver<bool>>,
+    ) -> Entry {
+        let task_token = self.runtime_token.child_token();
+
+        let actor = TaskActor::new(
+            self.bus.clone(),
+            Arc::clone(&label),
+            spec.task().clone(),
+            TaskActorParams {
+                restart: spec.restart(),
+                backoff: spec.backoff(),
+                timeout: spec.timeout(),
+                max_retries: spec.max_retries(),
+            },
+            self.semaphore.clone(),
+            id,
+        );
+
+        let task_token_clone = task_token.clone();
+        let actor_future = async move {
+            if let Some(mut start) = start {
+                loop {
+                    if *start.borrow_and_update() {
+                        break;
+                    }
+                    if start.changed().await.is_err() {
+                        return ActorExitReason::Canceled;
+                    }
+                }
+            }
+            actor.run(task_token_clone).await
+        };
+        let join_handle = Self::spawn_tracked_actor(id, self.completion_tx.clone(), actor_future);
+
+        Entry {
+            label,
+            state: EntryState::Registered(Handle {
+                join: join_handle,
+                cancel: task_token,
+                done,
+            }),
+        }
+    }
+
+    /// Validates and registers a complete static task batch without partial start.
+    async fn spawn_and_register_batch(
+        &self,
+        items: Vec<AddBatchItem>,
+        reply: oneshot::Sender<AddReply>,
+    ) {
+        let mut st = self.state.write().await;
+        let mut seen = HashSet::with_capacity(items.len());
+        let mut conflicting_ids = HashSet::new();
+        let mut first_conflict = None;
+
+        for item in &items {
+            let conflicts_with_registry = st.by_label.contains_key(&item.label);
+            let repeats_in_batch = !seen.insert(Arc::clone(&item.label));
+            if conflicts_with_registry || repeats_in_batch {
+                first_conflict.get_or_insert_with(|| Arc::clone(&item.label));
+                conflicting_ids.insert(item.id);
+            }
+        }
+
+        if let Some(name) = first_conflict {
+            drop(st);
+            for item in items {
+                let reason = if conflicting_ids.contains(&item.id) {
+                    reasons::ALREADY_EXISTS
+                } else {
+                    reasons::BATCH_REJECTED
+                };
+                self.bus.publish(
+                    Event::new(EventKind::TaskAddFailed)
+                        .with_task(item.label)
+                        .with_id(item.id)
+                        .with_reason(reason),
+                );
+            }
+            let _ = reply.send(Err(RuntimeError::TaskAlreadyExists { name }));
+            return;
+        }
+
+        let (start_tx, start_rx) = watch::channel(false);
+        let mut accepted = Vec::with_capacity(items.len());
+        for item in items {
+            let id = item.id;
+            let label = item.label;
+            let entry = self.spawn_entry(
+                id,
+                Arc::clone(&label),
+                item.spec,
+                None,
+                Some(start_rx.clone()),
+            );
+            st.tasks.insert(id, entry);
+            st.by_label.insert(Arc::clone(&label), id);
+            accepted.push((id, label));
+        }
+        drop(st);
+
+        for (id, label) in accepted {
+            self.bus.publish(
+                Event::new(EventKind::TaskAdded)
+                    .with_task(label)
+                    .with_id(id),
+            );
+        }
+        let _ = reply.send(Ok(()));
+        start_tx.send_replace(true);
+    }
+
     /// Spawns an actor and registers it under `id`.
     ///
     /// Duplicate task names are rejected.
@@ -764,37 +907,8 @@ impl Registry {
             return;
         }
 
-        let task_token = self.runtime_token.child_token();
-
-        let actor = TaskActor::new(
-            self.bus.clone(),
-            label.clone(),
-            spec.task().clone(),
-            TaskActorParams {
-                restart: spec.restart(),
-                backoff: spec.backoff(),
-                timeout: spec.timeout(),
-                max_retries: spec.max_retries(),
-            },
-            self.semaphore.clone(),
-            id,
-        );
-
-        let task_token_clone = task_token.clone();
-        let join_handle =
-            Self::spawn_tracked_actor(id, self.completion_tx.clone(), actor.run(task_token_clone));
-
-        st.tasks.insert(
-            id,
-            Entry {
-                label: Arc::clone(&label),
-                state: EntryState::Registered(Handle {
-                    join: join_handle,
-                    cancel: task_token,
-                    done,
-                }),
-            },
-        );
+        let entry = self.spawn_entry(id, Arc::clone(&label), spec, done, None);
+        st.tasks.insert(id, entry);
         st.by_label.insert(label.clone(), id);
         drop(st);
 
@@ -1317,6 +1431,21 @@ mod tests {
         reply_rx
     }
 
+    fn batch_item(id: TaskId, spec: TaskSpec) -> AddBatchItem {
+        AddBatchItem {
+            id,
+            label: Arc::from(spec.task().name()),
+            spec,
+        }
+    }
+
+    fn send_batch(tx: &mpsc::Sender<RegistryCommand>, items: Vec<AddBatchItem>) -> AddReplyRx {
+        let (reply, reply_rx) = oneshot::channel();
+        tx.try_send(RegistryCommand::AddBatch { items, reply })
+            .expect("registry command channel must stay open");
+        reply_rx
+    }
+
     fn send_remove(tx: &mpsc::Sender<RegistryCommand>, id: TaskId) -> RemoveReplyRx {
         let (reply, reply_rx) = oneshot::channel();
         tx.try_send(RegistryCommand::Remove { id, reply })
@@ -1396,6 +1525,249 @@ mod tests {
             "event lag must not change the authoritative add result"
         );
 
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn batch_reply_commits_every_task_as_one_registry_decision() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(1));
+        let mut events = bus.subscribe();
+        let mut expected = Vec::new();
+        let mut items = Vec::new();
+        for label in ["batch-a", "batch-b", "batch-c"] {
+            let id = TaskId::next();
+            let task: TaskRef = TaskFn::arc(label, |ctx: TaskContext| async move {
+                ctx.cancelled().await;
+                Ok(())
+            });
+            expected.push((id, Arc::from(label)));
+            items.push(batch_item(id, TaskSpec::restartable(task)));
+        }
+        expected.sort_by_key(|(id, _)| *id);
+
+        let result = receive_reply(send_batch(&tx, items), "batch add reply").await;
+        assert!(result.is_ok(), "unique batch must be accepted: {result:?}");
+        assert_eq!(registry.list().await, expected);
+
+        let added: Vec<_> = std::iter::from_fn(|| events.try_recv().ok())
+            .filter(|event| event.kind == EventKind::TaskAdded)
+            .collect();
+        assert_eq!(added.len(), 3);
+
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropped_batch_reply_still_starts_after_all_added_events() {
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(1));
+        let mut events = bus.subscribe();
+        let (body_tx, mut body_rx) = mpsc::unbounded_channel();
+        let mut items = Vec::new();
+        for label in ["dropped-batch-a", "dropped-batch-b"] {
+            let id = TaskId::next();
+            let body_tx = body_tx.clone();
+            let task: TaskRef = TaskFn::arc(label, move |_ctx: TaskContext| {
+                let _ = body_tx.send(id);
+                async { Ok(()) }
+            });
+            items.push(batch_item(id, TaskSpec::once(task)));
+        }
+        drop(body_tx);
+
+        let reply = send_batch(&tx, items);
+        drop(reply);
+        let first = receive_completion(&mut body_rx, "first batch body").await;
+        let second = receive_completion(&mut body_rx, "second batch body").await;
+        assert_ne!(first, second);
+        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
+            .await
+            .expect("both one-shot batch tasks must finish");
+
+        let observed: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        let added: Vec<_> = observed
+            .iter()
+            .filter(|event| event.kind == EventKind::TaskAdded)
+            .collect();
+        let starting: Vec<_> = observed
+            .iter()
+            .filter(|event| event.kind == EventKind::TaskStarting)
+            .collect();
+        assert_eq!(added.len(), 2);
+        assert_eq!(starting.len(), 2);
+        let last_added = added.iter().map(|event| event.seq).max().unwrap();
+        let first_starting = starting.iter().map(|event| event.seq).min().unwrap();
+        assert!(
+            last_added < first_starting,
+            "the batch start gate must keep bodies behind all TaskAdded events"
+        );
+
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn duplicate_inside_batch_rejects_every_item_without_starting_bodies() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(1));
+        let mut events = bus.subscribe();
+        let runs = Arc::new(AtomicUsize::new(0));
+        let mut items = Vec::new();
+        let mut ids = Vec::new();
+        for label in ["unique", "duplicate", "duplicate"] {
+            let runs = Arc::clone(&runs);
+            let task: TaskRef = TaskFn::arc(label, move |_ctx: TaskContext| {
+                runs.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+            let id = TaskId::next();
+            ids.push(id);
+            items.push(batch_item(id, TaskSpec::once(task)));
+        }
+
+        let result = receive_reply(send_batch(&tx, items), "duplicate batch reply").await;
+        assert!(
+            matches!(
+                result,
+                Err(RuntimeError::TaskAlreadyExists { ref name }) if name.as_ref() == "duplicate"
+            ),
+            "the first conflicting input label must reject the batch: {result:?}"
+        );
+        assert!(registry.list().await.is_empty());
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+
+        let observed: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        assert_eq!(
+            observed
+                .iter()
+                .filter(|event| event.kind == EventKind::TaskAdded)
+                .count(),
+            0
+        );
+        let failed: Vec<_> = observed
+            .into_iter()
+            .filter(|event| event.kind == EventKind::TaskAddFailed)
+            .collect();
+        assert_eq!(failed.len(), 3);
+        assert_eq!(failed[0].id, Some(ids[0]));
+        assert_eq!(failed[0].reason.as_deref(), Some(reasons::BATCH_REJECTED));
+        assert_eq!(failed[1].id, Some(ids[1]));
+        assert_eq!(failed[1].reason.as_deref(), Some(reasons::BATCH_REJECTED));
+        assert_eq!(failed[2].id, Some(ids[2]));
+        assert_eq!(failed[2].reason.as_deref(), Some(reasons::ALREADY_EXISTS));
+
+        stop_registry(&registry, &token).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn batch_conflict_with_registered_or_removing_label_starts_no_new_body() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskError, TaskFn, TaskRef};
+
+        let (registry, _bus, token, tx) = started_registry(64, Duration::from_secs(1));
+        let started = Arc::new(Notify::new());
+        let cancellation_seen = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let started_by_task = Arc::clone(&started);
+        let seen_by_task = Arc::clone(&cancellation_seen);
+        let release_by_task = Arc::clone(&release);
+        let existing: TaskRef = TaskFn::arc("reserved-batch-name", move |ctx: TaskContext| {
+            let started = Arc::clone(&started_by_task);
+            let cancellation_seen = Arc::clone(&seen_by_task);
+            let release = Arc::clone(&release_by_task);
+            async move {
+                started.notify_one();
+                ctx.cancelled().await;
+                cancellation_seen.notify_one();
+                release.notified().await;
+                Err(TaskError::Canceled)
+            }
+        });
+        let existing_id = TaskId::next();
+        assert!(
+            receive_reply(
+                send_add(&tx, existing_id, TaskSpec::restartable(existing), None,),
+                "existing add reply",
+            )
+            .await
+            .is_ok()
+        );
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("the existing task body must start before removal");
+
+        let candidate_runs = Arc::new(AtomicUsize::new(0));
+        let make_candidate = |label: &'static str| {
+            let runs = Arc::clone(&candidate_runs);
+            let task: TaskRef = TaskFn::arc(label, move |_ctx: TaskContext| {
+                runs.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+            batch_item(TaskId::next(), TaskSpec::once(task))
+        };
+
+        let registered_result = receive_reply(
+            send_batch(
+                &tx,
+                vec![
+                    make_candidate("registered-peer"),
+                    make_candidate("reserved-batch-name"),
+                ],
+            ),
+            "registered conflict batch",
+        )
+        .await;
+        assert!(matches!(
+            registered_result,
+            Err(RuntimeError::TaskAlreadyExists { name })
+                if name.as_ref() == "reserved-batch-name"
+        ));
+        assert_eq!(candidate_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            registry.list().await,
+            vec![(existing_id, Arc::from("reserved-batch-name"))]
+        );
+
+        assert!(matches!(
+            receive_reply(send_remove(&tx, existing_id), "existing remove reply").await,
+            Ok(true)
+        ));
+        tokio::time::timeout(Duration::from_secs(2), cancellation_seen.notified())
+            .await
+            .expect("the existing task must enter Removing");
+
+        let removing_result = receive_reply(
+            send_batch(
+                &tx,
+                vec![
+                    make_candidate("removing-peer"),
+                    make_candidate("reserved-batch-name"),
+                ],
+            ),
+            "removing conflict batch",
+        )
+        .await;
+        assert!(matches!(
+            removing_result,
+            Err(RuntimeError::TaskAlreadyExists { name })
+                if name.as_ref() == "reserved-batch-name"
+        ));
+        assert_eq!(candidate_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            registry.list().await,
+            vec![(existing_id, Arc::from("reserved-batch-name"))]
+        );
+
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), registry.wait_until_empty())
+            .await
+            .expect("the existing removing task must finish");
         stop_registry(&registry, &token).await;
     }
 

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -42,8 +42,8 @@
 //!
 //! run(tasks)
 //!   starts listeners
-//!   adds initial tasks
-//!   waits for registration confirmation best-effort
+//!   registers all initial tasks as one atomic batch
+//!   waits for the direct registry reply
 //!   waits for OS shutdown signal or natural completion
 //!
 //! shutdown()
@@ -61,6 +61,7 @@
 //! - Explicit, signal, and natural shutdown paths join one detached operation.
 //! - Every shutdown waiter receives the same cached result after full cleanup.
 //! - The first shutdown trigger controls the result and request events.
+//! - Static `run()` tasks are accepted or rejected as one registry operation.
 //! - Registry membership is keyed by `TaskId`.
 //! - `run()` is single-shot. A second call returns `RuntimeError::AlreadyRunning`.
 //! - `snapshot` and `is_alive` are best-effort views from the alive tracker.
@@ -77,8 +78,8 @@ use tokio_util::sync::CancellationToken;
 use crate::core::{
     alive::AliveTracker,
     registry::{
-        AddReplyRx, CancelDecision, CancelReplyRx, OutcomeTx, Registry, RegistryCommand,
-        RemoveReplyRx,
+        AddBatchItem, AddReplyRx, CancelDecision, CancelReplyRx, OutcomeTx, Registry,
+        RegistryCommand, RemoveReplyRx,
     },
 };
 use crate::{
@@ -498,6 +499,44 @@ impl SupervisorCore {
         (id, reply_rx)
     }
 
+    /// Waits for one queue slot, then commits the complete static task batch.
+    async fn enqueue_add_batch_wait(
+        &self,
+        items: Vec<AddBatchItem>,
+    ) -> Result<AddReplyRx, RuntimeError> {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self
+            .cmd_tx
+            .reserve()
+            .await
+            .map_err(|_| RuntimeError::ShuttingDown)?;
+        let Some(_admission) = self.command_admission() else {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        };
+
+        let (reply, reply_rx) = oneshot::channel();
+        for item in &items {
+            self.bus.publish(
+                Event::new(EventKind::TaskAddRequested)
+                    .with_task(Arc::clone(&item.label))
+                    .with_id(item.id),
+            );
+        }
+        permit.send(RegistryCommand::AddBatch { items, reply });
+        Ok(reply_rx)
+    }
+
+    /// Resolves the authoritative decision for one static registration batch.
+    async fn await_add_batch_reply(reply: AddReplyRx) -> Result<(), RuntimeError> {
+        match reply.await {
+            Ok(result) => result,
+            Err(_) => Err(RuntimeError::ShuttingDown),
+        }
+    }
+
     /// Removes a task after queue capacity and the registry claim decision.
     pub(crate) async fn remove(&self, id: TaskId) -> Result<bool, RuntimeError> {
         let reply = self.enqueue_remove_wait(id, None).await?;
@@ -677,9 +716,8 @@ impl SupervisorCore {
 
     /// Runs a static task set until OS shutdown signal or natural completion.
     ///
-    /// This starts the runtime listeners, queues the initial tasks, waits for their
-    /// registration confirmations best-effort, then drives shutdown/natural
-    /// completion.
+    /// This starts the runtime listeners, registers the initial tasks as one
+    /// atomic batch, then drives shutdown or natural completion.
     ///
     /// Single-shot: a second or concurrent call returns [`RuntimeError::AlreadyRunning`].
     pub(crate) async fn run(self: &Arc<Self>, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
@@ -691,72 +729,33 @@ impl SupervisorCore {
         }
         self.start();
 
-        if !tasks.is_empty() {
-            let mut rx = self.bus.subscribe();
-            let mut pending_ids = Vec::with_capacity(tasks.len());
-            for spec in tasks {
-                let queued = self.enqueue_add_task_wait(TaskId::next(), spec, None).await;
-                let (id, reply) = match queued {
-                    Ok(queued) => queued,
-                    Err((RuntimeError::ShuttingDown, _))
-                        if self.shutdown.started.is_cancelled() =>
-                    {
-                        return self.wait_started_shutdown().await;
-                    }
-                    Err((error, _)) => return Err(error),
-                };
-                drop(reply);
-                pending_ids.push(id);
-            }
-            tokio::select! {
-                _ = self.shutdown.started.cancelled() => {
-                    return self.wait_started_shutdown().await;
-                }
-                _ = self.wait_tasks_registered(&mut rx, &pending_ids) => {}
-            }
+        if tasks.is_empty() {
+            return self.drive_shutdown().await;
         }
-        self.drive_shutdown().await
-    }
 
-    /// Best-effort wait for initial task registration events.
-    ///
-    /// Waits for `TaskAdded` or `TaskAddFailed` for every initial task id.
-    /// If the bus receiver lags, falls back to registry membership.
-    ///
-    /// This wait has a fixed backstop and currently does not return an error when the backstop expires.
-    async fn wait_tasks_registered(
-        &self,
-        rx: &mut broadcast::Receiver<Arc<Event>>,
-        ids: &[TaskId],
-    ) {
-        let mut pending: Vec<TaskId> = ids.to_vec();
-
-        let confirm = async {
-            while !pending.is_empty() {
-                match rx.recv().await {
-                    Ok(ev)
-                        if matches!(ev.kind, EventKind::TaskAdded | EventKind::TaskAddFailed) =>
-                    {
-                        if let Some(id) = ev.id {
-                            pending.retain(|p| *p != id);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        let mut still = Vec::new();
-                        for id in std::mem::take(&mut pending) {
-                            if !self.registry.contains(id).await {
-                                still.push(id);
-                            }
-                        }
-                        pending = still;
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                }
+        let items = tasks
+            .into_iter()
+            .map(|spec| AddBatchItem {
+                id: TaskId::next(),
+                label: Arc::from(spec.task().name()),
+                spec,
+            })
+            .collect();
+        let reply = match self.enqueue_add_batch_wait(items).await {
+            Ok(reply) => reply,
+            Err(RuntimeError::ShuttingDown) if self.shutdown.started.is_cancelled() => {
+                return self.wait_started_shutdown().await;
             }
+            Err(error) => return Err(error),
         };
-        const CONFIRM_BACKSTOP: Duration = Duration::from_secs(5);
-        let _ = timeout(CONFIRM_BACKSTOP, confirm).await;
+
+        match Self::await_add_batch_reply(reply).await {
+            Ok(()) => self.drive_shutdown().await,
+            Err(RuntimeError::ShuttingDown) if self.shutdown.started.is_cancelled() => {
+                self.wait_started_shutdown().await
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Initiates explicit graceful shutdown.
@@ -1342,6 +1341,208 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_fence_processes_whole_committed_batch_before_drain() {
+        use crate::{TaskContext, TaskError, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            grace: Duration::from_secs(1),
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let mut ids = Vec::new();
+        let mut items = Vec::new();
+        for label in ["batch-before-shutdown-a", "batch-before-shutdown-b"] {
+            let task: TaskRef = TaskFn::arc(label, |ctx: TaskContext| async move {
+                ctx.cancelled().await;
+                Err(TaskError::Canceled)
+            });
+            let id = TaskId::next();
+            ids.push(id);
+            items.push(AddBatchItem {
+                id,
+                label: Arc::from(label),
+                spec: TaskSpec::restartable(task),
+            });
+        }
+        let batch_reply = core
+            .enqueue_add_batch_wait(items)
+            .await
+            .expect("the whole batch must commit before shutdown starts");
+
+        let mut shutdown = Box::pin(core.shutdown());
+        assert_pending_once(shutdown.as_mut()).await;
+        core.start();
+
+        assert!(matches!(
+            timeout(Duration::from_secs(2), batch_reply)
+                .await
+                .expect("the committed batch reply must resolve"),
+            Ok(Ok(()))
+        ));
+        timeout(Duration::from_secs(2), shutdown)
+            .await
+            .expect("shutdown must pass the batch fence")
+            .expect("the accepted batch must drain cleanly");
+        assert!(core.registry.list().await.is_empty());
+
+        let observed: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        for id in ids {
+            assert!(
+                observed
+                    .iter()
+                    .any(|event| { event.id == Some(id) && event.kind == EventKind::TaskAdded })
+            );
+            assert!(
+                observed
+                    .iter()
+                    .any(|event| { event.id == Some(id) && event.kind == EventKind::TaskRemoved })
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn committed_duplicate_batch_keeps_its_error_during_shutdown() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let core = core(SupervisorConfig::default());
+        let mut events = core.bus.subscribe();
+        let runs = Arc::new(AtomicUsize::new(0));
+        let mut items = Vec::new();
+        for label in ["shutdown-peer", "shutdown-duplicate", "shutdown-duplicate"] {
+            let runs = Arc::clone(&runs);
+            let task: TaskRef = TaskFn::arc(label, move |_ctx: TaskContext| {
+                runs.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+            items.push(AddBatchItem {
+                id: TaskId::next(),
+                label: Arc::from(label),
+                spec: TaskSpec::once(task),
+            });
+        }
+        let batch_reply = core
+            .enqueue_add_batch_wait(items)
+            .await
+            .expect("the duplicate batch must commit before shutdown starts");
+
+        let mut shutdown = Box::pin(core.shutdown());
+        assert_pending_once(shutdown.as_mut()).await;
+        core.start();
+
+        let batch_result = timeout(
+            Duration::from_secs(2),
+            SupervisorCore::await_add_batch_reply(batch_reply),
+        )
+        .await
+        .expect("the committed duplicate batch must receive its decision");
+        assert!(matches!(
+            batch_result,
+            Err(RuntimeError::TaskAlreadyExists { name })
+                if name.as_ref() == "shutdown-duplicate"
+        ));
+        timeout(Duration::from_secs(2), shutdown)
+            .await
+            .expect("explicit shutdown must finish after the batch decision")
+            .expect("the rejected batch leaves an empty clean runtime");
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+
+        let observed: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        assert_eq!(
+            observed
+                .iter()
+                .filter(|event| event.kind == EventKind::TaskAddFailed)
+                .count(),
+            3
+        );
+        assert_eq!(
+            observed
+                .iter()
+                .filter(|event| event.kind == EventKind::TaskAdded)
+                .count(),
+            0
+        );
+        assert_eq!(
+            observed
+                .iter()
+                .filter(|event| event.kind == EventKind::ShutdownRequested)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backpressured_batch_loses_whole_admission_race_to_shutdown() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::{TaskContext, TaskFn, TaskRef};
+
+        let cfg = SupervisorConfig {
+            grace: Duration::from_secs(1),
+            registry_queue_capacity: 1,
+            ..Default::default()
+        };
+        let core = core(cfg);
+        let mut events = core.bus.subscribe();
+        let filler_reply = core
+            .enqueue_remove(TaskId::next(), None)
+            .expect("the filler must occupy the command queue");
+        let runs = Arc::new(AtomicUsize::new(0));
+        let mut ids = Vec::new();
+        let mut items = Vec::new();
+        for label in ["batch-after-shutdown-a", "batch-after-shutdown-b"] {
+            let runs = Arc::clone(&runs);
+            let task: TaskRef = TaskFn::arc(label, move |_ctx: TaskContext| {
+                runs.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+            let id = TaskId::next();
+            ids.push(id);
+            items.push(AddBatchItem {
+                id,
+                label: Arc::from(label),
+                spec: TaskSpec::once(task),
+            });
+        }
+
+        let mut batch = Box::pin(core.enqueue_add_batch_wait(items));
+        assert_pending_once(batch.as_mut()).await;
+        let mut shutdown = Box::pin(core.shutdown());
+        assert_pending_once(shutdown.as_mut()).await;
+        core.start();
+
+        timeout(Duration::from_secs(2), shutdown)
+            .await
+            .expect("the fence must not wait for the backpressured batch")
+            .expect("the empty runtime must shut down cleanly");
+        assert!(matches!(
+            timeout(Duration::from_secs(2), filler_reply)
+                .await
+                .expect("the filler reply must resolve"),
+            Ok(Ok(false))
+        ));
+        assert!(matches!(
+            timeout(Duration::from_secs(2), batch)
+                .await
+                .expect("the whole batch must wake after admission closes"),
+            Err(RuntimeError::ShuttingDown)
+        ));
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+
+        while let Ok(event) = events.try_recv() {
+            if let Some(id) = event.id {
+                assert!(
+                    !ids.contains(&id) || event.kind != EventKind::TaskAddRequested,
+                    "a batch rejected behind the admission gate must stay silent"
+                );
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn unpolled_backpressured_add_does_not_block_shutdown_fence() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1908,16 +2109,26 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn static_run_backpressures_initial_batch_larger_than_queue() {
+    async fn static_run_batch_uses_one_queue_slot_with_lagged_observer() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         use crate::{TaskContext, TaskFn, TaskRef};
 
         let cfg = SupervisorConfig {
+            bus_capacity: 1,
             registry_queue_capacity: 1,
             ..Default::default()
         };
         let core = core(cfg);
+        let mut stale_events = core.bus.subscribe();
+        for index in 0..4 {
+            core.bus
+                .publish(Event::new(EventKind::TaskStarting).with_task(format!("noise-{index}")));
+        }
+        assert!(matches!(
+            stale_events.try_recv(),
+            Err(broadcast::error::TryRecvError::Lagged(_))
+        ));
         let runs = Arc::new(AtomicUsize::new(0));
         let tasks = (0..4)
             .map(|index| {

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -142,13 +142,18 @@ impl Supervisor {
     /// Runs a fixed task set until natural completion or OS shutdown signal.
     ///
     /// This is static mode.
-    /// It starts the runtime, submits the provided tasks, and waits until all tasks complete or a shutdown signal is received.
+    /// It validates and registers the provided tasks as one atomic batch, then waits until all tasks complete or a shutdown signal is received.
+    /// If one task name conflicts, no task from the batch starts.
+    ///
+    /// A rejected batch does not stop tasks that were already registered through [`serve`](Self::serve).
+    /// The runtime stays open for dynamic management, but `run` remains single-shot and cannot be called again.
     ///
     /// `run` is single-shot for one supervisor instance.
     ///
     /// # Errors
     ///
     /// - [`RuntimeError::GraceExceeded`] when some tasks did not stop within the grace period.
+    /// - [`RuntimeError::TaskAlreadyExists`] when a task name is already in use or repeated in the batch.
     /// - [`RuntimeError::SignalSetupFailed`] when OS signal handlers cannot be installed.
     /// - [`RuntimeError::AlreadyRunning`] when `run` is called a second time.
     pub async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,8 +38,8 @@ pub enum RuntimeError {
         stuck: Vec<Arc<str>>,
     },
 
-    /// A task with the same name is already registered.
-    #[error("task '{name}' already exists in registry")]
+    /// A task with the same name is already registered or repeated in an atomic batch.
+    #[error("task name '{name}' already exists")]
     TaskAlreadyExists {
         /// Duplicate task name.
         name: Arc<str>,

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -177,8 +177,8 @@ pub enum EventKind {
 
     /// Request to add a new task to the supervisor.
     ///
-    /// Published by Supervisor on the bus for observability before sending
-    /// the `Add` command to Registry via mpsc.
+    /// Published before an `Add` command is sent. For an atomic `AddBatch`, one
+    /// request event is published per item before the whole command is sent.
     ///
     /// Sets:
     /// - `id`: task run identity (pre-allocated for this add request)
@@ -196,15 +196,16 @@ pub enum EventKind {
     /// - `seq`: global sequence
     TaskAdded,
 
-    /// Task could not be added: a task with the same name is already registered.
+    /// Task could not be added because its name conflicts or its atomic static
+    /// batch was rejected.
     ///
-    /// Published by Registry instead of `TaskAdded` when an `Add` command targets a name that already exists;
-    /// no new actor is spawned.
+    /// Published by Registry instead of `TaskAdded`. No actor is spawned for a
+    /// rejected dynamic add or for any item in a rejected static batch.
     ///
     /// Sets:
     /// - `id`: task run identity of the rejected add request
     /// - `task`: task name
-    /// - `reason`: e.g. "already_exists"
+    /// - `reason`: e.g. "already_exists" or "batch_rejected"
     /// - `at`: wall-clock timestamp
     /// - `seq`: global sequence
     TaskAddFailed,

--- a/src/reasons.rs
+++ b/src/reasons.rs
@@ -11,6 +11,7 @@
 //! | [`TASK_RETURNED_CANCELED`]   | `ActorExhausted`                                       | The task stopped itself.               |
 //! | [`MAX_RETRIES_EXCEEDED`]     | `ActorExhausted` (prefix)                              | Retry limit reached.                   |
 //! | [`ALREADY_EXISTS`]           | `TaskAddFailed`, `TaskOutcome::Rejected`               | A task with this name already exists.  |
+//! | [`BATCH_REJECTED`]           | `TaskAddFailed`                                        | Another item rejected the whole batch. |
 //! | [`QUEUE_FULL`]               | `ControllerRejected`, `TaskOutcome::Rejected` (prefix) | The slot queue is full.                |
 //! | [`REMOVED_FROM_QUEUE`]       | `ControllerRejected`, `TaskOutcome::Rejected`          | A queued task was removed.             |
 //! | [`SUPERSEDED_BY_REPLACE`]    | `ControllerRejected`, `TaskOutcome::Rejected`          | A newer `Replace` task took its place. |
@@ -37,6 +38,9 @@ pub const MAX_RETRIES_EXCEEDED: &str = "max_retries_exceeded";
 /// Registration/rejection reason: another running task already uses this name.
 pub const ALREADY_EXISTS: &str = "already_exists";
 
+/// Registration reason: another item caused an atomic static batch to be rejected.
+pub const BATCH_REJECTED: &str = "batch_rejected";
+
 /// Rejection reason **prefix**: a controller slot queue is full.
 ///
 /// The full reason is `queue_full: <depth>/<limit>`.
@@ -62,6 +66,7 @@ mod tests {
         assert_eq!(TASK_RETURNED_CANCELED, "task_returned_canceled");
         assert_eq!(MAX_RETRIES_EXCEEDED, "max_retries_exceeded");
         assert_eq!(ALREADY_EXISTS, "already_exists");
+        assert_eq!(BATCH_REJECTED, "batch_rejected");
         assert_eq!(QUEUE_FULL, "queue_full");
         assert_eq!(REMOVED_FROM_QUEUE, "removed_from_queue");
         assert_eq!(SUPERSEDED_BY_REPLACE, "superseded_by_replace");

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -464,6 +464,84 @@ async fn static_run_multiple_oneshots_all_complete_run_returns_ok() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn duplicate_static_batch_starts_no_task_body() {
+    let collector = EventCollector::new();
+    let supervisor = Supervisor::new(
+        SupervisorConfig::default(),
+        vec![collector.clone() as Arc<dyn Subscribe>],
+    );
+    let runs = Arc::new(AtomicU32::new(0));
+    let specs = ["unique", "duplicate", "duplicate"]
+        .into_iter()
+        .map(|label| {
+            let runs = Arc::clone(&runs);
+            let task = TaskFn::arc(label, move |_ctx: TaskContext| {
+                runs.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
+            TaskSpec::once(task)
+        })
+        .collect();
+
+    let result = with_timeout(5, supervisor.run(specs)).await;
+    assert!(
+        matches!(
+            result,
+            Err(RuntimeError::TaskAlreadyExists { ref name }) if name.as_ref() == "duplicate"
+        ),
+        "the duplicate label must reject the full batch: {result:?}"
+    );
+    assert_eq!(runs.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        supervisor.run(vec![]).await,
+        Err(RuntimeError::AlreadyRunning)
+    ));
+
+    let handle = supervisor.serve();
+    handle
+        .add(TaskSpec::restartable(make_coop("after-batch-error")))
+        .await
+        .expect("a rejected batch must leave the runtime open");
+    handle
+        .shutdown()
+        .await
+        .expect("the reused runtime must shut down cleanly");
+
+    assert_eq!(collector.count(EventKind::TaskAddRequested), 4);
+    assert_eq!(collector.count(EventKind::TaskAddFailed), 3);
+    assert_eq!(collector.count(EventKind::TaskAdded), 1);
+    assert_eq!(collector.count(EventKind::ShutdownRequested), 1);
+    assert_eq!(collector.count(EventKind::AllStoppedWithinGrace), 1);
+
+    for label in ["unique", "duplicate"] {
+        assert!(collector.by_label(label).iter().all(|event| {
+            !matches!(event.kind, EventKind::TaskAdded | EventKind::TaskStarting)
+        }));
+    }
+
+    let unique_failure = collector
+        .by_label("unique")
+        .into_iter()
+        .find(|event| event.kind == EventKind::TaskAddFailed)
+        .expect("unique item must receive its batch rejection event");
+    assert_eq!(
+        unique_failure.reason.as_deref(),
+        Some(taskvisor::reasons::BATCH_REJECTED)
+    );
+    let duplicate_reasons: Vec<_> = collector
+        .by_label("duplicate")
+        .into_iter()
+        .filter(|event| event.kind == EventKind::TaskAddFailed)
+        .filter_map(|event| event.reason)
+        .collect();
+    assert!(
+        duplicate_reasons
+            .iter()
+            .any(|reason| reason.as_ref() == taskvisor::reasons::ALREADY_EXISTS)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn terminal_events_carry_attempt_duration() {
     let collector = EventCollector::new();
     let subs: Vec<Arc<dyn Subscribe>> = vec![collector.clone() as Arc<dyn Subscribe>];


### PR DESCRIPTION
## 📝 Description

- Send all initial `run()` tasks in one registry command.
- Check all task names before any task starts.
- Reject the full batch if one name conflicts.
- Use a direct registry reply instead of runtime events.

## 🔄 Related Issues
Resolves #128

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] `task ci` passes locally
