### PR TITLE
Remove signal own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -571,7 +571,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -629,6 +629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "taskvisor"
 version = "0.7.0"
 dependencies = [
@@ -646,22 +657,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -685,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "libc",
  "mio",
@@ -705,14 +716,14 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -810,7 +821,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -896,7 +907,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ features     = ["logging", "tracing", "controller", "tokio-util-interop", "test-
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-tokio      = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }
-tokio-util = "0.7.18"
-thiserror  = "2.0.18"
-fastrand   = "2.4.1"
+tokio      = { version = "1.53.1", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }
+tokio-util = "0.7.19"
+thiserror  = "2.0.20"
+fastrand   = "2.5.0"
 dashmap    = { version = "6.1.0", optional = true }
 tracing    = { version = "0.1.44", optional = true, default-features = false, features = ["std"] }
 
@@ -46,7 +46,7 @@ criterion          = { version = "0.8.2", features = ["async_tokio"] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 prometheus         = { version = "0.14.0", default-features = false }
 rayon              = "1.12.0"
-tokio              = { version = "1.52.3", features = ["test-util"] }
+tokio              = { version = "1.53.1", features = ["test-util"] }
 
 [[example]]
 name              = "slots"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Once the task is defined, its supervision policy becomes one declaration:
 
 ```rust,ignore
 supervisor
-    .run(vec![TaskSpec::restartable(worker)])
+    .run_with_os_signals(vec![TaskSpec::restartable(worker)])
     .await?;
 ```
 
@@ -177,10 +177,14 @@ Retries for one task run in sequence. Two attempts for the same `TaskId` never r
 
 There are two runtime modes:
 
-| Mode                    | Use it when                | Shutdown owner                                  |
-|-------------------------|----------------------------|-------------------------------------------------|
-| `supervisor.run(specs)` | Tasks are known at startup | Taskvisor waits for completion or an OS signal. |
-| `supervisor.serve()`    | Tasks are added at runtime | Your code calls `handle.shutdown().await`.      |
+| Mode                                    | Use it when                              | Shutdown owner                                      |
+|-----------------------------------------|------------------------------------------|-----------------------------------------------------|
+| `supervisor.run(specs)`                 | Tasks finish naturally                   | No process signal handlers are installed            |
+| `supervisor.run_until(specs, future)`   | The application owns its shutdown source | The supplied future requests graceful shutdown      |
+| `supervisor.run_with_os_signals(specs)` | Taskvisor should own process signals      | Explicit SIGINT/SIGTERM/SIGQUIT or Ctrl-C handling  |
+| `supervisor.serve()`                    | Tasks are added at runtime               | Your code calls `handle.shutdown().await`            |
+
+`run_with_os_signals` is an explicit process-wide opt-in. On Unix, Tokio does not restore the default signal disposition when its listeners are dropped, so the application remains responsible for signal handling after that method returns. `run` and `run_until` never install signal listeners.
 
 `Supervisor::run(...).await == Ok(())` means the supervisor lifecycle and cleanup completed successfully. It does not mean that every task succeeded, and `run` does not return per-task outcomes. Register work through `add_and_watch` or `submit_and_watch` when application logic needs the final result.
 

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = SupervisorConfig::default().with_grace(Duration::from_secs(5));
     let supervisor = Supervisor::new(config, vec![]);
-    supervisor.run(specs).await?;
+    supervisor.run_with_os_signals(specs).await?;
 
     Ok(())
 }

--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spec = TaskSpec::periodic(heartbeat, Duration::from_secs(2));
 
     let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
-    supervisor.run(vec![spec]).await?;
+    supervisor.run_with_os_signals(vec![spec]).await?;
 
     Ok(())
 }

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spec = TaskSpec::restartable(worker);
 
     let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
-    supervisor.run(vec![spec]).await?;
+    supervisor.run_with_os_signals(vec![spec]).await?;
 
     Ok(())
 }

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -8,17 +8,17 @@ It shows which module owns each decision and how data moves through the runtime.
 
 Read the code in this order if you are new to the repository:
 
-| Step | Files                                                                                                                                                                          | Question answered                                               |
-|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| 1    | [`lib.rs`](lib.rs), [`prelude.rs`](prelude.rs)                                                                                                                                 | What is public                                                  |
-| 2    | [`tasks/`](tasks), [`policies/`](policies), [`core/task_defaults.rs`](core/task_defaults.rs)                                                                                   | What describes a task and its retry rules                       |
-| 3    | [`core/builder.rs`](core/builder.rs), [`core/supervisor.rs`](core/supervisor.rs), [`core/handle.rs`](core/handle.rs), [`core/owner.rs`](core/owner.rs)                         | How is the runtime built, owned, and exposed                    |
-| 4    | [`core/runtime.rs`](core/runtime.rs), [`core/runtime/management.rs`](core/runtime/management.rs), [`core/runtime/lifecycle.rs`](core/runtime/lifecycle.rs)                     | How do public calls enter the runtime                           |
-| 5    | [`core/registry.rs`](core/registry.rs), [`core/registry/`](core/registry)                                                                                                      | Which task state is authoritative, and how is it cleaned up     |
-| 6    | [`core/actor.rs`](core/actor.rs), [`core/runner.rs`](core/runner.rs)                                                                                                           | How does one task run, retry, time out, and stop                |
-| 7    | [`core/outcome.rs`](core/outcome.rs), [`events/`](events), [`subscribers/`](subscribers)                                                                                       | Which results are reliable, and which signals are observability |
+| Step | Files                                                                                                                                                                           | Question answered                                               |
+|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| 1    | [`lib.rs`](lib.rs), [`prelude.rs`](prelude.rs)                                                                                                                                  | What is public                                                  |
+| 2    | [`tasks/`](tasks), [`policies/`](policies), [`core/task_defaults.rs`](core/task_defaults.rs)                                                                                    | What describes a task and its retry rules                       |
+| 3    | [`core/builder.rs`](core/builder.rs), [`core/supervisor.rs`](core/supervisor.rs), [`core/handle.rs`](core/handle.rs), [`core/owner.rs`](core/owner.rs)                          | How is the runtime built, owned, and exposed                    |
+| 4    | [`core/runtime.rs`](core/runtime.rs), [`core/runtime/management.rs`](core/runtime/management.rs), [`core/runtime/lifecycle.rs`](core/runtime/lifecycle.rs)                      | How do public calls enter the runtime                           |
+| 5    | [`core/registry.rs`](core/registry.rs), [`core/registry/`](core/registry)                                                                                                       | Which task state is authoritative, and how is it cleaned up     |
+| 6    | [`core/actor.rs`](core/actor.rs), [`core/runner.rs`](core/runner.rs)                                                                                                            | How does one task run, retry, time out, and stop                |
+| 7    | [`core/outcome.rs`](core/outcome.rs), [`events/`](events), [`subscribers/`](subscribers)                                                                                        | Which results are reliable, and which signals are observability |
 | 8    | [`controller/mod.rs`](controller/mod.rs), [`controller/prepared.rs`](controller/prepared.rs), [`controller/slot.rs`](controller/slot.rs), [`controller/core/`](controller/core) | How does per-slot queue/replace/reject admission work           |
-| 9    | [`core/runtime/shutdown_workflow.rs`](core/runtime/shutdown_workflow.rs), [`core/shutdown.rs`](core/shutdown.rs), [`controller/core/shutdown.rs`](controller/core/shutdown.rs) | How is one shared shutdown coordinated                          |
+| 9    | [`core/runtime/shutdown_workflow.rs`](core/runtime/shutdown_workflow.rs), [`core/shutdown.rs`](core/shutdown.rs), [`controller/core/shutdown.rs`](controller/core/shutdown.rs)  | How is one shared shutdown coordinated                          |
 
 After the module documentation, read the integration tests by behavior: [`tests/watch.rs`](../tests/watch.rs), [`tests/identity.rs`](../tests/identity.rs), [`tests/controller.rs`](../tests/controller.rs), and [`tests/shutdown.rs`](../tests/shutdown.rs).
 
@@ -307,13 +307,14 @@ Policy behavior around those phases:
 
 ## Shared shutdown
 
-Explicit shutdown, a received OS signal, and natural completion join one cancellation-safe shutdown operation. The first trigger installs the operation; all callers wait for its cached result.
+Explicit shutdown, an application-owned `run_until` future, an OS signal explicitly enabled through `run_with_os_signals`, and natural completion join one cancellation-safe shutdown operation. The first trigger installs the operation; all callers wait for its cached result. Plain `run` does not install process signal handlers.
 
 ```mermaid
 %%{init: {"flowchart": {"curve": "linear"}}}%%
 flowchart LR
     Explicit["Explicit request"]
-    Signal["Received OS signal"]
+    External["Application shutdown future"]
+    Signal["Explicitly configured OS signal"]
     Natural["Registry becomes empty"]
     Coordinator["ShutdownCoordinator: first trigger wins"]
     Close["Close management admission,<br/>fence committed registry commands"]
@@ -323,6 +324,7 @@ flowchart LR
     Result["Cache and return<br/>one shared result"]
 
     Explicit --> Coordinator
+    External --> Coordinator
     Signal --> Coordinator
     Natural --> Coordinator
     Coordinator --> Close
@@ -333,7 +335,7 @@ flowchart LR
     Tail --> Result
 ```
 
-Subscriber shutdown has its own timeout and happens after the task grace phase. Every common cleanup phase is attempted even if an earlier phase reports an internal failure. If OS signal setup itself fails, shutdown still closes admission and runs the common cleanup tail, but it does not run the normal task-drain branch. Dropping the last runtime owner is only a synchronous fallback: it closes admission and cancels tokens, but cannot await or report graceful cleanup.
+Subscriber shutdown has its own timeout and happens after the task grace phase. Every common cleanup phase is attempted even if an earlier phase reports an internal failure. If explicitly requested OS signal setup fails, shutdown still closes admission and runs the common cleanup tail, but it does not run the normal task-drain branch. On Unix, Tokio's process-global handlers are not restored when listeners are dropped; this side effect exists only after the application calls `run_with_os_signals`. Dropping the last runtime owner is only a synchronous fallback: it closes admission and cancels tokens, but cannot await or report graceful cleanup.
 
 ## Where to make a change
 
@@ -348,19 +350,3 @@ Subscriber shutdown has its own timeout and happens after the task grace phase. 
 | Per-slot queue/replace/reject behavior                      | [`controller/slot.rs`](controller/slot.rs), [`controller/core/admission.rs`](controller/core/admission.rs), [`controller/core/queue.rs`](controller/core/queue.rs)                             | [`tests/controller.rs`](../tests/controller.rs), controller unit tests                                                                |
 | Shutdown order or grace behavior                            | [`core/runtime/shutdown_workflow.rs`](core/runtime/shutdown_workflow.rs), [`core/registry/removal.rs`](core/registry/removal.rs), [`controller/core/shutdown.rs`](controller/core/shutdown.rs) | [`tests/shutdown.rs`](../tests/shutdown.rs), [`tests/ownership.rs`](../tests/ownership.rs)                                            |
 | User-facing story                                           | [`../README.md`](../README.md), [`../examples/`](../examples), [`lib.rs`](lib.rs)                                                                                                              | `cargo test --all-features`, `cargo test --doc --all-features`                                                                        |
-
-## Invariants to preserve
-
-Before changing a coordination path, check these constraints in the owning module and its tests:
-
-1. Registry membership is authoritative; events never add or remove membership.
-2. Task ID and name indexes change under the same registry state lock.
-3. A name stays reserved until terminal join cleanup removes it.
-4. Exactly one cleanup owner claims and joins each actor handle.
-5. Accepted task bodies start only after indexing and the admission publication/reply attempts.
-6. Watched outcomes resolve outside the best-effort event path, after the actor join and registry membership removal.
-7. The serialized controller loop owns slot transitions; queued work starts only after the current Add is rejected or the current owner reaches terminal removal completion.
-8. Management admission closes and committed commands are fenced before shutdown drains tasks.
-9. Concurrent shutdown callers join the same operation and receive its cached result.
-
-When a change crosses one of these boundaries, update both the module-level documentation and the relevant diagram in this guide.

--- a/src/controller/core/admission.rs
+++ b/src/controller/core/admission.rs
@@ -4,12 +4,11 @@ use std::sync::Arc;
 
 use tokio::{task::JoinSet, time::Instant};
 
-use crate::core::SupervisorCore;
+use crate::core::{OutcomeTx, SupervisorCore, TaskOutcome};
 use crate::{
-    RuntimeError, TaskSpec,
     controller::{
         admission::AdmissionPolicy,
-        slot::{AdmissionTransition, ReplaceAction, SlotPhase, SlotState},
+        slot::{AdmissionTransition, PendingSubmission, ReplaceAction, SlotPhase, SlotState},
     },
     events::{Event, EventKind, RejectionKind},
     identity::TaskId,
@@ -18,10 +17,146 @@ use crate::{
 
 use super::{AdmissionResult, CompletionResult, Controller, RemovalResult, Submission};
 
+/// Keeps one watched admission owned across controller-side pre-commit work.
+///
+/// Before parking, the sender is local. After parking, it lives in `Controller::watchers`.
+/// A normal queue/registry commit disarms the guard.
+/// Unwinding user metadata preparation therefore resolves the waiter as an admission failure instead of leaving it parked.
+struct AdmissionWatcher<'a> {
+    controller: &'a Controller,
+    id: TaskId,
+    event_task: Option<Arc<str>>,
+    state: AdmissionWatcherState,
+}
+
+/// Registry handoff that did not commit and therefore remains controller-owned.
+type StartFailure = Box<crate::core::UncommittedWatchedAdd>;
+
+enum AdmissionWatcherState {
+    Local(Option<OutcomeTx>),
+    Parked,
+    Committed,
+}
+
+impl<'a> AdmissionWatcher<'a> {
+    fn new(
+        controller: &'a Controller,
+        id: TaskId,
+        done: Option<OutcomeTx>,
+        event_task: Option<Arc<str>>,
+    ) -> Self {
+        Self {
+            controller,
+            id,
+            event_task,
+            state: AdmissionWatcherState::Local(done),
+        }
+    }
+
+    /// Sets the slot label used by a possible rejection event.
+    fn set_event_task(&mut self, task: Arc<str>) {
+        self.event_task = Some(task);
+    }
+
+    /// Moves a watched sender into the controller map after user metadata is prepared.
+    fn park(&mut self) {
+        let state = std::mem::replace(&mut self.state, AdmissionWatcherState::Committed);
+        match state {
+            AdmissionWatcherState::Local(Some(tx)) => {
+                self.controller.watchers.insert(self.id, tx);
+                self.state = AdmissionWatcherState::Parked;
+            }
+            AdmissionWatcherState::Local(None) => {
+                self.state = AdmissionWatcherState::Parked;
+            }
+            AdmissionWatcherState::Committed => {}
+            AdmissionWatcherState::Parked => {
+                self.state = AdmissionWatcherState::Parked;
+            }
+        }
+    }
+
+    /// Marks queue or registry ownership as authoritative.
+    fn commit(&mut self) {
+        debug_assert!(
+            !matches!(self.state, AdmissionWatcherState::Local(Some(_))),
+            "a watched admission must be parked before commit"
+        );
+        self.state = AdmissionWatcherState::Committed;
+    }
+
+    /// Resolves a normal controller rejection and disarms unwind fallback.
+    fn reject(&mut self, kind: RejectionKind, reason: &str) {
+        let state = std::mem::replace(&mut self.state, AdmissionWatcherState::Committed);
+        match state {
+            AdmissionWatcherState::Local(Some(tx)) => {
+                let _ = tx.send(TaskOutcome::Rejected {
+                    kind,
+                    reason: Arc::from(reason),
+                });
+            }
+            AdmissionWatcherState::Parked => {
+                self.controller.finalize_rejected(self.id, kind, reason);
+            }
+            AdmissionWatcherState::Local(None) | AdmissionWatcherState::Committed => {}
+        }
+    }
+
+    /// Publishes and resolves one controller-side rejection exactly once.
+    fn reject_with_event(&mut self, kind: RejectionKind, reason: &str) {
+        if matches!(self.state, AdmissionWatcherState::Committed) {
+            return;
+        }
+        let mut event = Event::new(EventKind::ControllerRejected)
+            .with_id(self.id)
+            .with_rejection_kind(kind)
+            .with_reason(reason);
+        if let Some(task) = &self.event_task {
+            event = event.with_task(Arc::clone(task));
+        }
+        self.controller.bus.publish(event);
+        self.reject(kind, reason);
+    }
+}
+
+impl Drop for AdmissionWatcher<'_> {
+    fn drop(&mut self) {
+        if matches!(self.state, AdmissionWatcherState::Committed) {
+            return;
+        }
+        self.reject_with_event(
+            RejectionKind::AdmissionFailed,
+            crate::reasons::CONTROLLER_ADMISSION_INTERRUPTED,
+        );
+    }
+}
+
 impl Controller {
+    /// Returns an immediate busy-slot rejection that needs no task metadata.
+    fn busy_rejection(
+        &self,
+        slot: &SlotState,
+        admission: AdmissionPolicy,
+    ) -> Option<(RejectionKind, String)> {
+        if slot.is_idle() {
+            return None;
+        }
+        match admission {
+            AdmissionPolicy::Queue => self
+                .queue_full_reason(slot.queue.len())
+                .map(|reason| (RejectionKind::QueueFull, reason)),
+            AdmissionPolicy::DropIfRunning => Some((
+                RejectionKind::SlotBusy,
+                format!("{} ({})", reasons::DROP_IF_RUNNING, slot.status_label()),
+            )),
+            AdmissionPolicy::Replace => None,
+        }
+    }
+
     /// Applies admission policy for one submission.
     ///
     /// Watched submissions are parked in `watchers` until they are either rejected by the controller or handed to the runtime registry.
+    /// User-provided task metadata is snapshotted before parking, so a panic from `Task::name` cannot strand the waiter.
     ///
     /// Policy behavior:
     /// - idle slot: try to commit the registry Add; enter `Admitting` on success, otherwise reject the submission,
@@ -36,55 +171,101 @@ impl Controller {
         admissions: &mut JoinSet<AdmissionResult>,
         removals: &mut JoinSet<RemovalResult>,
     ) {
+        let Submission { id, spec, done } = sub;
+        let admission = spec.admission();
+        let explicit_slot = spec.slot_override().map(Arc::<str>::from);
+        let mut watcher =
+            AdmissionWatcher::new(self, id, done, explicit_slot.as_ref().map(Arc::clone));
         let Some(sup) = self.supervisor.upgrade() else {
+            watcher.reject_with_event(
+                RejectionKind::AdmissionFailed,
+                reasons::CONTROLLER_ADMISSION_INTERRUPTED,
+            );
+            self.drop_guarded("drop_unavailable_submission", spec).await;
             return;
         };
-        let Submission { id, spec, done } = sub;
-        if let Some(tx) = done {
-            self.watchers.insert(id, tx);
-        }
+
         if self.is_shutting_down() {
-            self.bus.publish(
-                Event::new(EventKind::ControllerRejected)
-                    .with_task(spec.slot_name().to_owned())
-                    .with_id(id)
-                    .with_rejection_kind(RejectionKind::ControllerShuttingDown)
-                    .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
-            );
-            self.finalize_rejected(
-                id,
+            watcher.reject_with_event(
                 RejectionKind::ControllerShuttingDown,
-                crate::reasons::CONTROLLER_SHUTTING_DOWN,
+                reasons::CONTROLLER_SHUTTING_DOWN,
             );
+            self.drop_guarded("drop_shutdown_submission", spec).await;
             return;
         }
 
-        let slot_name: Arc<str> = Arc::from(spec.slot_name());
-        let admission = spec.admission();
-        let task_spec = spec.into_task_spec();
+        // An explicit slot is sufficient for policy-only rejection.
+        // Avoid calling user-provided `Task::name` when the task cannot be admitted anyway.
+        if let Some(slot_name) = &explicit_slot
+            && let Some(slot_arc) = self.slots.get(&**slot_name).map(|entry| entry.clone())
+        {
+            let slot = slot_arc.lock().await;
+            if self.is_shutting_down() {
+                drop(slot);
+                watcher.reject_with_event(
+                    RejectionKind::ControllerShuttingDown,
+                    reasons::CONTROLLER_SHUTTING_DOWN,
+                );
+                self.drop_guarded("drop_shutdown_submission", spec).await;
+                return;
+            }
+            let rejection = self.busy_rejection(&slot, admission);
+            drop(slot);
+            if let Some((kind, reason)) = rejection {
+                watcher.reject_with_event(kind, &reason);
+                self.drop_guarded("drop_policy_rejected_submission", spec)
+                    .await;
+                return;
+            }
+        }
 
+        let Some(task_name) = self
+            .guarded("task_name_snapshot", async {
+                Arc::<str>::from(spec.task_spec().name())
+            })
+            .await
+        else {
+            watcher.reject_with_event(
+                RejectionKind::AdmissionFailed,
+                reasons::CONTROLLER_ADMISSION_INTERRUPTED,
+            );
+            self.drop_guarded("drop_name_rejected_submission", spec)
+                .await;
+            return;
+        };
+        let slot_name = explicit_slot.unwrap_or_else(|| Arc::clone(&task_name));
+        watcher.set_event_task(Arc::clone(&slot_name));
+        let pending = PendingSubmission::new(id, task_name, spec.into_task_spec());
+
+        if self.is_shutting_down() {
+            watcher.reject_with_event(
+                RejectionKind::ControllerShuttingDown,
+                reasons::CONTROLLER_SHUTTING_DOWN,
+            );
+            self.drop_guarded("drop_shutdown_submission", pending).await;
+            return;
+        }
+
+        watcher.park();
+
+        let mut displaced_to_drop = None;
         let slot_arc = self.get_or_create_slot(&slot_name);
         let mut slot = slot_arc.lock().await;
         if self.is_shutting_down() {
-            self.bus.publish(
-                Event::new(EventKind::ControllerRejected)
-                    .with_task(Arc::clone(&slot_name))
-                    .with_id(id)
-                    .with_rejection_kind(RejectionKind::ControllerShuttingDown)
-                    .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
-            );
-            self.finalize_rejected(
-                id,
+            watcher.reject_with_event(
                 RejectionKind::ControllerShuttingDown,
-                crate::reasons::CONTROLLER_SHUTTING_DOWN,
+                reasons::CONTROLLER_SHUTTING_DOWN,
             );
+            self.gc_if_idle(&slot_name, slot);
+            self.drop_guarded("drop_shutdown_submission", pending).await;
             return;
         }
 
         match (slot.phase(), admission) {
             (SlotPhase::Idle, _) => {
-                match self.start_in_slot(&sup, &mut slot, &slot_name, id, task_spec, admissions) {
+                match self.start_in_slot(&sup, &mut slot, &slot_name, pending, admissions) {
                     Ok(()) => {
+                        watcher.commit();
                         let reason: &'static str = match admission {
                             AdmissionPolicy::Queue => "admission=Queue status=admitting",
                             AdmissionPolicy::Replace => "admission=Replace status=admitting",
@@ -99,22 +280,18 @@ impl Controller {
                                 .with_reason(reason),
                         );
                     }
-                    Err(e) => {
-                        let reason = format!("add_failed: {e}");
-                        self.bus.publish(
-                            Event::new(EventKind::ControllerRejected)
-                                .with_task(Arc::clone(&slot_name))
-                                .with_id(id)
-                                .with_rejection_kind(RejectionKind::AdmissionFailed)
-                                .with_reason(reason.clone()),
-                        );
-                        self.finalize_rejected(id, RejectionKind::AdmissionFailed, &reason);
+                    Err(uncommitted) => {
+                        let reason = format!("add_failed: {}", uncommitted.error);
+                        watcher.reject_with_event(RejectionKind::AdmissionFailed, &reason);
                         self.gc_if_idle(&slot_name, slot);
+                        self.drop_start_failure(uncommitted).await;
+                        return;
                     }
                 }
             }
             (SlotPhase::Running { .. }, AdmissionPolicy::Replace) => {
-                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
+                displaced_to_drop = self.replace_head_or_push(&mut slot, &slot_name, pending);
+                watcher.commit();
                 let ReplaceAction::RemoveNow(owner) = slot.request_replacement(Instant::now())
                 else {
                     unreachable!("a running slot must start removal on replace")
@@ -133,7 +310,8 @@ impl Controller {
                 );
             }
             (SlotPhase::Admitting { .. }, AdmissionPolicy::Replace) => {
-                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
+                displaced_to_drop = self.replace_head_or_push(&mut slot, &slot_name, pending);
+                watcher.commit();
                 let action = slot.request_replacement(Instant::now());
                 debug_assert_eq!(action, ReplaceAction::WaitForAdmission);
                 self.bus.publish(
@@ -155,7 +333,8 @@ impl Controller {
                 SlotPhase::CancelPendingAdmission { .. } | SlotPhase::Terminating { .. },
                 AdmissionPolicy::Replace,
             ) => {
-                self.replace_head_or_push(&mut slot, &slot_name, id, task_spec);
+                displaced_to_drop = self.replace_head_or_push(&mut slot, &slot_name, pending);
+                watcher.commit();
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
@@ -173,10 +352,15 @@ impl Controller {
                 | SlotPhase::Terminating { .. },
                 AdmissionPolicy::Queue,
             ) => {
-                if self.reject_if_full(&slot_name, id, slot.queue.len()) {
+                if let Some(reason) = self.queue_full_reason(slot.queue.len()) {
+                    watcher.reject_with_event(RejectionKind::QueueFull, &reason);
+                    drop(slot);
+                    self.drop_guarded("drop_policy_rejected_submission", pending)
+                        .await;
                     return;
                 }
-                slot.queue.push_back((id, task_spec));
+                slot.queue.push_back(pending);
+                watcher.commit();
                 self.bus.publish(
                     Event::new(EventKind::ControllerSubmitted)
                         .with_task(Arc::clone(&slot_name))
@@ -192,15 +376,20 @@ impl Controller {
                 AdmissionPolicy::DropIfRunning,
             ) => {
                 let reason = format!("{} ({})", reasons::DROP_IF_RUNNING, slot.status_label());
-                self.bus.publish(
-                    Event::new(EventKind::ControllerRejected)
-                        .with_task(Arc::clone(&slot_name))
-                        .with_id(id)
-                        .with_rejection_kind(RejectionKind::SlotBusy)
-                        .with_reason(reason.clone()),
-                );
-                self.finalize_rejected(id, RejectionKind::SlotBusy, &reason);
+                watcher.reject_with_event(RejectionKind::SlotBusy, &reason);
+                drop(slot);
+                self.drop_guarded("drop_policy_rejected_submission", pending)
+                    .await;
+                return;
             }
+        }
+
+        // A displaced user task may own an arbitrary destructor.
+        // Release the slot lock before dropping it; its watcher has already reached a terminal result.
+        drop(slot);
+        if let Some(displaced) = displaced_to_drop {
+            self.drop_guarded("drop_superseded_submission", displaced)
+                .await;
         }
     }
 
@@ -248,13 +437,16 @@ impl Controller {
                     return;
                 }
 
-                if !self.is_shutting_down()
+                let deferred_drops = if !self.is_shutting_down()
                     && let Some(sup) = self.supervisor.upgrade()
                 {
-                    self.start_next_from_queue(&sup, &mut slot, &slot_name, admissions);
-                }
+                    self.start_next_from_queue(&sup, &mut slot, &slot_name, admissions)
+                } else {
+                    Vec::new()
+                };
 
                 self.gc_if_idle(&slot_name, slot);
+                self.drop_pending_submissions(deferred_drops).await;
             }
         }
     }
@@ -282,11 +474,14 @@ impl Controller {
             return;
         }
 
-        if !self.is_shutting_down() {
-            self.start_next_from_queue(&sup, &mut slot, &result.slot_name, admissions);
-        }
+        let deferred_drops = if !self.is_shutting_down() {
+            self.start_next_from_queue(&sup, &mut slot, &result.slot_name, admissions)
+        } else {
+            Vec::new()
+        };
 
         self.gc_if_idle(&result.slot_name, slot);
+        self.drop_pending_submissions(deferred_drops).await;
     }
 
     /// Hands a submission to the runtime under its pre-minted id.
@@ -298,24 +493,28 @@ impl Controller {
         sup: &Arc<SupervisorCore>,
         slot: &mut SlotState,
         slot_name: &Arc<str>,
-        id: TaskId,
-        task_spec: TaskSpec,
+        pending: PendingSubmission,
         admissions: &mut JoinSet<AdmissionResult>,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<(), StartFailure> {
         assert!(slot.is_idle(), "start_in_slot requires an idle slot");
+        let PendingSubmission {
+            id,
+            task_name,
+            task_spec,
+        } = pending;
         let done = self.watchers.remove(&id).map(|(_, tx)| tx);
-        match sup.add_task_with_id_watched(id, task_spec, done) {
+        match sup.add_task_with_id_watched(id, task_name, task_spec, done) {
             Ok((reply, completion)) => {
                 let started = slot.begin_admission(id, Instant::now());
                 debug_assert!(started);
                 Self::track_admission(admissions, id, Arc::clone(slot_name), reply, completion);
                 Ok(())
             }
-            Err((e, done)) => {
-                if let Some(tx) = done {
+            Err(mut uncommitted) => {
+                if let Some(tx) = uncommitted.done.take() {
                     self.watchers.insert(id, tx);
                 }
-                Err(e)
+                Err(uncommitted)
             }
         }
     }
@@ -332,13 +531,15 @@ impl Controller {
         slot: &mut SlotState,
         slot_name: &Arc<str>,
         admissions: &mut JoinSet<AdmissionResult>,
-    ) {
+    ) -> Vec<StartFailure> {
+        let mut deferred_drops = Vec::new();
         debug_assert!(slot.is_idle());
         if !slot.is_idle() {
-            return;
+            return deferred_drops;
         }
-        while let Some((next_id, next_spec)) = slot.queue.pop_front() {
-            match self.start_in_slot(sup, slot, slot_name, next_id, next_spec, admissions) {
+        while let Some(next) = slot.queue.pop_front() {
+            let next_id = next.id;
+            match self.start_in_slot(sup, slot, slot_name, next, admissions) {
                 Ok(()) => {
                     self.bus.publish(
                         Event::new(EventKind::ControllerSubmitted)
@@ -346,10 +547,10 @@ impl Controller {
                             .with_id(next_id)
                             .with_reason(format!("started_from_queue depth={}", slot.queue.len())),
                     );
-                    return;
+                    return deferred_drops;
                 }
-                Err(e) => {
-                    let reason = format!("queue_start_failed: {e}");
+                Err(uncommitted) => {
+                    let reason = format!("queue_start_failed: {}", uncommitted.error);
                     self.bus.publish(
                         Event::new(EventKind::ControllerRejected)
                             .with_task(Arc::clone(slot_name))
@@ -358,8 +559,30 @@ impl Controller {
                             .with_reason(reason.clone()),
                     );
                     self.finalize_rejected(next_id, RejectionKind::AdmissionFailed, &reason);
+                    deferred_drops.push(uncommitted);
                 }
             }
         }
+        deferred_drops
+    }
+
+    /// Drops rejected queue payloads only after their outcomes are terminal and the slot is unlocked.
+    pub(super) async fn drop_pending_submissions(&self, pending: Vec<StartFailure>) {
+        for pending in pending {
+            self.drop_start_failure(pending).await;
+        }
+    }
+
+    /// Destroys one recovered registry handoff behind the controller panic boundary.
+    async fn drop_start_failure(&self, pending: StartFailure) {
+        let crate::core::UncommittedWatchedAdd {
+            error,
+            label,
+            spec,
+            done,
+        } = *pending;
+        debug_assert!(done.is_none(), "the watcher must be restored before drop");
+        self.drop_guarded("drop_uncommitted_submission", (error, label, spec, done))
+            .await;
     }
 }

--- a/src/controller/core/identity.rs
+++ b/src/controller/core/identity.rs
@@ -88,10 +88,10 @@ impl Controller {
             if self.is_shutting_down() {
                 return false;
             }
-            let Some(pos) = slot.queue.iter().position(|(qid, _)| *qid == id) else {
+            let Some(pos) = slot.queue.iter().position(|pending| pending.id == id) else {
                 continue;
             };
-            let task_name: Arc<str> = Arc::from(slot.queue[pos].1.name());
+            let task_name = Arc::clone(&slot.queue[pos].task_name);
             let mut request = Event::new(EventKind::TaskRemoveRequested)
                 .with_task(task_name)
                 .with_id(id);
@@ -99,11 +99,10 @@ impl Controller {
                 request = request.with_reason(reason);
             }
             self.bus.publish(request);
-            drop(
-                slot.queue
-                    .remove(pos)
-                    .expect("the queued submission position was checked above"),
-            );
+            let removed = slot
+                .queue
+                .remove(pos)
+                .expect("the queued submission position was checked above");
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(Arc::clone(&slot_name))
@@ -117,6 +116,7 @@ impl Controller {
                 crate::reasons::REMOVED_FROM_QUEUE,
             );
             self.gc_if_idle(&slot_name, slot);
+            self.drop_guarded("drop_removed_submission", removed).await;
             return true;
         }
         false

--- a/src/controller/core/lifecycle.rs
+++ b/src/controller/core/lifecycle.rs
@@ -210,7 +210,7 @@ impl Controller {
             }
         })
         .await;
-        self.finalize_pending_on_shutdown(&mut rx);
+        self.finalize_pending_on_shutdown(&mut rx).await;
         admissions.abort_all();
         completions.abort_all();
         removals.abort_all();
@@ -232,10 +232,6 @@ impl Controller {
     /// Runs one controller work unit behind a panic boundary.
     ///
     /// A panic is converted into a diagnostic `RuntimeFailure` event and the loop continues.
-    ///
-    /// This guard does not repair partially updated slot state by itself.
-    /// Callers that park watcher state must still make sure the watcher is resolved or returned on every failure path.
-    /// Returns the work-unit output on success and `None` after a caught panic.
     pub(super) async fn guarded<T>(
         &self,
         who: &'static str,
@@ -251,5 +247,12 @@ impl Controller {
                 None
             }
         }
+    }
+
+    /// Destroys one user-owned value behind its own panic boundary.
+    ///
+    /// Callers must release controller locks and resolve any waiter before calling this.
+    pub(super) async fn drop_guarded<T>(&self, who: &'static str, value: T) {
+        let _ = self.guarded(who, async move { drop(value) }).await;
     }
 }

--- a/src/controller/core/mod.rs
+++ b/src/controller/core/mod.rs
@@ -37,6 +37,9 @@
 //! - its Add command is committed and the watcher is handed to the runtime registry,
 //! - the submission is rejected and resolved as `TaskOutcome::Rejected`.
 //!
+//! Admission snapshots user-provided task metadata before parking the sender in controller state.
+//! A panic from `Task::name` is caught by the controller work-unit boundary and the ownership guard resolves the waiter as an admission failure.
+//!
 //! ## Internal Architecture
 //!
 //! `Controller` keeps shared state and construction in this facade.

--- a/src/controller/core/queue.rs
+++ b/src/controller/core/queue.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::{
-    controller::slot::SlotState,
+    controller::slot::{PendingSubmission, SlotState},
     events::{Event, EventKind, RejectionKind},
-    identity::TaskId,
 };
 
 use super::Controller;
@@ -41,29 +40,20 @@ impl Controller {
         }
     }
 
-    /// Rejects a queued submission if the per-slot queue is already full.
+    /// Builds the rejection reason when the per-slot queue is already full.
     ///
     /// `slot_len` is the current pending queue depth and does not include the current slot owner.
     #[inline]
-    pub(super) fn reject_if_full(&self, slot_name: &str, id: TaskId, slot_len: usize) -> bool {
+    pub(super) fn queue_full_reason(&self, slot_len: usize) -> Option<String> {
         if slot_len >= self.config.max_slot_queue() {
-            let reason = format!(
+            Some(format!(
                 "{}: {}/{}",
                 crate::reasons::QUEUE_FULL,
                 slot_len,
                 self.config.max_slot_queue()
-            );
-            self.bus.publish(
-                Event::new(EventKind::ControllerRejected)
-                    .with_task(slot_name)
-                    .with_id(id)
-                    .with_rejection_kind(RejectionKind::QueueFull)
-                    .with_reason(reason.clone()),
-            );
-            self.finalize_rejected(id, RejectionKind::QueueFull, &reason);
-            true
+            ))
         } else {
-            false
+            None
         }
     }
 
@@ -78,25 +68,26 @@ impl Controller {
         &self,
         slot: &mut SlotState,
         slot_name: &Arc<str>,
-        id: TaskId,
-        task_spec: crate::TaskSpec,
-    ) {
+        pending: PendingSubmission,
+    ) -> Option<PendingSubmission> {
         if let Some(head) = slot.queue.front_mut() {
-            let (displaced_id, _) = std::mem::replace(head, (id, task_spec));
+            let displaced = std::mem::replace(head, pending);
             self.bus.publish(
                 Event::new(EventKind::ControllerRejected)
                     .with_task(Arc::clone(slot_name))
-                    .with_id(displaced_id)
+                    .with_id(displaced.id)
                     .with_rejection_kind(RejectionKind::SupersededByReplace)
                     .with_reason(crate::reasons::SUPERSEDED_BY_REPLACE),
             );
             self.finalize_rejected(
-                displaced_id,
+                displaced.id,
                 RejectionKind::SupersededByReplace,
                 crate::reasons::SUPERSEDED_BY_REPLACE,
             );
+            Some(displaced)
         } else {
-            slot.queue.push_front((id, task_spec));
+            slot.queue.push_front(pending);
+            None
         }
     }
 }

--- a/src/controller/core/shutdown.rs
+++ b/src/controller/core/shutdown.rs
@@ -31,37 +31,48 @@ impl Controller {
     /// a submission that never reaches the runtime must resolve as [`TaskOutcome::Rejected`], not as a dropped oneshot.
     ///
     /// `rx.close()` prevents new messages from being accepted while the remaining buffered commands are drained.
-    pub(super) fn finalize_pending_on_shutdown(&self, rx: &mut mpsc::Receiver<ControllerCommand>) {
+    pub(super) async fn finalize_pending_on_shutdown(
+        &self,
+        rx: &mut mpsc::Receiver<ControllerCommand>,
+    ) {
         rx.close();
+        let mut deferred_drops = Vec::new();
 
         while let Ok(command) = rx.try_recv() {
             match command {
                 ControllerCommand::Submit(sub) => {
+                    let super::Submission { id, spec, done } = sub;
                     let mut event = Event::new(EventKind::ControllerRejected)
-                        .with_id(sub.id)
+                        .with_id(id)
                         .with_rejection_kind(RejectionKind::ControllerShuttingDown)
                         .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN);
-                    if let Some(slot_name) = sub.spec.slot_override() {
+                    if let Some(slot_name) = spec.slot_override() {
                         event = event.with_task(slot_name.to_owned());
                     }
                     self.bus.publish(event);
 
-                    if let Some(done) = sub.done {
+                    if let Some(done) = done {
                         let _ = done.send(TaskOutcome::Rejected {
                             kind: RejectionKind::ControllerShuttingDown,
                             reason: Arc::from(crate::reasons::CONTROLLER_SHUTTING_DOWN),
                         });
                     }
+                    deferred_drops.push(spec);
                 }
                 ControllerCommand::ManageIdentity { reply, .. } => {
                     let _ = reply.send(Err(RuntimeError::ShuttingDown));
                 }
             }
         }
+
+        for spec in deferred_drops {
+            self.drop_guarded("drop_buffered_submission", spec).await;
+        }
     }
 
     /// Rejects queued slot work, resolves every remaining watcher, and clears slot indexes.
     pub(super) async fn finalize_slot_state_on_shutdown(&self) {
+        let mut pending_to_drop = Vec::new();
         let slot_names: Vec<Arc<str>> = self
             .slots
             .iter()
@@ -73,24 +84,28 @@ impl Controller {
                 continue;
             };
             let mut slot = slot.lock().await;
-            while let Some((id, _spec)) = slot.queue.pop_front() {
+            while let Some(pending) = slot.queue.pop_front() {
                 self.bus.publish(
                     Event::new(EventKind::ControllerRejected)
                         .with_task(Arc::clone(&slot_name))
-                        .with_id(id)
+                        .with_id(pending.id)
                         .with_rejection_kind(RejectionKind::ControllerShuttingDown)
                         .with_reason(crate::reasons::CONTROLLER_SHUTTING_DOWN),
                 );
                 self.finalize_rejected(
-                    id,
+                    pending.id,
                     RejectionKind::ControllerShuttingDown,
                     crate::reasons::CONTROLLER_SHUTTING_DOWN,
                 );
+                pending_to_drop.push(pending);
             }
         }
 
         self.finalize_remaining_watchers();
         self.slots.clear();
+        for pending in pending_to_drop {
+            self.drop_guarded("drop_queued_submission", pending).await;
+        }
     }
 
     /// Waits until every already-aborted controller worker has finished cancellation.

--- a/src/controller/core/tests.rs
+++ b/src/controller/core/tests.rs
@@ -6,8 +6,8 @@ use crate::TaskContext;
 use crate::{BackoffPolicy, BoxTaskFuture, RestartPolicy, Task, TaskFn, TaskRef, TaskSpec};
 use std::num::NonZeroUsize;
 use std::sync::{
-    Mutex as StdMutex,
-    atomic::{AtomicBool, Ordering},
+    Mutex as StdMutex, Weak,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::time::Duration;
 
@@ -23,13 +23,128 @@ impl Task for PanickingNameTask {
     }
 }
 
+struct NameBombTask {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Task for NameBombTask {
+    fn name(&self) -> &str {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        panic!("injected unexpected task name read")
+    }
+
+    fn spawn(&self, _ctx: TaskContext) -> BoxTaskFuture {
+        panic!("a policy-rejected task must not spawn")
+    }
+}
+
+struct PanickingDropTask {
+    name: &'static str,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Task for PanickingDropTask {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn spawn(&self, _ctx: TaskContext) -> BoxTaskFuture {
+        Box::pin(std::future::pending())
+    }
+}
+
+impl Drop for PanickingDropTask {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::AcqRel);
+        panic!("injected task drop panic")
+    }
+}
+
+struct ShutdownDropProbeTask {
+    controller: Weak<Controller>,
+    state_clean_at_drop: Arc<AtomicBool>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Task for ShutdownDropProbeTask {
+    fn name(&self) -> &str {
+        "slot-shutdown-drop-panic"
+    }
+
+    fn spawn(&self, _ctx: TaskContext) -> BoxTaskFuture {
+        Box::pin(std::future::pending())
+    }
+}
+
+impl Drop for ShutdownDropProbeTask {
+    fn drop(&mut self) {
+        let state_is_clean = self.controller.upgrade().is_some_and(|controller| {
+            controller.watchers.is_empty() && controller.slots.is_empty()
+        });
+        self.state_clean_at_drop
+            .store(state_is_clean, Ordering::Release);
+        self.drops.fetch_add(1, Ordering::AcqRel);
+        panic!("injected task drop panic")
+    }
+}
+
+struct SingleReadNameTask {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Task for SingleReadNameTask {
+    fn name(&self) -> &str {
+        assert_eq!(
+            self.calls.fetch_add(1, Ordering::AcqRel),
+            0,
+            "controller admission must snapshot Task::name exactly once"
+        );
+        "single-read-name"
+    }
+
+    fn spawn(&self, _ctx: TaskContext) -> BoxTaskFuture {
+        Box::pin(std::future::pending())
+    }
+}
+
 fn make_spec(name: &str) -> TaskSpec {
     let task: TaskRef = TaskFn::arc(name, |_ctx: TaskContext| async { Ok(()) });
     TaskSpec::new(task, RestartPolicy::Never, BackoffPolicy::default(), None)
 }
 
+fn pending(id: TaskId, task_spec: TaskSpec) -> crate::controller::slot::PendingSubmission {
+    let task_name = Arc::from(task_spec.name());
+    crate::controller::slot::PendingSubmission::new(id, task_name, task_spec)
+}
+
 fn slot_arc_name() -> Arc<str> {
     Arc::from("s")
+}
+
+fn drain_events(events: &mut tokio::sync::broadcast::Receiver<Arc<Event>>) -> Vec<Arc<Event>> {
+    let mut drained = Vec::new();
+    while let Ok(event) = events.try_recv() {
+        drained.push(event);
+    }
+    drained
+}
+
+fn assert_rejection_parity(event: &Event, id: TaskId, outcome: &TaskOutcome) {
+    let TaskOutcome::Rejected { kind, reason, .. } = outcome else {
+        panic!("expected a rejected task outcome, got {outcome:?}");
+    };
+    assert_eq!(event.kind, EventKind::ControllerRejected);
+    assert_eq!(event.id, Some(id));
+    assert_eq!(event.rejection_kind, Some(*kind));
+    assert_eq!(event.outcome_kind, Some(crate::TaskOutcomeKind::Rejected));
+    assert_eq!(event.reason.as_deref(), Some(reason.as_ref()));
+}
+
+async fn receive_oneshot<T>(receiver: oneshot::Receiver<T>, context: &str) -> T {
+    tokio::time::timeout(Duration::from_secs(2), receiver)
+        .await
+        .unwrap_or_else(|_| panic!("{context} timed out"))
+        .unwrap_or_else(|_| panic!("{context} sender was dropped"))
 }
 
 fn admitting_slot(owner: TaskId) -> SlotState {
@@ -67,19 +182,23 @@ fn replace_head_or_push_replaces_existing_head_and_rejects_displaced() {
     let mut rx = ctrl.bus.subscribe();
     let mut slot = SlotState::new();
     let displaced = TaskId::next();
-    slot.queue.push_back((displaced, make_spec("old-head")));
-    slot.queue.push_back((TaskId::next(), make_spec("tail")));
+    slot.queue
+        .push_back(pending(displaced, make_spec("old-head")));
+    slot.queue
+        .push_back(pending(TaskId::next(), make_spec("tail")));
 
-    ctrl.replace_head_or_push(
-        &mut slot,
-        &slot_arc_name(),
-        TaskId::next(),
-        make_spec("new-head"),
-    );
+    let displaced_spec = ctrl
+        .replace_head_or_push(
+            &mut slot,
+            &slot_arc_name(),
+            pending(TaskId::next(), make_spec("new-head")),
+        )
+        .expect("the old queue head must be returned for deferred drop");
 
     assert_eq!(slot.queue.len(), 2, "queue depth should not grow");
-    assert_eq!(slot.queue.front().unwrap().1.name(), "new-head");
-    assert_eq!(slot.queue.back().unwrap().1.name(), "tail");
+    assert_eq!(slot.queue.front().unwrap().task_spec.name(), "new-head");
+    assert_eq!(slot.queue.back().unwrap().task_spec.name(), "tail");
+    assert_eq!(displaced_spec.task_spec.name(), "old-head");
 
     let ev = rx.try_recv().expect("displaced head must be rejected");
     assert_eq!(ev.kind, EventKind::ControllerRejected);
@@ -99,25 +218,40 @@ fn replace_head_or_push_appends_to_empty_then_keeps_only_the_latest_head() {
     let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
     let mut slot = SlotState::new();
     let name = slot_arc_name();
-    ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v1"));
+    assert!(
+        ctrl.replace_head_or_push(&mut slot, &name, pending(TaskId::next(), make_spec("v1")),)
+            .is_none()
+    );
     assert_eq!(slot.queue.len(), 1);
-    assert_eq!(slot.queue.front().unwrap().1.name(), "v1");
+    assert_eq!(slot.queue.front().unwrap().task_spec.name(), "v1");
 
-    ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v2"));
-    ctrl.replace_head_or_push(&mut slot, &name, TaskId::next(), make_spec("v3"));
+    assert_eq!(
+        ctrl.replace_head_or_push(&mut slot, &name, pending(TaskId::next(), make_spec("v2")),)
+            .expect("v1 must be displaced")
+            .task_spec
+            .name(),
+        "v1"
+    );
+    assert_eq!(
+        ctrl.replace_head_or_push(&mut slot, &name, pending(TaskId::next(), make_spec("v3")),)
+            .expect("v2 must be displaced")
+            .task_spec
+            .name(),
+        "v2"
+    );
 
     assert_eq!(slot.queue.len(), 1);
-    assert_eq!(slot.queue.front().unwrap().1.name(), "v3");
+    assert_eq!(slot.queue.front().unwrap().task_spec.name(), "v3");
 }
 
 #[test]
-fn reject_if_full_respects_the_capacity_boundary() {
+fn queue_full_reason_respects_the_capacity_boundary() {
     let config = ControllerConfig::new(NonZeroUsize::new(16).unwrap(), 3);
     let ctrl = make_controller(config, Bus::new(64));
 
     for (depth, expected_rejection) in [(0, false), (2, false), (3, true), (10, true)] {
         assert_eq!(
-            ctrl.reject_if_full("slot", TaskId::next(), depth),
+            ctrl.queue_full_reason(depth).is_some(),
             expected_rejection,
             "unexpected decision at queue depth {depth}"
         );
@@ -184,7 +318,7 @@ async fn removal_not_claimed_keeps_terminating_until_reliable_completion() {
         let mut slot = slot_arc.lock().await;
         *slot = terminating_slot(owner);
         slot.queue
-            .push_back((queued, waiting_spec("after-unclaimed-removal")));
+            .push_back(pending(queued, waiting_spec("after-unclaimed-removal")));
     }
 
     ctrl.handle_removal_result(RemovalResult {
@@ -198,7 +332,7 @@ async fn removal_not_claimed_keeps_terminating_until_reliable_completion() {
         let slot = slot_arc.lock().await;
         assert_eq!(slot.owner_id(), Some(owner));
         assert!(matches!(slot.phase(), SlotPhase::Terminating { .. }));
-        assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(queued));
+        assert_eq!(slot.queue.front().map(|pending| pending.id), Some(queued));
     }
     assert!(
         events.try_recv().is_err(),
@@ -240,7 +374,7 @@ async fn removal_error_preserves_owner_and_queue_and_emits_one_diagnostic() {
         let mut slot = slot_arc.lock().await;
         *slot = terminating_slot(owner);
         slot.queue
-            .push_back((queued, waiting_spec("after-failed-removal")));
+            .push_back(pending(queued, waiting_spec("after-failed-removal")));
     }
 
     ctrl.handle_removal_result(RemovalResult {
@@ -267,7 +401,7 @@ async fn removal_error_preserves_owner_and_queue_and_emits_one_diagnostic() {
     let slot = slot_arc.lock().await;
     assert_eq!(slot.owner_id(), Some(owner));
     assert!(matches!(slot.phase(), SlotPhase::Terminating { .. }));
-    assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(queued));
+    assert_eq!(slot.queue.front().map(|pending| pending.id), Some(queued));
 }
 
 #[tokio::test]
@@ -283,7 +417,7 @@ async fn stale_removal_error_does_not_publish_or_mutate_new_owner() {
         let mut slot = slot_arc.lock().await;
         *slot = running_slot(current);
         slot.queue
-            .push_back((queued, waiting_spec("new-owner-queued")));
+            .push_back(pending(queued, waiting_spec("new-owner-queued")));
     }
 
     ctrl.handle_removal_result(RemovalResult {
@@ -297,7 +431,7 @@ async fn stale_removal_error_does_not_publish_or_mutate_new_owner() {
     let slot = slot_arc.lock().await;
     assert_eq!(slot.owner_id(), Some(current));
     assert!(matches!(slot.phase(), SlotPhase::Running { .. }));
-    assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(queued));
+    assert_eq!(slot.queue.front().map(|pending| pending.id), Some(queued));
 }
 
 #[tokio::test]
@@ -358,7 +492,7 @@ async fn duplicate_completion_does_not_start_queued_owner_twice() {
         let mut slot = slot_arc.lock().await;
         *slot = running_slot(completed_id);
         slot.queue
-            .push_back((next_id, waiting_spec("duplicate-completion-next")));
+            .push_back(pending(next_id, waiting_spec("duplicate-completion-next")));
     }
 
     let mut admissions = JoinSet::new();
@@ -503,7 +637,7 @@ async fn repeated_replace_while_admitting_is_latest_wins_with_one_removal_after_
             SlotPhase::CancelPendingAdmission { owner: id, .. } if id == owner
         ));
         assert_eq!(slot.queue.len(), 1);
-        assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(latest));
+        assert_eq!(slot.queue.front().map(|pending| pending.id), Some(latest));
     }
     assert!(removals.is_empty());
 
@@ -526,7 +660,7 @@ async fn repeated_replace_while_admitting_is_latest_wins_with_one_removal_after_
         slot.phase(),
         SlotPhase::Terminating { owner: id, .. } if id == owner
     ));
-    assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(latest));
+    assert_eq!(slot.queue.front().map(|pending| pending.id), Some(latest));
     assert_eq!(completions.len(), 1, "duplicate Add Ok must be stale");
     assert_eq!(
         removals.len(),
@@ -552,7 +686,7 @@ async fn shutdown_finalizes_buffered_submission_as_rejected() {
         .expect("submission accepted into channel");
 
     let mut rx = ctrl.rx.write().await.take().expect("rx present");
-    ctrl.finalize_pending_on_shutdown(&mut rx);
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
     drop(rx);
 
     let outcome = tokio::time::timeout(Duration::from_secs(1), waiter)
@@ -583,7 +717,7 @@ async fn try_submit_and_watch_is_fail_fast_and_preserves_watched_outcome() {
     ));
 
     let mut rx = ctrl.rx.write().await.take().expect("rx present");
-    ctrl.finalize_pending_on_shutdown(&mut rx);
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
     drop(rx);
 
     assert!(matches!(
@@ -606,9 +740,9 @@ async fn shutdown_rejects_slot_queue_and_clears_controller_state() {
         let mut slot = slot.lock().await;
         *slot = running_slot(running_id);
         slot.queue
-            .push_back((watched_id, waiting_spec("watched-shutdown-queue")));
+            .push_back(pending(watched_id, waiting_spec("watched-shutdown-queue")));
         slot.queue
-            .push_back((unwatched_id, waiting_spec("plain-shutdown-queue")));
+            .push_back(pending(unwatched_id, waiting_spec("plain-shutdown-queue")));
     }
 
     ctrl.finalize_slot_state_on_shutdown().await;
@@ -626,6 +760,77 @@ async fn shutdown_rejects_slot_queue_and_clears_controller_state() {
     assert!(ctrl.slots.is_empty());
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn slot_shutdown_finishes_all_watchers_before_panicking_task_drop() {
+    let ctrl = Arc::new(make_controller(ControllerConfig::default(), Bus::new(64)));
+    let mut events = ctrl.bus.subscribe();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let state_clean_at_drop = Arc::new(AtomicBool::new(false));
+    let first = TaskId::next();
+    let second = TaskId::next();
+    let (first_done, first_outcome) = oneshot::channel();
+    let (second_done, second_outcome) = oneshot::channel();
+    ctrl.watchers.insert(first, first_done);
+    ctrl.watchers.insert(second, second_done);
+
+    let slot = ctrl.get_or_create_slot("slot-shutdown-drop-panic");
+    {
+        let mut slot = slot.lock().await;
+        slot.queue
+            .push_back(crate::controller::slot::PendingSubmission::new(
+                first,
+                Arc::from("slot-shutdown-drop-panic"),
+                TaskSpec::once(Arc::new(ShutdownDropProbeTask {
+                    controller: Arc::downgrade(&ctrl),
+                    state_clean_at_drop: Arc::clone(&state_clean_at_drop),
+                    drops: Arc::clone(&drops),
+                })),
+            ));
+        slot.queue
+            .push_back(pending(second, waiting_spec("slot-shutdown-after-panic")));
+    }
+
+    ctrl.finalize_slot_state_on_shutdown().await;
+
+    let first_outcome = receive_oneshot(first_outcome, "first slot-shutdown watcher").await;
+    let second_outcome = receive_oneshot(second_outcome, "second slot-shutdown watcher").await;
+    for outcome in [&first_outcome, &second_outcome] {
+        assert!(matches!(
+            outcome,
+            TaskOutcome::Rejected {
+                kind: crate::RejectionKind::ControllerShuttingDown,
+                ..
+            }
+        ));
+    }
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+    assert!(
+        state_clean_at_drop.load(Ordering::Acquire),
+        "all controller watchers and slots must be finalized before user Drop"
+    );
+    assert!(ctrl.watchers.is_empty());
+    assert!(ctrl.slots.is_empty());
+
+    let drained = drain_events(&mut events);
+    let first_event = drained
+        .iter()
+        .find(|event| event.kind == EventKind::ControllerRejected && event.id == Some(first))
+        .expect("first slot-shutdown rejection event");
+    let second_event = drained
+        .iter()
+        .find(|event| event.kind == EventKind::ControllerRejected && event.id == Some(second))
+        .expect("second slot-shutdown rejection event");
+    assert_rejection_parity(first_event, first, &first_outcome);
+    assert_rejection_parity(second_event, second, &second_outcome);
+    assert!(drained.iter().any(|event| {
+        event.kind == EventKind::RuntimeFailure
+            && event
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("injected task drop panic"))
+    }));
+}
+
 #[tokio::test]
 async fn shutdown_resolves_buffered_removal_reply() {
     let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
@@ -639,7 +844,7 @@ async fn shutdown_resolves_buffered_removal_reply() {
         .expect("the controller command channel has capacity");
 
     let mut rx = ctrl.rx.write().await.take().expect("rx present");
-    ctrl.finalize_pending_on_shutdown(&mut rx);
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
 
     assert!(matches!(
         reply_rx.await,
@@ -669,6 +874,73 @@ async fn aborted_identity_worker_sends_explicit_shutdown_reply() {
         tokio::time::timeout(Duration::from_secs(1), reply_rx).await,
         Ok(Ok(Err(RuntimeError::ShuttingDown)))
     ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn queued_identity_reply_survives_panicking_task_drop() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let slot_name: Arc<str> = Arc::from("identity-drop-panic-slot");
+    let (done, outcome) = oneshot::channel();
+    ctrl.watchers.insert(id, done);
+    let slot = ctrl.get_or_create_slot(&slot_name);
+    slot.lock()
+        .await
+        .queue
+        .push_back(crate::controller::slot::PendingSubmission::new(
+            id,
+            Arc::from("identity-drop-panic-task"),
+            TaskSpec::once(Arc::new(PanickingDropTask {
+                name: "identity-drop-panic-task",
+                drops: Arc::clone(&drops),
+            })),
+        ));
+
+    let (reply, result) = oneshot::channel();
+    let mut identity_operations = JoinSet::new();
+    ctrl.handle_identity_operation(
+        id,
+        IdentityOperation::Remove,
+        reply,
+        &mut identity_operations,
+    )
+    .await;
+
+    assert!(matches!(
+        receive_oneshot(result, "queued identity result").await,
+        Ok(true)
+    ));
+    let outcome = receive_oneshot(outcome, "queued identity watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::RemovedFromQueue,
+            ..
+        }
+    ));
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+    assert!(identity_operations.is_empty());
+    assert!(ctrl.watchers.is_empty());
+    assert!(ctrl.slots.get(&*slot_name).is_none());
+
+    let drained = drain_events(&mut events);
+    let rejections: Vec<_> = drained
+        .iter()
+        .filter(|event| event.kind == EventKind::ControllerRejected && event.id == Some(id))
+        .collect();
+    assert_eq!(rejections.len(), 1);
+    assert_rejection_parity(rejections[0], id, &outcome);
+    assert!(drained.iter().any(|event| {
+        event.kind == EventKind::RuntimeFailure
+            && event
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("injected task drop panic"))
+    }));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -719,7 +991,7 @@ async fn submit_after_shutdown_finalize_is_rejected_not_leaked() {
     let ctrl = make_controller(ControllerConfig::default(), bus);
 
     let mut rx = ctrl.rx.write().await.take().expect("rx present");
-    ctrl.finalize_pending_on_shutdown(&mut rx);
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
 
     let task: TaskRef = TaskFn::arc("late", |_ctx: TaskContext| async { Ok(()) });
     let result = ctrl
@@ -766,6 +1038,639 @@ async fn guarded_converts_panic_to_diagnostic_and_survives() {
         "diagnostic must carry the panic message, got {:?}",
         ev.reason
     );
+}
+
+#[tokio::test]
+async fn explicit_slot_shutdown_rejects_without_reading_task_name() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+    ctrl.mark_shutting_down();
+
+    ctrl.handle_submission(
+        Submission {
+            id,
+            spec: ControllerSpec::queue(TaskSpec::once(Arc::new(NameBombTask {
+                calls: Arc::clone(&calls),
+            })))
+            .with_slot("explicit-shutdown"),
+            done: Some(done),
+        },
+        &mut admissions,
+        &mut removals,
+    )
+    .await;
+
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+    let outcome = receive_oneshot(outcome, "shutdown watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::ControllerShuttingDown,
+            ..
+        }
+    ));
+    let drained = drain_events(&mut events);
+    let rejections: Vec<_> = drained
+        .iter()
+        .filter(|event| event.kind == EventKind::ControllerRejected)
+        .collect();
+    assert_eq!(rejections.len(), 1);
+    assert_rejection_parity(rejections[0], id, &outcome);
+    assert_eq!(rejections[0].task.as_deref(), Some("explicit-shutdown"));
+    assert!(
+        drained
+            .iter()
+            .all(|event| event.kind != EventKind::RuntimeFailure)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn explicit_slot_shutdown_while_waiting_for_lock_skips_task_name() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let slot = ctrl.get_or_create_slot("locked-at-shutdown");
+    let owner = TaskId::next();
+    let mut slot_guard = slot.lock().await;
+    *slot_guard = running_slot(owner);
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+    let mut admission = Box::pin(
+        ctrl.handle_submission(
+            Submission {
+                id,
+                spec: ControllerSpec::queue(TaskSpec::once(Arc::new(NameBombTask {
+                    calls: Arc::clone(&calls),
+                })))
+                .with_slot("locked-at-shutdown"),
+                done: Some(done),
+            },
+            &mut admissions,
+            &mut removals,
+        ),
+    );
+
+    std::future::poll_fn(|cx| match admission.as_mut().poll(cx) {
+        std::task::Poll::Pending => std::task::Poll::Ready(()),
+        std::task::Poll::Ready(()) => {
+            panic!("submission must wait for the held explicit-slot lock")
+        }
+    })
+    .await;
+    ctrl.mark_shutting_down();
+    drop(slot_guard);
+    tokio::time::timeout(Duration::from_secs(2), admission)
+        .await
+        .expect("submission must resume after the explicit-slot lock is released");
+
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+    let outcome = receive_oneshot(outcome, "lock-wait shutdown watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::ControllerShuttingDown,
+            ..
+        }
+    ));
+    assert!(admissions.is_empty());
+    assert!(removals.is_empty());
+    assert!(ctrl.watchers.is_empty());
+    let slot = ctrl
+        .slots
+        .get("locked-at-shutdown")
+        .expect("the existing running slot remains owned")
+        .clone();
+    assert_eq!(slot.lock().await.owner_id(), Some(owner));
+
+    let drained = drain_events(&mut events);
+    let rejections: Vec<_> = drained
+        .iter()
+        .filter(|event| event.kind == EventKind::ControllerRejected)
+        .collect();
+    assert_eq!(rejections.len(), 1);
+    assert_rejection_parity(rejections[0], id, &outcome);
+    assert_eq!(rejections[0].task.as_deref(), Some("locked-at-shutdown"));
+    assert!(
+        drained
+            .iter()
+            .all(|event| event.kind != EventKind::RuntimeFailure)
+    );
+}
+
+#[tokio::test]
+async fn explicit_slot_drop_if_running_rejects_without_reading_task_name() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let owner = TaskId::next();
+    ctrl.slots.insert(
+        Arc::from("busy-slot"),
+        Arc::new(Mutex::new(running_slot(owner))),
+    );
+    let calls = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+
+    ctrl.handle_submission(
+        Submission {
+            id,
+            spec: ControllerSpec::drop_if_running(TaskSpec::once(Arc::new(NameBombTask {
+                calls: Arc::clone(&calls),
+            })))
+            .with_slot("busy-slot"),
+            done: Some(done),
+        },
+        &mut admissions,
+        &mut removals,
+    )
+    .await;
+
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+    let outcome = receive_oneshot(outcome, "busy-rejection watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::SlotBusy,
+            ..
+        }
+    ));
+    let slot = ctrl
+        .slots
+        .get("busy-slot")
+        .expect("busy slot remains")
+        .clone();
+    let slot = slot.lock().await;
+    assert_eq!(slot.owner_id(), Some(owner));
+    assert!(slot.queue.is_empty());
+    drop(slot);
+    let drained = drain_events(&mut events);
+    let rejections: Vec<_> = drained
+        .iter()
+        .filter(|event| event.kind == EventKind::ControllerRejected)
+        .collect();
+    assert_eq!(rejections.len(), 1);
+    assert_rejection_parity(rejections[0], id, &outcome);
+    assert!(
+        drained
+            .iter()
+            .all(|event| event.kind != EventKind::RuntimeFailure)
+    );
+}
+
+#[tokio::test]
+async fn explicit_slot_queue_full_rejects_without_reading_task_name() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let config = ControllerConfig::new(NonZeroUsize::new(16).unwrap(), 1);
+    let ctrl = Controller::new(config, supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let owner = TaskId::next();
+    let queued = TaskId::next();
+    let mut state = running_slot(owner);
+    state
+        .queue
+        .push_back(pending(queued, waiting_spec("existing-head")));
+    ctrl.slots
+        .insert(Arc::from("full-slot"), Arc::new(Mutex::new(state)));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+
+    ctrl.handle_submission(
+        Submission {
+            id,
+            spec: ControllerSpec::queue(TaskSpec::once(Arc::new(NameBombTask {
+                calls: Arc::clone(&calls),
+            })))
+            .with_slot("full-slot"),
+            done: Some(done),
+        },
+        &mut admissions,
+        &mut removals,
+    )
+    .await;
+
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+    let outcome = receive_oneshot(outcome, "queue-full watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::QueueFull,
+            ..
+        }
+    ));
+    let slot = ctrl
+        .slots
+        .get("full-slot")
+        .expect("full slot remains")
+        .clone();
+    let slot = slot.lock().await;
+    assert_eq!(slot.owner_id(), Some(owner));
+    assert_eq!(slot.queue.len(), 1);
+    assert_eq!(slot.queue.front().map(|pending| pending.id), Some(queued));
+    drop(slot);
+    let drained = drain_events(&mut events);
+    let rejections: Vec<_> = drained
+        .iter()
+        .filter(|event| event.kind == EventKind::ControllerRejected)
+        .collect();
+    assert_eq!(rejections.len(), 1);
+    assert_rejection_parity(rejections[0], id, &outcome);
+    assert!(
+        drained
+            .iter()
+            .all(|event| event.kind != EventKind::RuntimeFailure)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn task_name_panic_publishes_rejection_matching_waiter() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+
+    for explicit_slot in [None, Some("explicit-name-panic")] {
+        let id = TaskId::next();
+        let (done, outcome) = oneshot::channel();
+        let spec = ControllerSpec::queue(TaskSpec::once(Arc::new(PanickingNameTask)));
+        let spec = if let Some(slot) = explicit_slot {
+            spec.with_slot(slot)
+        } else {
+            spec
+        };
+
+        ctrl.handle_submission(
+            Submission {
+                id,
+                spec,
+                done: Some(done),
+            },
+            &mut admissions,
+            &mut removals,
+        )
+        .await;
+
+        let outcome = receive_oneshot(outcome, "task-name panic watcher").await;
+        assert!(matches!(
+            outcome,
+            TaskOutcome::Rejected {
+                kind: crate::RejectionKind::AdmissionFailed,
+                ref reason,
+                ..
+            } if reason.as_ref() == crate::reasons::CONTROLLER_ADMISSION_INTERRUPTED
+        ));
+        let drained = drain_events(&mut events);
+        let rejections: Vec<_> = drained
+            .iter()
+            .filter(|event| event.kind == EventKind::ControllerRejected)
+            .collect();
+        assert_eq!(rejections.len(), 1);
+        assert_rejection_parity(rejections[0], id, &outcome);
+        assert_eq!(rejections[0].task.as_deref(), explicit_slot);
+        assert_eq!(
+            drained
+                .iter()
+                .filter(|event| event.kind == EventKind::RuntimeFailure)
+                .count(),
+            1
+        );
+    }
+
+    assert!(admissions.is_empty());
+    assert!(removals.is_empty());
+    assert!(ctrl.watchers.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn task_name_panic_rejects_watcher_and_controller_continues() {
+    let supervisor = Supervisor::builder(crate::SupervisorConfig::default())
+        .with_controller(ControllerConfig::default())
+        .build();
+    let handle = supervisor.serve();
+
+    let hostile_specs = [
+        ControllerSpec::queue(TaskSpec::once(Arc::new(PanickingNameTask))),
+        ControllerSpec::queue(TaskSpec::once(Arc::new(PanickingNameTask)))
+            .with_slot("explicit-slot"),
+    ];
+    for spec in hostile_specs {
+        let (_id, waiter) = handle
+            .submit_and_watch(spec)
+            .await
+            .expect("controller intake must accept the hostile submission");
+        let outcome = tokio::time::timeout(Duration::from_secs(2), waiter.wait())
+            .await
+            .expect("a task-name panic must not leave the waiter pending")
+            .expect("panic-safe admission must produce a typed outcome");
+        assert!(matches!(
+            outcome,
+            TaskOutcome::Rejected {
+                kind: crate::RejectionKind::AdmissionFailed,
+                reason,
+                ..
+            } if reason.as_ref() == crate::reasons::CONTROLLER_ADMISSION_INTERRUPTED
+        ));
+    }
+
+    let good: TaskRef = TaskFn::arc("after-name-panic", |_ctx: TaskContext| async { Ok(()) });
+    let (_id, waiter) = handle
+        .submit_and_watch(ControllerSpec::queue(TaskSpec::once(good)))
+        .await
+        .expect("the controller loop must continue after the caught panic");
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(2), waiter.wait()).await,
+        Ok(Ok(TaskOutcome::Completed))
+    ));
+
+    handle
+        .shutdown()
+        .await
+        .expect("panic-safe controller admission must shut down cleanly");
+}
+
+#[tokio::test]
+async fn controller_registry_commit_reuses_snapshotted_task_name() {
+    let supervisor = Supervisor::new(crate::SupervisorConfig::default(), vec![]);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), Bus::new(64));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let task: TaskRef = Arc::new(SingleReadNameTask {
+        calls: Arc::clone(&calls),
+    });
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+
+    ctrl.handle_submission(
+        Submission {
+            id,
+            spec: ControllerSpec::queue(TaskSpec::once(task)),
+            done: Some(done),
+        },
+        &mut admissions,
+        &mut removals,
+    )
+    .await;
+
+    assert_eq!(calls.load(Ordering::Acquire), 1);
+    assert_eq!(admissions.len(), 1);
+    assert!(removals.is_empty());
+    assert!(ctrl.watchers.is_empty());
+    let slot = ctrl
+        .slots
+        .get("single-read-name")
+        .expect("the snapshotted name must become the fallback slot")
+        .clone();
+    assert!(matches!(
+        slot.lock().await.phase(),
+        SlotPhase::Admitting { owner, .. } if owner == id
+    ));
+
+    drop(outcome);
+    abort_and_drain(&mut admissions).await;
+    abort_and_drain(&mut removals).await;
+}
+
+#[tokio::test]
+async fn registry_backpressure_drop_panic_preserves_watcher_and_controller_state() {
+    let supervisor = Supervisor::new(
+        crate::SupervisorConfig::default()
+            .with_registry_queue_capacity(NonZeroUsize::new(1).unwrap()),
+        vec![],
+    );
+    let filler_id = TaskId::next();
+    let (_reply, _completion) = supervisor
+        .core()
+        .add_task_with_id_watched(
+            filler_id,
+            Arc::from("drop-panic-filler"),
+            waiting_spec("drop-panic-filler"),
+            None,
+        )
+        .expect("the filler must occupy the registry queue");
+    assert_eq!(supervisor.core().registry_command_capacity(), 0);
+
+    let bus = Bus::new(64);
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), bus.clone());
+    let mut events = bus.subscribe();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let id = TaskId::next();
+    let (done, outcome) = oneshot::channel();
+    let mut admissions = JoinSet::new();
+    let mut removals = JoinSet::new();
+
+    ctrl.handle_submission(
+        Submission {
+            id,
+            spec: ControllerSpec::queue(TaskSpec::once(Arc::new(PanickingDropTask {
+                name: "drop-panic-uncommitted",
+                drops: Arc::clone(&drops),
+            })))
+            .with_slot("drop-panic-slot"),
+            done: Some(done),
+        },
+        &mut admissions,
+        &mut removals,
+    )
+    .await;
+
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+    let outcome = receive_oneshot(outcome, "pre-commit failure watcher").await;
+    assert!(matches!(
+        outcome,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::AdmissionFailed,
+            ..
+        }
+    ));
+    assert!(ctrl.watchers.is_empty());
+    assert!(ctrl.slots.get("drop-panic-slot").is_none());
+    assert!(admissions.is_empty());
+    assert!(removals.is_empty());
+
+    let drained = drain_events(&mut events);
+    let rejection = drained
+        .iter()
+        .find(|event| event.kind == EventKind::ControllerRejected)
+        .expect("pre-commit failure must publish a rejection");
+    assert_rejection_parity(rejection, id, &outcome);
+    let drop_failure = drained
+        .iter()
+        .find(|event| {
+            event.kind == EventKind::RuntimeFailure
+                && event
+                    .reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("injected task drop panic"))
+        })
+        .expect("panicking destructor must be isolated and diagnosed");
+    assert_eq!(drop_failure.task.as_deref(), Some("controller"));
+}
+
+#[tokio::test]
+async fn queued_precommit_failures_finish_before_panicking_task_drop() {
+    let supervisor = Supervisor::new(
+        crate::SupervisorConfig::default()
+            .with_registry_queue_capacity(NonZeroUsize::new(1).unwrap()),
+        vec![],
+    );
+    let filler_id = TaskId::next();
+    let (_reply, _completion) = supervisor
+        .core()
+        .add_task_with_id_watched(
+            filler_id,
+            Arc::from("queued-drop-filler"),
+            waiting_spec("queued-drop-filler"),
+            None,
+        )
+        .expect("the filler must occupy the registry queue");
+
+    let ctrl = Controller::new(ControllerConfig::default(), supervisor.core(), Bus::new(64));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let first = TaskId::next();
+    let second = TaskId::next();
+    let (first_done, first_outcome) = oneshot::channel();
+    let (second_done, second_outcome) = oneshot::channel();
+    ctrl.watchers.insert(first, first_done);
+    ctrl.watchers.insert(second, second_done);
+    let mut slot = SlotState::new();
+    slot.queue
+        .push_back(crate::controller::slot::PendingSubmission::new(
+            first,
+            Arc::from("queued-drop-panic"),
+            TaskSpec::once(Arc::new(PanickingDropTask {
+                name: "queued-drop-panic",
+                drops: Arc::clone(&drops),
+            })),
+        ));
+    slot.queue
+        .push_back(pending(second, waiting_spec("queued-after-drop-panic")));
+    let mut admissions = JoinSet::new();
+    let slot_name = Arc::from("queued-drop-slot");
+
+    let deferred =
+        ctrl.start_next_from_queue(supervisor.core(), &mut slot, &slot_name, &mut admissions);
+
+    assert!(slot.is_idle());
+    assert!(slot.queue.is_empty());
+    assert!(admissions.is_empty());
+    assert_eq!(deferred.len(), 2);
+    assert!(matches!(
+        receive_oneshot(first_outcome, "first queued pre-commit watcher").await,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::AdmissionFailed,
+            ..
+        }
+    ));
+    assert!(matches!(
+        receive_oneshot(second_outcome, "second queued pre-commit watcher").await,
+        TaskOutcome::Rejected {
+            kind: crate::RejectionKind::AdmissionFailed,
+            ..
+        }
+    ));
+    assert!(ctrl.watchers.is_empty());
+    assert_eq!(drops.load(Ordering::Acquire), 0);
+
+    ctrl.drop_pending_submissions(deferred).await;
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test]
+async fn buffered_shutdown_drain_continues_after_task_drop_panic() {
+    let ctrl = make_controller(ControllerConfig::default(), Bus::new(64));
+    let mut events = ctrl.bus.subscribe();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let first = TaskId::next();
+    let second = TaskId::next();
+    let (first_done, first_outcome) = oneshot::channel();
+    let (second_done, second_outcome) = oneshot::channel();
+    let (identity_reply, identity_result) = oneshot::channel();
+
+    ctrl.tx
+        .try_send(ControllerCommand::Submit(Submission {
+            id: first,
+            spec: ControllerSpec::queue(TaskSpec::once(Arc::new(PanickingDropTask {
+                name: "buffered-drop-panic",
+                drops: Arc::clone(&drops),
+            })))
+            .with_slot("buffered-first"),
+            done: Some(first_done),
+        }))
+        .expect("first buffered submission");
+    ctrl.tx
+        .try_send(ControllerCommand::Submit(Submission {
+            id: second,
+            spec: ControllerSpec::queue(waiting_spec("buffered-after-drop-panic"))
+                .with_slot("buffered-second"),
+            done: Some(second_done),
+        }))
+        .expect("second buffered submission");
+    ctrl.tx
+        .try_send(ControllerCommand::ManageIdentity {
+            id: TaskId::next(),
+            operation: IdentityOperation::Remove,
+            reply: identity_reply,
+        })
+        .expect("buffered identity operation");
+
+    let mut rx = ctrl.rx.write().await.take().expect("rx present");
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
+
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+    let first_outcome = receive_oneshot(first_outcome, "first shutdown rejection").await;
+    let second_outcome = receive_oneshot(second_outcome, "second shutdown rejection").await;
+    for outcome in [&first_outcome, &second_outcome] {
+        assert!(matches!(
+            outcome,
+            TaskOutcome::Rejected {
+                kind: crate::RejectionKind::ControllerShuttingDown,
+                ..
+            }
+        ));
+    }
+    assert!(matches!(
+        receive_oneshot(identity_result, "buffered shutdown identity reply").await,
+        Err(RuntimeError::ShuttingDown)
+    ));
+
+    let drained = drain_events(&mut events);
+    let first_event = drained
+        .iter()
+        .find(|event| event.kind == EventKind::ControllerRejected && event.id == Some(first))
+        .expect("first shutdown event");
+    let second_event = drained
+        .iter()
+        .find(|event| event.kind == EventKind::ControllerRejected && event.id == Some(second))
+        .expect("second shutdown event");
+    assert_rejection_parity(first_event, first, &first_outcome);
+    assert_rejection_parity(second_event, second, &second_outcome);
+    assert!(drained.iter().any(|event| {
+        event.kind == EventKind::RuntimeFailure
+            && event
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("injected task drop panic"))
+    }));
 }
 
 #[tokio::test]
@@ -1084,7 +1989,7 @@ async fn try_identity_operations_report_full_controller_command_queue() {
     ));
 
     let mut rx = ctrl.rx.write().await.take().expect("rx present");
-    ctrl.finalize_pending_on_shutdown(&mut rx);
+    ctrl.finalize_pending_on_shutdown(&mut rx).await;
     drop(rx);
     let _ = runtime_handle.shutdown().await;
 }
@@ -1099,7 +2004,12 @@ async fn try_identity_operations_propagate_full_registry_queue_after_controller_
     let filler_id = TaskId::next();
     let (_filler_reply, _filler_completion) = sup
         .core()
-        .add_task_with_id_watched(filler_id, waiting_spec("registry-queue-filler"), None)
+        .add_task_with_id_watched(
+            filler_id,
+            Arc::from("registry-queue-filler"),
+            waiting_spec("registry-queue-filler"),
+            None,
+        )
         .expect("the filler must occupy the registry queue");
     assert_eq!(sup.core().registry_command_capacity(), 0);
 
@@ -1431,7 +2341,7 @@ async fn replace_is_processed_while_registry_reply_is_pending() {
             };
             let slot = slot.lock().await;
             matches!(slot.phase(), SlotPhase::CancelPendingAdmission { .. })
-                && slot.queue.front().map(|(id, _)| *id) == Some(replacement_id)
+                && slot.queue.front().map(|pending| pending.id) == Some(replacement_id)
         })
         .await,
         "Replace must be processed without waiting for the first registry reply"
@@ -1483,7 +2393,12 @@ async fn replace_stays_responsive_under_registry_backpressure() {
     let filler_id = TaskId::next();
     let (filler_reply, _filler_completion) = sup
         .core()
-        .add_task_with_id_watched(filler_id, waiting_spec("replace-filler"), None)
+        .add_task_with_id_watched(
+            filler_id,
+            Arc::from("replace-filler"),
+            waiting_spec("replace-filler"),
+            None,
+        )
         .expect("the filler must occupy the registry queue");
     assert_eq!(sup.core().registry_command_capacity(), 0);
 
@@ -1530,7 +2445,10 @@ async fn replace_stays_responsive_under_registry_backpressure() {
         .expect("the slot must remain tracked");
     let slot = slot.lock().await;
     assert!(matches!(slot.phase(), SlotPhase::Terminating { .. }));
-    assert_eq!(slot.queue.front().map(|(id, _)| *id), Some(second_id));
+    assert_eq!(
+        slot.queue.front().map(|pending| pending.id),
+        Some(second_id)
+    );
     drop(slot);
     assert_eq!(
         removals.len(),
@@ -1758,7 +2676,7 @@ async fn reliable_completion_reuses_task_name_without_task_removed() {
             let Some(slot) = ctrl.slots.get("s").map(|entry| entry.clone()) else {
                 return false;
             };
-            slot.lock().await.queue.front().map(|(id, _)| *id) == Some(second_id)
+            slot.lock().await.queue.front().map(|pending| pending.id) == Some(second_id)
         })
         .await,
         "the second task must wait behind the first"
@@ -1858,10 +2776,12 @@ async fn queued_admission_skips_registry_rejected_head() {
     {
         let mut slot = slot_arc.lock().await;
         slot.queue
-            .push_back((duplicate_id, waiting_spec("queued-duplicate")));
+            .push_back(pending(duplicate_id, waiting_spec("queued-duplicate")));
         slot.queue
-            .push_back((accepted_id, waiting_spec("queued-accepted")));
-        ctrl.start_next_from_queue(sup.core(), &mut slot, &slot_name, &mut admissions);
+            .push_back(pending(accepted_id, waiting_spec("queued-accepted")));
+        let deferred =
+            ctrl.start_next_from_queue(sup.core(), &mut slot, &slot_name, &mut admissions);
+        assert!(deferred.is_empty());
     }
 
     for _ in 0..2 {
@@ -1902,7 +2822,7 @@ async fn no_queue_advancement_after_shutdown_starts() {
     let ctrl = Controller::new(ControllerConfig::default(), sup.core(), Bus::new(64));
 
     let mut queue = std::collections::VecDeque::new();
-    queue.push_back((TaskId::next(), waiting_spec("queued")));
+    queue.push_back(pending(TaskId::next(), waiting_spec("queued")));
     let mut slot = running_slot(id);
     slot.queue = queue;
     ctrl.slots
@@ -1970,7 +2890,7 @@ async fn snapshot_maps_every_internal_slot_phase_and_owner() {
     let with_queue = |mut slot: SlotState, depth: usize| {
         for _ in 0..depth {
             slot.queue
-                .push_back((TaskId::next(), make_spec("snapshot-queued")));
+                .push_back(pending(TaskId::next(), make_spec("snapshot-queued")));
         }
         slot
     };

--- a/src/controller/slot.rs
+++ b/src/controller/slot.rs
@@ -7,12 +7,28 @@
 //! `SlotPhase` owns the current `TaskId` in every occupied phase; an idle slot cannot retain an owner and an occupied slot cannot exist without one.
 //! Transition methods reject stale identities without mutating the current owner.
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 use tokio::time::Instant;
 
-use crate::TaskSpec;
-use crate::identity::TaskId;
+use crate::{TaskSpec, identity::TaskId};
+
+/// Controller work whose user-provided task name was resolved before queue ownership.
+pub(super) struct PendingSubmission {
+    pub(super) id: TaskId,
+    pub(super) task_name: Arc<str>,
+    pub(super) task_spec: TaskSpec,
+}
+
+impl PendingSubmission {
+    pub(super) fn new(id: TaskId, task_name: Arc<str>, task_spec: TaskSpec) -> Self {
+        Self {
+            id,
+            task_name,
+            task_spec,
+        }
+    }
+}
 
 /// Mutable state for one controller slot.
 pub(super) struct SlotState {
@@ -21,7 +37,7 @@ pub(super) struct SlotState {
     /// Pending submissions for this slot.
     ///
     /// The front item is next after the current admission fails or after terminal cleanup of an accepted owner.
-    pub(super) queue: VecDeque<(TaskId, TaskSpec)>,
+    pub(super) queue: VecDeque<PendingSubmission>,
 }
 
 /// Internal lifecycle phase of one controller slot.
@@ -297,15 +313,19 @@ mod tests {
     #[test]
     fn queue_push_pop_fifo() {
         let mut slot = SlotState::new();
+        let pending = |name: &str| {
+            let task_spec = make_spec(name);
+            PendingSubmission::new(TaskId::next(), Arc::from(name), task_spec)
+        };
 
-        slot.queue.push_back((TaskId::next(), make_spec("a")));
-        slot.queue.push_back((TaskId::next(), make_spec("b")));
-        slot.queue.push_back((TaskId::next(), make_spec("c")));
+        slot.queue.push_back(pending("a"));
+        slot.queue.push_back(pending("b"));
+        slot.queue.push_back(pending("c"));
 
         assert_eq!(slot.queue.len(), 3);
-        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "a");
-        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "b");
-        assert_eq!(slot.queue.pop_front().unwrap().1.name(), "c");
+        assert_eq!(slot.queue.pop_front().unwrap().task_spec.name(), "a");
+        assert_eq!(slot.queue.pop_front().unwrap().task_spec.name(), "b");
+        assert_eq!(slot.queue.pop_front().unwrap().task_spec.name(), "c");
         assert!(slot.queue.is_empty());
     }
 

--- a/src/core/handle.rs
+++ b/src/core/handle.rs
@@ -475,8 +475,8 @@ impl SupervisorHandle {
     /// # Errors
     ///
     /// - [`RuntimeError::GraceExceeded`] when some tasks did not stop within the grace period.
-    /// - [`RuntimeError::SignalSetupFailed`] if a concurrent static `run` call started shutdown after signal setup failed.
     /// - [`RuntimeError::ShuttingDown`] when shared runtime cleanup cannot finish normally.
+    /// - [`RuntimeError::SignalSetupFailed`]
     #[doc(alias = "graceful shutdown")]
     #[doc(alias = "graceful stop")]
     pub async fn shutdown(self) -> Result<(), RuntimeError> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -41,7 +41,8 @@
 //!
 //! ## Important Rules
 //!
-//! - [`Supervisor::run`] is single-shot and registers its initial tasks as one batch.
+//! - Static run methods are single-shot and register their initial tasks as one batch.
+//! - [`Supervisor::run`] and [`Supervisor::run_until`] do not install process signal handlers.
 //! - Attempts for one registered task are sequential.
 //! - New task admission closes when shutdown starts.
 //! - Explicit shutdown returns after task, listener, and subscriber cleanup.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -83,3 +83,24 @@ mod shutdown;
 mod registry;
 #[cfg(feature = "controller")]
 pub(crate) use registry::{AddReplyRx, OutcomeTx, RemovalCompletion};
+
+/// Controller add payload returned intact when registry command admission does not commit.
+///
+/// Keeping the user task and outcome sender together lets the controller restore
+/// ownership before any user-provided destructor can run.
+#[cfg(feature = "controller")]
+pub(crate) struct UncommittedWatchedAdd {
+    pub(crate) error: crate::RuntimeError,
+    pub(crate) label: std::sync::Arc<str>,
+    pub(crate) spec: crate::TaskSpec,
+    pub(crate) done: Option<registry::OutcomeTx>,
+}
+
+#[cfg(feature = "controller")]
+impl std::fmt::Debug for UncommittedWatchedAdd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UncommittedWatchedAdd")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}

--- a/src/core/registry/admission.rs
+++ b/src/core/registry/admission.rs
@@ -194,13 +194,12 @@ impl Registry {
     pub(super) async fn spawn_and_register(
         &self,
         id: TaskId,
+        label: Arc<str>,
         spec: TaskSpec,
         done: Option<OutcomeTx>,
         completion: Option<RemovalCompletion>,
         reply: oneshot::Sender<AddReply>,
     ) {
-        let label: Arc<str> = Arc::from(spec.task().name());
-
         let mut st = self.state.write().await;
         if st.by_label.contains_key(&label) {
             drop(st);

--- a/src/core/registry/listener.rs
+++ b/src/core/registry/listener.rs
@@ -141,6 +141,7 @@ impl Registry {
         match command {
             RegistryCommand::Add {
                 id,
+                label,
                 spec,
                 outcome,
                 completion,
@@ -148,7 +149,7 @@ impl Registry {
             } => {
                 self.guarded(
                     "registry",
-                    self.spawn_and_register(id, spec, outcome, completion, reply),
+                    self.spawn_and_register(id, label, spec, outcome, completion, reply),
                 )
                 .await;
             }

--- a/src/core/registry/protocol.rs
+++ b/src/core/registry/protocol.rs
@@ -64,6 +64,7 @@ pub(crate) enum RegistryCommand {
     /// Register a task under a pre-minted runtime identity.
     Add {
         id: TaskId,
+        label: Arc<str>,
         spec: TaskSpec,
         outcome: Option<OutcomeTx>,
         completion: Option<RemovalCompletion>,

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -8,6 +8,27 @@ use crate::{
 use std::{future::Future, pin::Pin, task::Poll};
 use tokio::sync::oneshot;
 
+struct RegistryNameProbe {
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+    allow_lifecycle_reads: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl crate::Task for RegistryNameProbe {
+    fn name(&self) -> &str {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        assert!(
+            self.allow_lifecycle_reads
+                .load(std::sync::atomic::Ordering::Acquire),
+            "registry admission must consume the cached command label"
+        );
+        "cached-command-label"
+    }
+
+    fn spawn(&self, _ctx: crate::TaskContext) -> crate::BoxTaskFuture {
+        Box::pin(std::future::pending())
+    }
+}
+
 async fn assert_pending_once<F: Future>(mut future: Pin<&mut F>) {
     std::future::poll_fn(|cx| match future.as_mut().poll(cx) {
         Poll::Pending => Poll::Ready(()),
@@ -198,8 +219,10 @@ fn send_add(
     outcome: Option<OutcomeTx>,
 ) -> AddReplyRx {
     let (reply, reply_rx) = oneshot::channel();
+    let label = Arc::from(spec.name());
     tx.try_send(RegistryCommand::Add {
         id,
+        label,
         spec,
         outcome,
         completion: None,
@@ -260,6 +283,56 @@ async fn stop_registry(registry: &Registry, token: &CancellationToken) {
     tokio::time::timeout(Duration::from_secs(2), registry.join_listener())
         .await
         .expect("registry listener must stop");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn add_command_consumes_cached_label_without_reading_task_name() {
+    let (registry, bus, token, tx) = started_registry(64, Duration::from_secs(1));
+    let mut events = bus.subscribe();
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let allow_lifecycle_reads = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let id = TaskId::next();
+    let (reply, reply_rx) = oneshot::channel();
+    let task: crate::TaskRef = Arc::new(RegistryNameProbe {
+        calls: Arc::clone(&calls),
+        allow_lifecycle_reads: Arc::clone(&allow_lifecycle_reads),
+    });
+
+    tx.try_send(RegistryCommand::Add {
+        id,
+        label: Arc::from("cached-command-label"),
+        spec: TaskSpec::once(task),
+        outcome: None,
+        completion: None,
+        reply,
+    })
+    .expect("registry command channel must stay open");
+
+    assert!(matches!(
+        receive_reply(reply_rx, "cached-label Add").await,
+        Ok(())
+    ));
+    assert_eq!(calls.load(std::sync::atomic::Ordering::Acquire), 0);
+    assert_eq!(
+        registry.id_for_label("cached-command-label").await,
+        Some(id)
+    );
+
+    let added = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let event = events.recv().await.expect("event bus remains open");
+            if event.kind == EventKind::TaskAdded && event.id == Some(id) {
+                break event;
+            }
+        }
+    })
+    .await
+    .expect("cached-label TaskAdded event");
+    assert_eq!(added.task.as_deref(), Some("cached-command-label"));
+    assert_eq!(calls.load(std::sync::atomic::Ordering::Acquire), 0);
+
+    allow_lifecycle_reads.store(true, std::sync::atomic::Ordering::Release);
+    stop_registry(&registry, &token).await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -331,11 +404,11 @@ async fn single_add_publishes_added_before_starting() {
         let registry = Arc::clone(&registry);
         registrations.spawn(async move {
             let id = TaskId::next();
-            let task: TaskRef =
-                TaskFn::arc(format!("ordered-add-{index}"), |_ctx| async { Ok(()) });
+            let name = format!("ordered-add-{index}");
+            let task: TaskRef = TaskFn::arc(name.clone(), |_ctx| async { Ok(()) });
             let (reply, reply_rx) = oneshot::channel();
             registry
-                .spawn_and_register(id, TaskSpec::once(task), None, None, reply)
+                .spawn_and_register(id, Arc::from(name), TaskSpec::once(task), None, None, reply)
                 .await;
             assert!(
                 matches!(reply_rx.await, Ok(Ok(()))),
@@ -1482,6 +1555,7 @@ async fn shutdown_drains_buffered_command_and_never_silently_drops() {
     let id = TaskId::next();
     tx.try_send(RegistryCommand::Add {
         id,
+        label: Arc::from("buffered"),
         spec: TaskSpec::restartable(task),
         outcome: Some(done_tx),
         completion: None,

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -17,22 +17,24 @@
 //!
 //! ## Modes
 //!
-//! | Entry point  | Behavior                                                                                                                                 |
-//! |--------------|------------------------------------------------------------------------------------------------------------------------------------------|
-//! | `start()`    | Start subscriber workers, the event relay, and the registry listener once                                                                |
-//! | `run(tasks)` | Start the runtime, register a non-empty task set as one atomic batch, then wait for shared shutdown, an OS signal, or registry emptiness |
-//! | `shutdown()` | Start or join shared cleanup and return its cached result                                                                                |
+//! | Entry point                  | Behavior                                                                                                                  |
+//! |------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+//! | `start()`                    | Start subscriber workers, the event relay, and the registry listener once                                                 |
+//! | `run(tasks)`                 | Start the runtime, register a non-empty task set as one atomic batch, then wait for shared shutdown or registry emptiness |
+//! | `run_until(tasks, future)`   | Add one application-owned shutdown trigger without installing process signal handlers                                     |
+//! | `run_with_os_signals(tasks)` | Explicitly opt into OS signal handlers as the shutdown trigger                                                            |
+//! | `shutdown()`                 | Start or join shared cleanup and return its cached result                                                                 |
 //!
 //! ## Rules
 //!
 //! - Management command admission closes once shutdown begins.
 //! - Shutdown processes commands committed before the admission gate closed.
-//! - Explicit, signal, and natural shutdown share one cleanup operation.
+//! - Explicit, caller-provided, signal, and natural shutdown share one cleanup operation.
 //! - Every shutdown caller receives the same cached result.
-//! - The first trigger that installs the shared shutdown operation selects its result. `ShutdownRequested` is emitted only when an explicit request or received OS signal wins that race.
+//! - The first trigger that installs the shared shutdown operation selects its result. `ShutdownRequested` is emitted only when an explicit request, caller-provided trigger, or received OS signal wins that race.
 //! - Static `run()` tasks are accepted or rejected as one batch.
 //! - Registry membership is keyed by `TaskId`.
-//! - `run()` is single-shot. A second call returns `RuntimeError::AlreadyRunning`.
+//! - Static run methods share one single-shot lifecycle. A second call returns `RuntimeError::AlreadyRunning`.
 //! - `snapshot` and `is_alive` are best-effort event-based views.
 //! - `start()` is idempotent.
 

--- a/src/core/runtime/lifecycle.rs
+++ b/src/core/runtime/lifecycle.rs
@@ -1,6 +1,9 @@
 //! Runtime startup and static-run lifecycle.
 
-use std::sync::{Arc, atomic::Ordering};
+use std::{
+    future::Future,
+    sync::{Arc, atomic::Ordering},
+};
 
 use super::{SupervisorCore, shutdown_workflow::ShutdownTrigger};
 use crate::{core::registry::AddBatchItem, error::RuntimeError, identity::TaskId, tasks::TaskSpec};
@@ -33,13 +36,55 @@ impl SupervisorCore {
         self.started.store(true, Ordering::Release);
     }
 
-    /// Runs a static task set until explicit shutdown, an OS signal, or registry emptiness.
+    /// Runs a static task set until shared shutdown or registry emptiness.
     ///
     /// This starts the runtime and, when the task set is non-empty, registers it as one atomic batch.
     /// It then drives shutdown or natural completion.
     ///
     /// Single-shot: a second or concurrent call returns [`RuntimeError::AlreadyRunning`].
     pub(crate) async fn run(self: &Arc<Self>, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
+        self.run_until_trigger(tasks, std::future::pending()).await
+    }
+
+    /// Runs a static task set with one explicit external shutdown trigger.
+    pub(crate) async fn run_until<F>(
+        self: &Arc<Self>,
+        tasks: Vec<TaskSpec>,
+        shutdown: F,
+    ) -> Result<(), RuntimeError>
+    where
+        F: Future<Output = ()>,
+    {
+        self.run_until_trigger(tasks, async move {
+            shutdown.await;
+            ShutdownTrigger::Requested
+        })
+        .await
+    }
+
+    /// Runs a static task set with explicit process-signal handling.
+    pub(crate) async fn run_with_os_signals(
+        self: &Arc<Self>,
+        tasks: Vec<TaskSpec>,
+    ) -> Result<(), RuntimeError> {
+        self.run_until_trigger(tasks, async {
+            match crate::core::shutdown::wait_for_shutdown_signal().await {
+                Ok(()) => ShutdownTrigger::Requested,
+                Err(source) => ShutdownTrigger::SignalSetupFailed(Arc::new(source)),
+            }
+        })
+        .await
+    }
+
+    /// Owns the single-shot static lifecycle for every shutdown-source variant.
+    async fn run_until_trigger<F>(
+        self: &Arc<Self>,
+        tasks: Vec<TaskSpec>,
+        shutdown: F,
+    ) -> Result<(), RuntimeError>
+    where
+        F: Future<Output = ShutdownTrigger>,
+    {
         if self.running.swap(true, Ordering::AcqRel) {
             return Err(RuntimeError::AlreadyRunning);
         }
@@ -49,7 +94,7 @@ impl SupervisorCore {
         self.start();
 
         if tasks.is_empty() {
-            return self.drive_shutdown().await;
+            return self.drive_shutdown(shutdown).await;
         }
 
         let items = tasks
@@ -69,7 +114,7 @@ impl SupervisorCore {
         };
 
         match Self::await_add_batch_reply(reply).await {
-            Ok(()) => self.drive_shutdown().await,
+            Ok(()) => self.drive_shutdown(shutdown).await,
             Err(RuntimeError::ShuttingDown) if self.shutdown.started.is_cancelled() => {
                 self.wait_started_shutdown().await
             }
@@ -81,33 +126,18 @@ impl SupervisorCore {
     ///
     /// Waits for either:
     /// - a shared shutdown already started by another entry point,
-    /// - an OS shutdown signal,
+    /// - the caller-provided shutdown trigger,
     /// - natural completion when the registry becomes empty.
     ///
     /// Every path joins registry and subscriber listeners and closes subscribers before returning.
-    async fn drive_shutdown(self: &Arc<Self>) -> Result<(), RuntimeError> {
+    async fn drive_shutdown<F>(self: &Arc<Self>, shutdown: F) -> Result<(), RuntimeError>
+    where
+        F: Future<Output = ShutdownTrigger>,
+    {
         tokio::select! {
             _ = self.shutdown.started.cancelled() => self.wait_started_shutdown().await,
-            sig = crate::core::shutdown::wait_for_shutdown_signal() => self.on_shutdown_signal(sig).await,
+            trigger = shutdown => self.join_shutdown(trigger).await,
             _ = self.registry.wait_until_empty() => self.join_shutdown(ShutdownTrigger::Natural).await,
-        }
-    }
-
-    /// Handles the result of OS shutdown-signal setup/waiting.
-    ///
-    /// If a received signal wins the shutdown race, it starts graceful shutdown and publishes `ShutdownRequested`.
-    /// If a signal-setup error wins, the shared result is [`RuntimeError::SignalSetupFailed`];
-    /// common cleanup still runs, but `ShutdownRequested` and the graceful task-drain verdict are not emitted.
-    pub(super) async fn on_shutdown_signal(
-        self: &Arc<Self>,
-        res: std::io::Result<()>,
-    ) -> Result<(), RuntimeError> {
-        match res {
-            Ok(()) => self.join_shutdown(ShutdownTrigger::Requested).await,
-            Err(source) => {
-                self.join_shutdown(ShutdownTrigger::SignalSetupFailed(Arc::new(source)))
-                    .await
-            }
         }
     }
 }

--- a/src/core/runtime/management.rs
+++ b/src/core/runtime/management.rs
@@ -50,6 +50,30 @@ impl SupervisorCore {
         }
     }
 
+    /// Reserves fail-fast command capacity and holds the shutdown admission gate.
+    fn try_reserve_command_admission(
+        &self,
+    ) -> Result<
+        (
+            mpsc::Permit<'_, RegistryCommand>,
+            std::sync::MutexGuard<'_, ()>,
+        ),
+        RuntimeError,
+    > {
+        if self.is_shutting_down() {
+            return Err(RuntimeError::ShuttingDown);
+        }
+        let permit = self.cmd_tx.try_reserve().map_err(|error| match error {
+            mpsc::error::TrySendError::Full(()) => RuntimeError::CommandQueueFull,
+            mpsc::error::TrySendError::Closed(()) => RuntimeError::ShuttingDown,
+        })?;
+        let Some(admission) = self.command_admission() else {
+            drop(permit);
+            return Err(RuntimeError::ShuttingDown);
+        };
+        Ok((permit, admission))
+    }
+
     /// Closes command admission and waits until the registry reaches that ordering point.
     ///
     /// Every command committed before the gate closes is ahead of this fence.
@@ -103,12 +127,18 @@ impl SupervisorCore {
     pub(crate) fn add_task_with_id_watched(
         &self,
         id: TaskId,
+        label: Arc<str>,
         spec: TaskSpec,
         done: Option<OutcomeTx>,
-    ) -> Result<(AddReplyRx, RemovalCompletion), (RuntimeError, Option<OutcomeTx>)> {
+    ) -> Result<(AddReplyRx, RemovalCompletion), Box<crate::core::UncommittedWatchedAdd>> {
         let completion = RemovalCompletion::new();
-        let (_id, reply) =
-            self.enqueue_add_task_with_completion(id, spec, done, Some(completion.clone()))?;
+        let (_id, reply) = self.enqueue_named_add_task_with_completion_recovering(
+            id,
+            label,
+            spec,
+            done,
+            Some(completion.clone()),
+        )?;
         Ok((reply, completion))
     }
 
@@ -161,18 +191,33 @@ impl SupervisorCore {
             return Err((RuntimeError::ShuttingDown, done));
         }
         let label: Arc<str> = Arc::from(spec.task().name());
-        let permit = match self.cmd_tx.try_reserve() {
-            Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(())) => {
-                return Err((RuntimeError::CommandQueueFull, done));
-            }
-            Err(mpsc::error::TrySendError::Closed(())) => {
-                return Err((RuntimeError::ShuttingDown, done));
-            }
+        let (permit, _admission) = match self.try_reserve_command_admission() {
+            Ok(admission) => admission,
+            Err(error) => return Err((error, done)),
         };
-        let Some(_admission) = self.command_admission() else {
-            drop(permit);
-            return Err((RuntimeError::ShuttingDown, done));
+        Ok(self.commit_add(permit, id, label, spec, done, completion))
+    }
+
+    /// Queues one add command while returning user-owned values intact on pre-commit failure.
+    #[cfg(feature = "controller")]
+    fn enqueue_named_add_task_with_completion_recovering(
+        &self,
+        id: TaskId,
+        label: Arc<str>,
+        spec: TaskSpec,
+        done: Option<OutcomeTx>,
+        completion: Option<RemovalCompletion>,
+    ) -> Result<(TaskId, AddReplyRx), Box<crate::core::UncommittedWatchedAdd>> {
+        let (permit, _admission) = match self.try_reserve_command_admission() {
+            Ok(admission) => admission,
+            Err(error) => {
+                return Err(Box::new(crate::core::UncommittedWatchedAdd {
+                    error,
+                    label,
+                    spec,
+                    done,
+                }));
+            }
         };
         Ok(self.commit_add(permit, id, label, spec, done, completion))
     }
@@ -214,11 +259,12 @@ impl SupervisorCore {
         let (reply, reply_rx) = oneshot::channel();
         self.bus.publish(
             Event::new(EventKind::TaskAddRequested)
-                .with_task(label)
+                .with_task(Arc::clone(&label))
                 .with_id(id),
         );
         permit.send(RegistryCommand::Add {
             id,
+            label,
             spec,
             outcome: done,
             completion,

--- a/src/core/runtime/tests.rs
+++ b/src/core/runtime/tests.rs
@@ -1374,9 +1374,24 @@ async fn add_task_with_id_watched_returns_watcher_on_failure() {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let task: TaskRef = TaskFn::arc("x", |_ctx: TaskContext| async { Ok(()) });
 
-    let res = core.add_task_with_id_watched(TaskId::next(), TaskSpec::once(task), Some(tx));
+    let res = core.add_task_with_id_watched(
+        TaskId::next(),
+        Arc::from("x"),
+        TaskSpec::once(task),
+        Some(tx),
+    );
     match res {
-        Err((RuntimeError::ShuttingDown, Some(returned))) => {
+        Err(uncommitted) => {
+            let crate::core::UncommittedWatchedAdd {
+                error,
+                label,
+                spec,
+                done,
+            } = *uncommitted;
+            assert!(matches!(error, RuntimeError::ShuttingDown));
+            assert_eq!(&*label, "x");
+            assert_eq!(spec.name(), "x");
+            let returned = done.expect("the watcher must be returned with the task spec");
             returned
                 .send(crate::TaskOutcome::Rejected {
                     kind: crate::RejectionKind::AdmissionFailed,
@@ -1385,7 +1400,7 @@ async fn add_task_with_id_watched_returns_watcher_on_failure() {
                 .expect("returned watcher must still be live");
             assert!(matches!(rx.await, Ok(crate::TaskOutcome::Rejected { .. })));
         }
-        other => panic!("add must hand the watcher back on failure, got {other:?}"),
+        Ok(_) => panic!("add must hand the watcher and task spec back on failure"),
     }
 }
 
@@ -1399,7 +1414,12 @@ async fn controller_completion_waits_for_registry_membership_cleanup() {
     let id = TaskId::next();
     let task: TaskRef = TaskFn::arc("completion-cleanup", |_ctx: TaskContext| async { Ok(()) });
     let (reply, completion) = core
-        .add_task_with_id_watched(id, TaskSpec::once(task), None)
+        .add_task_with_id_watched(
+            id,
+            Arc::from("completion-cleanup"),
+            TaskSpec::once(task),
+            None,
+        )
         .expect("controller Add must enter the registry queue");
 
     assert!(matches!(reply.await, Ok(Ok(()))));

--- a/src/core/runtime/tests.rs
+++ b/src/core/runtime/tests.rs
@@ -1427,7 +1427,9 @@ async fn signal_setup_error_surfaces_as_runtime_error_not_shutdown() {
     let mut rx = core.bus.subscribe();
 
     let err = std::io::Error::other("signal registration failed");
-    let out = core.on_shutdown_signal(Err(err)).await;
+    let out = core
+        .join_shutdown(ShutdownTrigger::SignalSetupFailed(Arc::new(err)))
+        .await;
 
     assert!(
         matches!(out, Err(RuntimeError::SignalSetupFailed { .. })),
@@ -1474,7 +1476,10 @@ async fn signal_setup_error_keeps_custom_source_for_late_callers() {
     core.start();
     let original = std::io::Error::new(std::io::ErrorKind::PermissionDenied, Marker);
 
-    let first = signal_setup_source(core.on_shutdown_signal(Err(original)).await);
+    let first = signal_setup_source(
+        core.join_shutdown(ShutdownTrigger::SignalSetupFailed(Arc::new(original)))
+            .await,
+    );
     let late = signal_setup_source(core.shutdown().await);
 
     for source in [&first, &late] {
@@ -1493,7 +1498,10 @@ async fn signal_setup_error_keeps_raw_os_code_for_late_callers() {
     core.start();
     let original = std::io::Error::from_raw_os_error(2);
 
-    let first = signal_setup_source(core.on_shutdown_signal(Err(original)).await);
+    let first = signal_setup_source(
+        core.join_shutdown(ShutdownTrigger::SignalSetupFailed(Arc::new(original)))
+            .await,
+    );
     let late = signal_setup_source(core.shutdown().await);
     assert_eq!(first.raw_os_error(), Some(2));
     assert_eq!(late.raw_os_error(), Some(2));
@@ -1505,7 +1513,7 @@ async fn real_signal_publishes_shutdown_requested() {
     core.start();
     let mut rx = core.bus.subscribe();
 
-    let out = core.on_shutdown_signal(Ok(())).await;
+    let out = core.join_shutdown(ShutdownTrigger::Requested).await;
     assert!(out.is_ok(), "a real signal drains gracefully: {out:?}");
 
     let mut saw_shutdown = false;

--- a/src/core/shutdown.rs
+++ b/src/core/shutdown.rs
@@ -1,10 +1,13 @@
 //! # OS shutdown signal helper
 //!
-//! [`Supervisor::run`](crate::Supervisor::run) uses [`wait_for_shutdown_signal`] in static mode.
-//! Dynamic mode through [`Supervisor::serve`](crate::Supervisor::serve) does not install this wait; the application decides when to call `shutdown`.
+//! [`Supervisor::run_with_os_signals`](crate::Supervisor::run_with_os_signals) uses [`wait_for_shutdown_signal`] as an explicit opt-in.
+//! [`Supervisor::run`](crate::Supervisor::run), [`Supervisor::run_until`](crate::Supervisor::run_until), and dynamic mode through [`Supervisor::serve`](crate::Supervisor::serve) do not install signal listeners.
 //!
 //! This helper installs signal listeners and waits.
 //! It does not publish events or cancel tasks.
+//!
+//! On Unix, Tokio's process-global signal handling is not restored when these listeners are dropped.
+//! Callers remain responsible for process signals after opting in.
 //!
 //! ## Unix Signals
 //!

--- a/src/core/supervisor.rs
+++ b/src/core/supervisor.rs
@@ -16,7 +16,9 @@
 //! [`run`](Supervisor::run) is for a known initial batch.
 //! [`serve`](Supervisor::serve) is for tasks managed while the service runs.
 //!
-//! After its batch is accepted, `run` waits for natural completion, explicit shutdown, or an OS shutdown signal.
+//! After its batch is accepted, `run` waits for natural completion or shared shutdown.
+//! Use [`run_until`](Supervisor::run_until) with an application-owned shutdown future.
+//! Use [`run_with_os_signals`](Supervisor::run_with_os_signals) only when taskvisor should explicitly install process signal handlers.
 //! `serve` does not install a signal wait; the application decides when to call [`SupervisorHandle::shutdown`](crate::SupervisorHandle::shutdown).
 //!
 //! ## Ownership and Drop
@@ -29,7 +31,7 @@
 //!
 //! [`SupervisorCore`]: crate::core::SupervisorCore
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use crate::core::{RuntimeOwner, SupervisorConfig, SupervisorCore, builder::SupervisorBuilder};
 use crate::{error::RuntimeError, subscribers::Subscribe, tasks::TaskSpec};
@@ -148,8 +150,7 @@ impl Supervisor {
         handle
     }
 
-    /// Runs an initial task batch until natural completion or shared shutdown,
-    /// started explicitly or by an OS signal.
+    /// Runs an initial task batch until natural completion or shared shutdown.
     ///
     /// This is static mode.
     /// The registry accepts the full batch or rejects it.
@@ -186,13 +187,99 @@ impl Supervisor {
     ///
     /// - [`RuntimeError::GraceExceeded`] when some tasks did not stop within the grace period.
     /// - [`RuntimeError::TaskAlreadyExists`] when a task name is already in use or repeated in the batch.
-    /// - [`RuntimeError::SignalSetupFailed`] when OS signal handlers cannot be installed.
     /// - [`RuntimeError::AlreadyRunning`] when `run` is called a second time.
     /// - [`RuntimeError::ShuttingDown`] when shutdown has started or cleanup cannot finish normally.
     pub async fn run(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
         #[cfg(feature = "controller")]
         self.start_controller();
         self.owner.core().run(tasks).await
+    }
+
+    /// Runs an initial task batch until natural completion, shared shutdown, or an application-owned shutdown future completes.
+    ///
+    /// The shutdown future is polled only after the initial batch has been accepted.
+    /// When it completes first, taskvisor starts the same graceful shutdown used by [`SupervisorHandle::shutdown`](crate::SupervisorHandle::shutdown).
+    ///
+    /// The future must resolve to `()`.
+    /// Wrap a fallible source so the application decides how to handle its error before requesting shutdown.
+    ///
+    /// This method does not install process signal handlers.
+    /// It is single-shot and shares the same one-call limit as [`run`](Self::run) and [`run_with_os_signals`](Self::run_with_os_signals).
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use taskvisor::prelude::*;
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
+    /// let task: TaskRef = TaskFn::arc("worker", |ctx| async move {
+    ///     ctx.cancelled().await;
+    ///     Err(TaskError::Canceled)
+    /// });
+    /// let (stop, stopped) = tokio::sync::oneshot::channel::<()>();
+    ///
+    /// tokio::spawn(async move {
+    ///     let _ = stop.send(());
+    /// });
+    /// supervisor
+    ///     .run_until(vec![TaskSpec::once(task)], async move {
+    ///         let _ = stopped.await;
+    ///     })
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the runtime must start and there is no active Tokio runtime.
+    ///
+    /// # Errors
+    ///
+    /// - [`RuntimeError::GraceExceeded`] when some tasks did not stop within the grace period.
+    /// - [`RuntimeError::TaskAlreadyExists`] when a task name is already in use or repeated in the batch.
+    /// - [`RuntimeError::AlreadyRunning`] when any static run method is called a second time.
+    /// - [`RuntimeError::ShuttingDown`] when shutdown has started or cleanup cannot finish normally.
+    pub async fn run_until<F>(&self, tasks: Vec<TaskSpec>, shutdown: F) -> Result<(), RuntimeError>
+    where
+        F: Future<Output = ()>,
+    {
+        #[cfg(feature = "controller")]
+        self.start_controller();
+        self.owner.core().run_until(tasks, shutdown).await
+    }
+
+    /// Runs an initial task batch with explicit OS-signal shutdown handling.
+    ///
+    /// On Unix this waits for SIGINT, SIGTERM, or SIGQUIT.
+    /// On other platforms it waits for Tokio's Ctrl-C signal.
+    /// A received signal starts graceful shutdown.
+    ///
+    /// # Process-wide side effect
+    ///
+    /// Calling this method explicitly installs process-global Tokio signal handlers.
+    /// On Unix, dropping the signal listeners does not restore the default signal disposition.
+    /// The application remains responsible for signal handling after this method returns.
+    ///
+    /// Use [`run`](Self::run) or [`run_until`](Self::run_until) when the surrounding application owns process signals.
+    ///
+    /// This method is single-shot and shares the same one-call limit as the other static run methods.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the runtime must start and there is no active Tokio runtime.
+    ///
+    /// # Errors
+    ///
+    /// - [`RuntimeError::GraceExceeded`] when some tasks did not stop within the grace period.
+    /// - [`RuntimeError::TaskAlreadyExists`] when a task name is already in use or repeated in the batch.
+    /// - [`RuntimeError::SignalSetupFailed`] when OS signal handlers cannot be installed.
+    /// - [`RuntimeError::AlreadyRunning`] when any static run method is called a second time.
+    /// - [`RuntimeError::ShuttingDown`] when shutdown has started or cleanup cannot finish normally.
+    pub async fn run_with_os_signals(&self, tasks: Vec<TaskSpec>) -> Result<(), RuntimeError> {
+        #[cfg(feature = "controller")]
+        self.start_controller();
+        self.owner.core().run_with_os_signals(tasks).await
     }
 
     /// Returns the immutable runtime configuration.

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,9 +75,9 @@ pub enum RuntimeError {
         timeout: Duration,
     },
 
-    /// OS signal listener setup failed.
+    /// Explicit OS signal listener setup failed.
     ///
-    /// Signal-based shutdown is unavailable.
+    /// Signal-based shutdown requested through [`Supervisor::run_with_os_signals`](crate::Supervisor::run_with_os_signals) is unavailable.
     /// The I/O error kind, message, and source chain are preserved for callers that join the shared shutdown operation.
     #[error("failed to install shutdown signal handlers: {source}")]
     #[non_exhaustive]
@@ -91,9 +91,12 @@ pub enum RuntimeError {
     #[error("supervisor is shutting down")]
     ShuttingDown,
 
-    /// [`Supervisor::run`](crate::Supervisor::run) was called more than once.
+    /// A static supervisor run method was called more than once.
     ///
-    /// A supervisor run is single-shot.
+    /// [`Supervisor::run`](crate::Supervisor::run),
+    /// [`Supervisor::run_until`](crate::Supervisor::run_until), and
+    /// [`Supervisor::run_with_os_signals`](crate::Supervisor::run_with_os_signals)
+    /// share one single-shot lifecycle.
     #[error("supervisor run() was already started")]
     AlreadyRunning,
 }

--- a/src/events/event.rs
+++ b/src/events/event.rs
@@ -111,7 +111,7 @@ pub enum EventKind {
 
     /// Shutdown was requested.
     ///
-    /// This can come from an OS signal or an explicit runtime shutdown request.
+    /// This can come from an application-owned shutdown future, an explicitly configured OS signal, or a runtime shutdown request.
     ///
     /// Sets:
     /// - `at`: wall-clock timestamp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@
 //! ## Choose a Mode
 //!
 //! - **Static:** call [`Supervisor::run`] with a known task set.
-//!   It waits for all tasks to finish or for an OS shutdown signal.
+//!   It waits for all tasks to finish without installing process signal handlers.
+//!   Use [`Supervisor::run_until`] with an application-owned shutdown future, or explicitly opt into signal handling with [`Supervisor::run_with_os_signals`].
 //! - **Dynamic:** call [`Supervisor::serve`].
 //!   It returns a [`SupervisorHandle`] that can add, remove, cancel, and list tasks while the service is running.
 //!

--- a/src/reasons.rs
+++ b/src/reasons.rs
@@ -21,6 +21,11 @@ pub(crate) const SUPERSEDED_BY_REPLACE: &str = "superseded by a newer replacemen
 #[cfg(feature = "controller")]
 pub(crate) const CONTROLLER_SHUTTING_DOWN: &str = "controller is shutting down";
 
+/// Rejection reason: controller admission unwound before it could commit ownership.
+#[cfg(feature = "controller")]
+pub(crate) const CONTROLLER_ADMISSION_INTERRUPTED: &str =
+    "controller admission was interrupted before ownership transfer";
+
 /// Diagnostic text used when `DropIfRunning` rejects a busy slot.
 #[cfg(feature = "controller")]
 pub(crate) const DROP_IF_RUNNING: &str = "slot is busy; DropIfRunning rejected the submission";

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -5,7 +5,10 @@ mod common;
 use std::future::Future;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use std::task::Poll;
 use std::time::Duration;
 
@@ -738,4 +741,49 @@ async fn run_blocks_while_gated_task_alive_then_unblocks_on_completion() {
         .await
         .expect("run() task should not panic")
         .expect("run returns Ok after the gated task completes");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_until_uses_application_owned_shutdown_future() {
+    let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
+    let started = Arc::new(tokio::sync::Notify::new());
+    let cancellation_seen = Arc::new(AtomicBool::new(false));
+    let task_started = Arc::clone(&started);
+    let task_cancellation_seen = Arc::clone(&cancellation_seen);
+    let task = TaskFn::arc("run-until", move |ctx: TaskContext| {
+        let started = Arc::clone(&task_started);
+        let cancellation_seen = Arc::clone(&task_cancellation_seen);
+        async move {
+            started.notify_one();
+            ctx.cancelled().await;
+            cancellation_seen.store(true, Ordering::Release);
+            Err(TaskError::Canceled)
+        }
+    });
+    let (request_shutdown, shutdown_requested) = tokio::sync::oneshot::channel::<()>();
+    let run_supervisor = Arc::clone(&supervisor);
+    let run = tokio::spawn(async move {
+        run_supervisor
+            .run_until(vec![TaskSpec::once(task)], async move {
+                let _ = shutdown_requested.await;
+            })
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("the task must start before the application requests shutdown");
+    request_shutdown
+        .send(())
+        .expect("the run_until shutdown future must still be live");
+    tokio::time::timeout(Duration::from_secs(2), run)
+        .await
+        .expect("run_until must finish after its shutdown future")
+        .expect("the run_until task must not panic")
+        .expect("cooperative shutdown must succeed");
+
+    assert!(
+        cancellation_seen.load(Ordering::Acquire),
+        "the application-owned future must start graceful task cancellation"
+    );
 }

--- a/tests/signal_ownership.rs
+++ b/tests/signal_ownership.rs
@@ -47,12 +47,16 @@ fn child_runs_supervisor_then_sends_sigterm() {
             .expect("plain run must finish naturally");
     });
 
-    let kill = Command::new("kill")
-        .arg("-TERM")
+    // Use the POSIX shell builtin instead of requiring an external `kill`
+    // executable, which minimal CI images may not install.
+    let kill = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("kill -TERM \"$1\"")
+        .arg("taskvisor-signal-test")
         .arg(std::process::id().to_string())
         .status()
-        .expect("the child must be able to send itself SIGTERM");
-    assert!(kill.success(), "the kill command must accept SIGTERM");
+        .expect("the child must be able to invoke the POSIX shell");
+    assert!(kill.success(), "the shell builtin must accept SIGTERM");
 
     std::thread::sleep(Duration::from_millis(250));
     panic!("the child survived SIGTERM after plain Supervisor::run");

--- a/tests/signal_ownership.rs
+++ b/tests/signal_ownership.rs
@@ -1,0 +1,59 @@
+//! Process-isolated regression tests for implicit OS signal ownership.
+
+#![cfg(unix)]
+
+use std::{os::unix::process::ExitStatusExt, process::Command, time::Duration};
+
+use taskvisor::prelude::*;
+
+const CHILD_ENV: &str = "TASKVISOR_PLAIN_RUN_SIGNAL_CHILD";
+
+#[test]
+fn plain_run_does_not_install_process_signal_handlers() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        child_runs_supervisor_then_sends_sigterm();
+        return;
+    }
+
+    let status = Command::new(std::env::current_exe().expect("the test binary path must exist"))
+        .arg("--exact")
+        .arg("plain_run_does_not_install_process_signal_handlers")
+        .arg("--nocapture")
+        .env(CHILD_ENV, "1")
+        .status()
+        .expect("the isolated signal test must start");
+
+    assert_eq!(
+        status.signal(),
+        Some(15),
+        "plain run must leave SIGTERM at its process-default disposition; child status: {status}"
+    );
+}
+
+fn child_runs_supervisor_then_sends_sigterm() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("the child Tokio runtime must build");
+    runtime.block_on(async {
+        let task: TaskRef = TaskFn::arc("natural", |_ctx| async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            Ok(())
+        });
+        let supervisor = Supervisor::new(SupervisorConfig::default(), vec![]);
+        supervisor
+            .run(vec![TaskSpec::once(task)])
+            .await
+            .expect("plain run must finish naturally");
+    });
+
+    let kill = Command::new("kill")
+        .arg("-TERM")
+        .arg(std::process::id().to_string())
+        .status()
+        .expect("the child must be able to send itself SIGTERM");
+    assert!(kill.success(), "the kill command must accept SIGTERM");
+
+    std::thread::sleep(Duration::from_millis(250));
+    panic!("the child survived SIGTERM after plain Supervisor::run");
+}


### PR DESCRIPTION
## 📝 Description

- Eliminate implicit interference from Unix signals.
- Make panic-safe admission controller

## ✅ Checklist
- [x] Documentation updated (README, API docs, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] `task ci` passes locally
